### PR TITLE
Switch APK build trigger from push to manual dispatch

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,9 +1,7 @@
 name: Build Android APK
 
 on:
-  push:
-    branches:
-      - master
+  workflow_dispatch:
 
 jobs: 
   build:


### PR DESCRIPTION
## Summary
Changed the Android APK build workflow to use manual trigger (`workflow_dispatch`) instead of automatically building on every push to the master branch.

## Changes
- Removed automatic trigger on `push` events to `master` branch
- Added `workflow_dispatch` to allow manual triggering of the build workflow via GitHub Actions UI

## Rationale
This change prevents automatic APK builds on every commit to master, reducing unnecessary CI/CD overhead and build artifacts. Builds can now be triggered manually when needed through the GitHub Actions interface.

https://claude.ai/code/session_01FLCGmBtobiksx6dbuwHbXn