### PR TITLE
Add quest management with team proposal generator

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -35,6 +35,10 @@ import { LocationMapScreen } from './src/screens/location/LocationMapScreen';
 import { EventsTimelineScreen } from './src/screens/events/EventsListScreen';
 import { EventsFormScreen } from './src/screens/events/EventsFormScreen';
 import { EventsDetailScreen } from './src/screens/events/EventsDetailScreen';
+import { QuestListScreen } from './src/screens/quest/QuestListScreen';
+import { QuestFormScreen } from './src/screens/quest/QuestFormScreen';
+import { QuestDetailScreen } from './src/screens/quest/QuestDetailScreen';
+import { QuestProposalScreen } from './src/screens/quest/QuestProposalScreen';
 import { InfluenceReportScreen } from './src/screens/InfluenceReportScreen';
 import { DiscordConfigScreen } from './src/screens/discord/DiscordConfigScreen';
 import { DiscordServerListScreen } from './src/screens/discord/DiscordServerListScreen';
@@ -106,6 +110,15 @@ function CustomDrawerContent(props: DrawerContentComponentProps) {
         label="Events"
         onPress={() => navigation.navigate('Events')}
         focused={isActive('Events')}
+        activeTintColor="#6C5CE7"
+        inactiveTintColor="#B8B8CC"
+        activeBackgroundColor="rgba(108, 92, 231, 0.1)"
+        labelStyle={drawerStyles.drawerLabel}
+      />
+      <DrawerItem
+        label="Quests"
+        onPress={() => navigation.navigate('Quests')}
+        focused={isActive('Quests')}
         activeTintColor="#6C5CE7"
         inactiveTintColor="#B8B8CC"
         activeBackgroundColor="rgba(108, 92, 231, 0.1)"
@@ -282,6 +295,14 @@ function MainDrawer() {
         }}
       />
       <Drawer.Screen
+        name="Quests"
+        component={QuestListScreen}
+        options={{
+          title: 'Quests',
+          drawerLabel: 'Quests',
+        }}
+      />
+      <Drawer.Screen
         name="InfluenceReport"
         component={InfluenceReportScreen}
         options={{
@@ -454,6 +475,26 @@ export default function App() {
                 name="EventsDetail"
                 component={EventsDetailScreen}
                 options={{ title: 'Event Details' }}
+              />
+              <Stack.Screen
+                name="QuestsList"
+                component={QuestListScreen}
+                options={{ title: 'Quests' }}
+              />
+              <Stack.Screen
+                name="QuestsForm"
+                component={QuestFormScreen}
+                options={{ title: 'Quest Form' }}
+              />
+              <Stack.Screen
+                name="QuestsDetail"
+                component={QuestDetailScreen}
+                options={{ title: 'Quest Details' }}
+              />
+              <Stack.Screen
+                name="QuestProposals"
+                component={QuestProposalScreen}
+                options={{ title: 'Quest Proposals' }}
               />
               <Stack.Screen
                 name="DiscordMessageContext"

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -1,6 +1,7 @@
 import {
   AVAILABLE_PERKS,
   AVAILABLE_DISTINCTIONS,
+  type PerkTag,
   type StatModifiers,
 } from './gameData';
 import type { Species } from './speciesTypes';
@@ -134,6 +135,60 @@ export interface EventDataset {
 }
 
 export type CertaintyLevel = 'unconfirmed' | 'confirmed' | 'disputed';
+
+// Quest / Mission Management
+export enum QuestStatus {
+  NotStarted = 'NOTSTARTED',
+  Assigned = 'ASSIGNED',
+  InProgress = 'INPROGRESS',
+  Successful = 'SUCCESSFUL',
+  Failure = 'FAILURE',
+}
+
+export interface QuestMaterial {
+  id: string;
+  name: string;
+  quantityRequired: number;
+  quantityProvided: number;
+}
+
+export interface QuestAttributePreferences {
+  tags?: PerkTag[];
+  species?: Species[];
+  distinctionIds?: DistinctionId[];
+  perkIds?: PerkId[];
+}
+
+export interface GameQuest {
+  id: string;
+  name: string;
+  details?: string;
+  date?: string; // ISO date string (YYYY-MM-DD), optional time of mission
+  time?: string; // Optional time in HH:MM format
+  status: QuestStatus;
+  assignedCharacterIds?: string[]; // References to GameCharacter.id
+  desirable?: QuestAttributePreferences;
+  undesirable?: QuestAttributePreferences;
+  locationId?: string; // Reference to GameLocation.id
+  factionNames?: string[]; // Faction names related to the quest
+  eventIds?: string[]; // References to GameEvent.id
+  junktownOffice?: string; // Related Junktown office (free text)
+  requiredMaterials?: QuestMaterial[];
+  teamSize?: number; // Desired team size for proposal generation
+  notes?: string;
+  imageUri?: string; // Deprecated: Use imageUris instead
+  imageUris?: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface QuestDataset {
+  quests: GameQuest[];
+  version: string;
+  lastUpdated: string;
+}
+
+export type QuestFormData = Omit<GameQuest, 'id' | 'createdAt' | 'updatedAt'>;
 
 // Discord Integration Types
 export interface DiscordServerConfig {

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -1,4 +1,9 @@
-import { GameCharacter, GameLocation, GameEvent } from '@models/types';
+import {
+  GameCharacter,
+  GameLocation,
+  GameEvent,
+  GameQuest,
+} from '@models/types';
 
 export type RootDrawerParamList = {
   CharacterList: undefined;
@@ -6,6 +11,7 @@ export type RootDrawerParamList = {
   Factions: undefined;
   Locations: undefined;
   Events: undefined;
+  Quests: undefined;
   InfluenceReport: undefined;
   DiscordConfig: undefined;
   DiscordServers: undefined;
@@ -31,6 +37,10 @@ export type RootStackParamList = {
   EventsTimeline: undefined;
   EventsForm: { event?: GameEvent };
   EventsDetail: { eventId: string };
+  QuestsList: undefined;
+  QuestsForm: { quest?: GameQuest };
+  QuestsDetail: { questId: string };
+  QuestProposals: undefined;
   DiscordMessageContext: { messageId: string; characterId?: string };
   DiscordServerForm: { serverConfigId?: string };
 };

--- a/src/screens/quest/QuestDetailScreen.tsx
+++ b/src/screens/quest/QuestDetailScreen.tsx
@@ -1,0 +1,445 @@
+import React, { useState, useCallback } from 'react';
+import { View, Text, StyleSheet, Alert } from 'react-native';
+import {
+  useNavigation,
+  useRoute,
+  RouteProp,
+  useFocusEffect,
+} from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { RootStackParamList } from '@/navigation/types';
+import {
+  loadQuests,
+  loadCharacters,
+  loadLocations,
+  loadEvents,
+  deleteQuest,
+} from '@utils/characterStorage';
+import { GameQuest, QuestStatus } from '@models/types';
+import { colors as themeColors } from '@/styles/theme';
+import { commonStyles } from '@/styles/commonStyles';
+import { BaseDetailScreen, Section, CollapsibleSection } from '@/components';
+import { formatEventDate } from '@utils/dateUtils';
+
+type QuestsDetailNavigationProp = StackNavigationProp<
+  RootStackParamList,
+  'QuestsDetail'
+>;
+
+type QuestsDetailRouteProp = RouteProp<RootStackParamList, 'QuestsDetail'>;
+
+const STATUS_LABELS: Record<QuestStatus, string> = {
+  [QuestStatus.NotStarted]: 'Not Started',
+  [QuestStatus.Assigned]: 'Assigned',
+  [QuestStatus.InProgress]: 'In Progress',
+  [QuestStatus.Successful]: 'Successful',
+  [QuestStatus.Failure]: 'Failure',
+};
+
+const STATUS_COLORS: Record<QuestStatus, string> = {
+  [QuestStatus.NotStarted]: themeColors.text.muted,
+  [QuestStatus.Assigned]: themeColors.accent.info,
+  [QuestStatus.InProgress]: themeColors.accent.warning,
+  [QuestStatus.Successful]: themeColors.accent.success,
+  [QuestStatus.Failure]: themeColors.accent.danger,
+};
+
+interface QuestWithDetails extends GameQuest {
+  locationName?: string;
+  characterNames: string[];
+  eventTitles: string[];
+}
+
+export const QuestDetailScreen: React.FC = () => {
+  const navigation = useNavigation<QuestsDetailNavigationProp>();
+  const route = useRoute<QuestsDetailRouteProp>();
+  const { questId } = route.params;
+
+  const [quest, setQuest] = useState<QuestWithDetails | null>(null);
+
+  const loadQuestDetails = useCallback(async () => {
+    const [quests, characters, locations, events] = await Promise.all([
+      loadQuests(),
+      loadCharacters(),
+      loadLocations(),
+      loadEvents(),
+    ]);
+
+    const foundQuest = quests.find(q => q.id === questId);
+    if (!foundQuest) {
+      Alert.alert('Error', 'Quest not found', [
+        { text: 'OK', onPress: () => navigation.goBack() },
+      ]);
+      return;
+    }
+
+    const locationMap = new Map(locations.map(l => [l.id, l.name]));
+    const characterMap = new Map(characters.map(c => [c.id, c.name]));
+    const eventMap = new Map(events.map(e => [e.id, e.title]));
+
+    const questWithDetails: QuestWithDetails = {
+      ...foundQuest,
+      locationName: foundQuest.locationId
+        ? locationMap.get(foundQuest.locationId)
+        : undefined,
+      characterNames:
+        foundQuest.assignedCharacterIds?.map(
+          id => characterMap.get(id) || 'Unknown'
+        ) || [],
+      eventTitles:
+        foundQuest.eventIds?.map(id => eventMap.get(id) || 'Unknown') || [],
+    };
+
+    setQuest(questWithDetails);
+  }, [questId, navigation]);
+
+  useFocusEffect(
+    useCallback(() => {
+      loadQuestDetails();
+    }, [loadQuestDetails])
+  );
+
+  if (!quest) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.loadingText}>Loading...</Text>
+      </View>
+    );
+  }
+
+  const hasPreferences =
+    (quest.desirable &&
+      ((quest.desirable.tags?.length ?? 0) > 0 ||
+        (quest.desirable.species?.length ?? 0) > 0 ||
+        (quest.desirable.perkIds?.length ?? 0) > 0 ||
+        (quest.desirable.distinctionIds?.length ?? 0) > 0)) ||
+    (quest.undesirable &&
+      ((quest.undesirable.tags?.length ?? 0) > 0 ||
+        (quest.undesirable.species?.length ?? 0) > 0 ||
+        (quest.undesirable.perkIds?.length ?? 0) > 0 ||
+        (quest.undesirable.distinctionIds?.length ?? 0) > 0));
+
+  return (
+    <BaseDetailScreen
+      onEditPress={() => navigation.navigate('QuestsForm', { quest })}
+      deleteConfig={{
+        itemName: `"${quest.name}"`,
+        onDelete: async () => {
+          const success = await deleteQuest(quest.id);
+          if (!success) {
+            throw new Error('Failed to delete quest');
+          }
+        },
+      }}
+    >
+      {/* Header */}
+      <View style={styles.header}>
+        <Text style={styles.questName}>{quest.name}</Text>
+        <View
+          style={[
+            styles.statusBadge,
+            { backgroundColor: STATUS_COLORS[quest.status] },
+          ]}
+        >
+          <Text style={styles.statusBadgeText}>
+            {STATUS_LABELS[quest.status]}
+          </Text>
+        </View>
+        {quest.date && (
+          <Text style={styles.dateText}>
+            {formatEventDate(quest.date, quest.time)}
+          </Text>
+        )}
+      </View>
+
+      {/* Details */}
+      {quest.details && (
+        <Section title="Details">
+          <Text style={styles.bodyText}>{quest.details}</Text>
+        </Section>
+      )}
+
+      {/* Overview */}
+      <Section title="Overview">
+        <View style={styles.overviewRow}>
+          <Text style={styles.overviewLabel}>Team Size Goal</Text>
+          <Text style={styles.overviewValue}>
+            {quest.teamSize ?? 'Default'}
+          </Text>
+        </View>
+        {quest.locationName && (
+          <View style={styles.overviewRow}>
+            <Text style={styles.overviewLabel}>Location</Text>
+            <Text style={styles.overviewValue}>{quest.locationName}</Text>
+          </View>
+        )}
+        {quest.junktownOffice && (
+          <View style={styles.overviewRow}>
+            <Text style={styles.overviewLabel}>Junktown Office</Text>
+            <Text style={styles.overviewValue}>{quest.junktownOffice}</Text>
+          </View>
+        )}
+      </Section>
+
+      {/* Assigned Team */}
+      <CollapsibleSection
+        title={`Assigned Team (${quest.characterNames.length})`}
+      >
+        {quest.characterNames.length > 0 ? (
+          <View style={styles.chipList}>
+            {quest.characterNames.map((name, index) => (
+              <View key={index} style={styles.chip}>
+                <Text style={styles.chipText}>{name}</Text>
+              </View>
+            ))}
+          </View>
+        ) : (
+          <Text style={styles.emptyText}>No characters assigned yet</Text>
+        )}
+      </CollapsibleSection>
+
+      {/* Team Preferences */}
+      {hasPreferences && (
+        <CollapsibleSection title="Team Preferences" defaultCollapsed>
+          {quest.desirable && (
+            <View style={styles.preferenceGroup}>
+              <Text style={styles.preferenceLabel}>Desirable</Text>
+              <View style={styles.chipList}>
+                {quest.desirable.tags?.map(tag => (
+                  <View key={`tag-${tag}`} style={styles.chipPositive}>
+                    <Text style={styles.chipText}>{tag}</Text>
+                  </View>
+                ))}
+                {quest.desirable.species?.map(species => (
+                  <View key={`species-${species}`} style={styles.chipPositive}>
+                    <Text style={styles.chipText}>{species}</Text>
+                  </View>
+                ))}
+                {quest.desirable.perkIds?.map(perkId => (
+                  <View key={`perk-${perkId}`} style={styles.chipPositive}>
+                    <Text style={styles.chipText}>{perkId}</Text>
+                  </View>
+                ))}
+                {quest.desirable.distinctionIds?.map(distinctionId => (
+                  <View
+                    key={`distinction-${distinctionId}`}
+                    style={styles.chipPositive}
+                  >
+                    <Text style={styles.chipText}>{distinctionId}</Text>
+                  </View>
+                ))}
+              </View>
+            </View>
+          )}
+          {quest.undesirable && (
+            <View style={styles.preferenceGroup}>
+              <Text style={styles.preferenceLabel}>Undesirable</Text>
+              <View style={styles.chipList}>
+                {quest.undesirable.tags?.map(tag => (
+                  <View key={`tag-${tag}`} style={styles.chipNegative}>
+                    <Text style={styles.chipText}>{tag}</Text>
+                  </View>
+                ))}
+                {quest.undesirable.species?.map(species => (
+                  <View key={`species-${species}`} style={styles.chipNegative}>
+                    <Text style={styles.chipText}>{species}</Text>
+                  </View>
+                ))}
+                {quest.undesirable.perkIds?.map(perkId => (
+                  <View key={`perk-${perkId}`} style={styles.chipNegative}>
+                    <Text style={styles.chipText}>{perkId}</Text>
+                  </View>
+                ))}
+                {quest.undesirable.distinctionIds?.map(distinctionId => (
+                  <View
+                    key={`distinction-${distinctionId}`}
+                    style={styles.chipNegative}
+                  >
+                    <Text style={styles.chipText}>{distinctionId}</Text>
+                  </View>
+                ))}
+              </View>
+            </View>
+          )}
+        </CollapsibleSection>
+      )}
+
+      {/* Required Materials */}
+      {quest.requiredMaterials && quest.requiredMaterials.length > 0 && (
+        <CollapsibleSection
+          title={`Required Materials (${quest.requiredMaterials.length})`}
+        >
+          <View style={styles.materialsList}>
+            {quest.requiredMaterials.map(material => {
+              const isComplete =
+                material.quantityProvided >= material.quantityRequired;
+              const isPartial = material.quantityProvided > 0 && !isComplete;
+              return (
+                <View key={material.id} style={styles.materialRow}>
+                  <Text style={styles.materialName}>{material.name}</Text>
+                  <View
+                    style={[
+                      styles.materialProgressBadge,
+                      isComplete && styles.materialProgressComplete,
+                      isPartial && styles.materialProgressPartial,
+                    ]}
+                  >
+                    <Text style={styles.materialProgressText}>
+                      {material.quantityProvided}/{material.quantityRequired}
+                    </Text>
+                  </View>
+                </View>
+              );
+            })}
+          </View>
+        </CollapsibleSection>
+      )}
+
+      {/* Related Factions */}
+      {quest.factionNames && quest.factionNames.length > 0 && (
+        <CollapsibleSection
+          title={`Related Factions (${quest.factionNames.length})`}
+          defaultCollapsed
+        >
+          <View style={styles.chipList}>
+            {quest.factionNames.map((faction, index) => (
+              <View key={index} style={styles.chip}>
+                <Text style={styles.chipText}>{faction}</Text>
+              </View>
+            ))}
+          </View>
+        </CollapsibleSection>
+      )}
+
+      {/* Related Events */}
+      {quest.eventTitles.length > 0 && (
+        <CollapsibleSection
+          title={`Related Events (${quest.eventTitles.length})`}
+          defaultCollapsed
+        >
+          <View style={styles.chipList}>
+            {quest.eventTitles.map((title, index) => (
+              <View key={index} style={styles.chip}>
+                <Text style={styles.chipText}>{title}</Text>
+              </View>
+            ))}
+          </View>
+        </CollapsibleSection>
+      )}
+
+      {/* Notes */}
+      {quest.notes && (
+        <Section title="Notes">
+          <Text style={styles.bodyText}>{quest.notes}</Text>
+        </Section>
+      )}
+    </BaseDetailScreen>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: themeColors.primary,
+  },
+  loadingText: {
+    ...commonStyles.text.body,
+    textAlign: 'center',
+    marginTop: 40,
+    paddingTop: 8,
+  },
+  header: {
+    ...commonStyles.card.base,
+    padding: 20,
+    marginBottom: 24,
+    alignItems: 'center',
+  },
+  questName: {
+    ...commonStyles.text.h1,
+    textAlign: 'center',
+    marginBottom: 12,
+  },
+  statusBadge: {
+    ...commonStyles.badge.base,
+    marginBottom: 8,
+  },
+  statusBadgeText: commonStyles.badge.text,
+  dateText: {
+    ...commonStyles.text.body,
+  },
+  bodyText: {
+    ...commonStyles.text.bodyLarge,
+  },
+  overviewRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 8,
+  },
+  overviewLabel: commonStyles.text.label,
+  overviewValue: {
+    ...commonStyles.text.body,
+    fontWeight: '600',
+  },
+  chipList: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  chip: {
+    ...commonStyles.badge.base,
+    backgroundColor: themeColors.elevated,
+    borderWidth: 1,
+    borderColor: themeColors.border,
+  },
+  chipPositive: {
+    ...commonStyles.badge.base,
+    backgroundColor: 'rgba(16, 185, 129, 0.15)',
+    borderWidth: 1,
+    borderColor: themeColors.accent.success,
+  },
+  chipNegative: {
+    ...commonStyles.badge.base,
+    backgroundColor: 'rgba(239, 68, 68, 0.15)',
+    borderWidth: 1,
+    borderColor: themeColors.accent.danger,
+  },
+  chipText: commonStyles.badge.text,
+  preferenceGroup: {
+    marginBottom: 16,
+  },
+  preferenceLabel: {
+    ...commonStyles.text.label,
+    marginBottom: 8,
+  },
+  emptyText: {
+    ...commonStyles.text.body,
+    color: themeColors.text.muted,
+  },
+  materialsList: {
+    gap: 8,
+  },
+  materialRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  materialName: {
+    ...commonStyles.text.body,
+    flex: 1,
+  },
+  materialProgressBadge: {
+    ...commonStyles.badge.small,
+    backgroundColor: themeColors.elevated,
+    borderWidth: 1,
+    borderColor: themeColors.border,
+  },
+  materialProgressPartial: {
+    backgroundColor: 'rgba(245, 158, 11, 0.15)',
+    borderColor: themeColors.accent.warning,
+  },
+  materialProgressComplete: {
+    backgroundColor: 'rgba(16, 185, 129, 0.15)',
+    borderColor: themeColors.accent.success,
+  },
+  materialProgressText: commonStyles.badge.text,
+});

--- a/src/screens/quest/QuestFormScreen.tsx
+++ b/src/screens/quest/QuestFormScreen.tsx
@@ -1,0 +1,892 @@
+import React, { useState, useEffect } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  Alert,
+} from 'react-native';
+import { v4 as uuidv4 } from 'uuid';
+import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { RootStackParamList } from '@/navigation/types';
+import {
+  createQuest,
+  updateQuest,
+  loadCharacters,
+  loadLocations,
+  loadFactions,
+  loadEvents,
+} from '@utils/characterStorage';
+import { colors as themeColors } from '@/styles/theme';
+import { commonStyles } from '@/styles/commonStyles';
+import { Picker } from '@react-native-picker/picker';
+import {
+  GameCharacter,
+  GameLocation,
+  GameEvent,
+  QuestStatus,
+  QuestMaterial,
+  PerkId,
+  DistinctionId,
+} from '@models/types';
+import {
+  PerkTag,
+  AVAILABLE_PERKS,
+  AVAILABLE_DISTINCTIONS,
+} from '@models/gameData';
+import { SPECIES_BASE_STATS, Species } from '@models/speciesTypes';
+import { BaseFormScreen, CollapsibleSection } from '@/components';
+
+type QuestsFormNavigationProp = StackNavigationProp<
+  RootStackParamList,
+  'QuestsForm'
+>;
+
+type QuestsFormRouteProp = RouteProp<RootStackParamList, 'QuestsForm'>;
+
+const STATUS_LABELS: Record<QuestStatus, string> = {
+  [QuestStatus.NotStarted]: 'Not Started',
+  [QuestStatus.Assigned]: 'Assigned',
+  [QuestStatus.InProgress]: 'In Progress',
+  [QuestStatus.Successful]: 'Successful',
+  [QuestStatus.Failure]: 'Failure',
+};
+
+interface PreferenceLists {
+  tags: PerkTag[];
+  species: Species[];
+  distinctionIds: DistinctionId[];
+  perkIds: PerkId[];
+}
+
+const emptyPreferenceLists = (): PreferenceLists => ({
+  tags: [],
+  species: [],
+  distinctionIds: [],
+  perkIds: [],
+});
+
+interface QuestFormData {
+  name: string;
+  details: string;
+  date: string;
+  time: string;
+  status: QuestStatus;
+  assignedCharacterIds: string[];
+  desirable: PreferenceLists;
+  undesirable: PreferenceLists;
+  locationId: string;
+  factionNames: string[];
+  eventIds: string[];
+  junktownOffice: string;
+  requiredMaterials: QuestMaterial[];
+  teamSize: string;
+  notes: string;
+}
+
+const emptyFormData = (): QuestFormData => ({
+  name: '',
+  details: '',
+  date: '',
+  time: '',
+  status: QuestStatus.NotStarted,
+  assignedCharacterIds: [],
+  desirable: emptyPreferenceLists(),
+  undesirable: emptyPreferenceLists(),
+  locationId: '',
+  factionNames: [],
+  eventIds: [],
+  junktownOffice: '',
+  requiredMaterials: [],
+  teamSize: '',
+  notes: '',
+});
+
+interface Option<T extends string> {
+  value: T;
+  label: string;
+}
+
+interface MultiSelectFieldProps<T extends string> {
+  label: string;
+  placeholder: string;
+  options: Option<T>[];
+  selected: T[];
+  onAdd: (value: T) => void;
+  onRemove: (value: T) => void;
+}
+
+function MultiSelectField<T extends string>({
+  label,
+  placeholder,
+  options,
+  selected,
+  onAdd,
+  onRemove,
+}: MultiSelectFieldProps<T>) {
+  const availableOptions = options.filter(
+    option => !selected.includes(option.value)
+  );
+
+  return (
+    <View style={styles.subField}>
+      <Text style={styles.sublabel}>{label}</Text>
+      <View style={styles.pickerContainer}>
+        <Picker
+          selectedValue=""
+          onValueChange={(value: string) => {
+            if (value) onAdd(value as T);
+          }}
+          style={styles.picker}
+          dropdownIconColor={themeColors.text.secondary}
+        >
+          <Picker.Item label={placeholder} value="" />
+          {availableOptions.map(option => (
+            <Picker.Item
+              key={option.value}
+              label={option.label}
+              value={option.value}
+            />
+          ))}
+        </Picker>
+      </View>
+      {selected.length > 0 && (
+        <View style={styles.selectedList}>
+          {selected.map(value => {
+            const option = options.find(o => o.value === value);
+            return (
+              <View key={value} style={styles.selectedChip}>
+                <Text style={styles.selectedChipText}>
+                  {option?.label ?? value}
+                </Text>
+                <TouchableOpacity onPress={() => onRemove(value)}>
+                  <Text style={styles.removeButton}>×</Text>
+                </TouchableOpacity>
+              </View>
+            );
+          })}
+        </View>
+      )}
+    </View>
+  );
+}
+
+const TAG_OPTIONS: Option<PerkTag>[] = Object.values(PerkTag).map(tag => ({
+  value: tag,
+  label: tag,
+}));
+
+const SPECIES_OPTIONS: Option<Species>[] = Object.keys(SPECIES_BASE_STATS).map(
+  species => ({
+    value: species as Species,
+    label: species,
+  })
+);
+
+const PERK_OPTIONS: Option<PerkId>[] = AVAILABLE_PERKS.map(perk => ({
+  value: perk.id as PerkId,
+  label: `${perk.name} (${perk.tag})`,
+}));
+
+const DISTINCTION_OPTIONS: Option<DistinctionId>[] = AVAILABLE_DISTINCTIONS.map(
+  distinction => ({
+    value: distinction.id as DistinctionId,
+    label: distinction.name,
+  })
+);
+
+export const QuestFormScreen: React.FC = () => {
+  const navigation = useNavigation<QuestsFormNavigationProp>();
+  const route = useRoute<QuestsFormRouteProp>();
+  const { quest } = route.params || {};
+
+  const [formData, setFormData] = useState<QuestFormData>(emptyFormData());
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [characters, setCharacters] = useState<GameCharacter[]>([]);
+  const [locations, setLocations] = useState<GameLocation[]>([]);
+  const [factions, setFactions] = useState<string[]>([]);
+  const [events, setEvents] = useState<GameEvent[]>([]);
+
+  useEffect(() => {
+    const loadData = async () => {
+      const [loadedCharacters, loadedLocations, loadedFactions, loadedEvents] =
+        await Promise.all([
+          loadCharacters(),
+          loadLocations(),
+          loadFactions(),
+          loadEvents(),
+        ]);
+      setCharacters(
+        loadedCharacters.sort((a, b) => a.name.localeCompare(b.name))
+      );
+      setLocations(
+        loadedLocations.sort((a, b) => a.name.localeCompare(b.name))
+      );
+      setFactions(
+        loadedFactions
+          .filter(f => !f.retired)
+          .map(f => f.name)
+          .sort()
+      );
+      setEvents(
+        [...loadedEvents].sort((a, b) => a.title.localeCompare(b.title))
+      );
+    };
+    loadData();
+  }, []);
+
+  useEffect(() => {
+    if (quest) {
+      setFormData({
+        name: quest.name,
+        details: quest.details || '',
+        date: quest.date || '',
+        time: quest.time || '',
+        status: quest.status,
+        assignedCharacterIds: quest.assignedCharacterIds || [],
+        desirable: {
+          tags: quest.desirable?.tags || [],
+          species: quest.desirable?.species || [],
+          distinctionIds: quest.desirable?.distinctionIds || [],
+          perkIds: quest.desirable?.perkIds || [],
+        },
+        undesirable: {
+          tags: quest.undesirable?.tags || [],
+          species: quest.undesirable?.species || [],
+          distinctionIds: quest.undesirable?.distinctionIds || [],
+          perkIds: quest.undesirable?.perkIds || [],
+        },
+        locationId: quest.locationId || '',
+        factionNames: quest.factionNames || [],
+        eventIds: quest.eventIds || [],
+        junktownOffice: quest.junktownOffice || '',
+        requiredMaterials: quest.requiredMaterials || [],
+        teamSize: quest.teamSize !== undefined ? String(quest.teamSize) : '',
+        notes: quest.notes || '',
+      });
+    }
+  }, [quest]);
+
+  const addCharacter = (characterId: string) => {
+    if (!formData.assignedCharacterIds.includes(characterId)) {
+      setFormData({
+        ...formData,
+        assignedCharacterIds: [...formData.assignedCharacterIds, characterId],
+      });
+    }
+  };
+
+  const removeCharacter = (characterId: string) => {
+    setFormData({
+      ...formData,
+      assignedCharacterIds: formData.assignedCharacterIds.filter(
+        id => id !== characterId
+      ),
+    });
+  };
+
+  const addFaction = (factionName: string) => {
+    if (!formData.factionNames.includes(factionName)) {
+      setFormData({
+        ...formData,
+        factionNames: [...formData.factionNames, factionName],
+      });
+    }
+  };
+
+  const removeFaction = (factionName: string) => {
+    setFormData({
+      ...formData,
+      factionNames: formData.factionNames.filter(f => f !== factionName),
+    });
+  };
+
+  const addEvent = (eventId: string) => {
+    if (!formData.eventIds.includes(eventId)) {
+      setFormData({ ...formData, eventIds: [...formData.eventIds, eventId] });
+    }
+  };
+
+  const removeEvent = (eventId: string) => {
+    setFormData({
+      ...formData,
+      eventIds: formData.eventIds.filter(id => id !== eventId),
+    });
+  };
+
+  const updatePreferenceList = <K extends keyof PreferenceLists>(
+    which: 'desirable' | 'undesirable',
+    key: K,
+    updater: (list: PreferenceLists[K]) => PreferenceLists[K]
+  ): void => {
+    setFormData(prev => ({
+      ...prev,
+      [which]: {
+        ...prev[which],
+        [key]: updater(prev[which][key]),
+      },
+    }));
+  };
+
+  const addPreference = <K extends keyof PreferenceLists>(
+    which: 'desirable' | 'undesirable',
+    key: K,
+    value: PreferenceLists[K][number]
+  ) => {
+    updatePreferenceList(which, key, list => {
+      const stringList = list as unknown as string[];
+      return stringList.includes(value as string)
+        ? list
+        : ([...stringList, value] as unknown as PreferenceLists[K]);
+    });
+  };
+
+  const removePreference = <K extends keyof PreferenceLists>(
+    which: 'desirable' | 'undesirable',
+    key: K,
+    value: PreferenceLists[K][number]
+  ) => {
+    updatePreferenceList(which, key, list => {
+      const stringList = list as unknown as string[];
+      return stringList.filter(
+        item => item !== value
+      ) as unknown as PreferenceLists[K];
+    });
+  };
+
+  const addMaterial = () => {
+    setFormData(prev => ({
+      ...prev,
+      requiredMaterials: [
+        ...prev.requiredMaterials,
+        { id: uuidv4(), name: '', quantityRequired: 1, quantityProvided: 0 },
+      ],
+    }));
+  };
+
+  const updateMaterial = (id: string, updates: Partial<QuestMaterial>) => {
+    setFormData(prev => ({
+      ...prev,
+      requiredMaterials: prev.requiredMaterials.map(material =>
+        material.id === id ? { ...material, ...updates } : material
+      ),
+    }));
+  };
+
+  const removeMaterial = (id: string) => {
+    setFormData(prev => ({
+      ...prev,
+      requiredMaterials: prev.requiredMaterials.filter(m => m.id !== id),
+    }));
+  };
+
+  const validateForm = (): boolean => {
+    const newErrors: Record<string, string> = {};
+
+    if (!formData.name.trim()) {
+      newErrors.name = 'Mission name is required';
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async () => {
+    if (!validateForm()) return;
+
+    setIsSubmitting(true);
+    try {
+      const parsedTeamSize = parseInt(formData.teamSize, 10);
+      const payload = {
+        name: formData.name.trim(),
+        details: formData.details.trim() || undefined,
+        date: formData.date || undefined,
+        time: formData.time || undefined,
+        status: formData.status,
+        assignedCharacterIds: formData.assignedCharacterIds,
+        desirable: formData.desirable,
+        undesirable: formData.undesirable,
+        locationId: formData.locationId || undefined,
+        factionNames: formData.factionNames,
+        eventIds: formData.eventIds,
+        junktownOffice: formData.junktownOffice.trim() || undefined,
+        requiredMaterials: formData.requiredMaterials,
+        teamSize:
+          formData.teamSize && !isNaN(parsedTeamSize)
+            ? parsedTeamSize
+            : undefined,
+        notes: formData.notes.trim() || undefined,
+      };
+
+      if (quest) {
+        await updateQuest(quest.id, payload);
+        Alert.alert('Success', 'Quest updated successfully', [
+          { text: 'OK', onPress: () => navigation.goBack() },
+        ]);
+      } else {
+        await createQuest(payload);
+        Alert.alert('Success', 'Quest created successfully', [
+          { text: 'OK', onPress: () => navigation.goBack() },
+        ]);
+      }
+    } catch {
+      Alert.alert('Error', 'Failed to save quest. Please try again.', [
+        { text: 'OK' },
+      ]);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const characterOptions: Option<string>[] = characters.map(character => ({
+    value: character.id,
+    label: character.name,
+  }));
+  const factionOptions: Option<string>[] = factions.map(faction => ({
+    value: faction,
+    label: faction,
+  }));
+  const eventOptions: Option<string>[] = events.map(event => ({
+    value: event.id,
+    label: event.title,
+  }));
+
+  return (
+    <BaseFormScreen contentContainerStyle={styles.content}>
+      {/* Name */}
+      <View style={styles.section}>
+        <Text style={styles.label}>Mission Name *</Text>
+        <TextInput
+          style={[styles.input, errors.name && styles.inputError]}
+          placeholder="Mission name"
+          placeholderTextColor={themeColors.text.muted}
+          value={formData.name}
+          onChangeText={name => setFormData({ ...formData, name })}
+        />
+        {errors.name && <Text style={styles.errorText}>{errors.name}</Text>}
+      </View>
+
+      {/* Details */}
+      <View style={styles.section}>
+        <Text style={styles.label}>Details</Text>
+        <TextInput
+          style={[styles.input, styles.textArea]}
+          placeholder="Mission details"
+          placeholderTextColor={themeColors.text.muted}
+          value={formData.details}
+          onChangeText={details => setFormData({ ...formData, details })}
+          multiline
+          numberOfLines={4}
+        />
+      </View>
+
+      {/* Date and Time */}
+      <View style={styles.section}>
+        <Text style={styles.label}>Time of Mission</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="YYYY-MM-DD (optional)"
+          placeholderTextColor={themeColors.text.muted}
+          value={formData.date}
+          onChangeText={date => setFormData({ ...formData, date })}
+        />
+        <TextInput
+          style={[styles.input, styles.labelMargin]}
+          placeholder="HH:MM (optional)"
+          placeholderTextColor={themeColors.text.muted}
+          value={formData.time}
+          onChangeText={time => setFormData({ ...formData, time })}
+        />
+      </View>
+
+      {/* Status */}
+      <View style={styles.section}>
+        <Text style={styles.label}>Mission Status</Text>
+        <View style={styles.pickerContainer}>
+          <Picker
+            selectedValue={formData.status}
+            onValueChange={status => setFormData({ ...formData, status })}
+            style={styles.picker}
+            dropdownIconColor={themeColors.text.secondary}
+          >
+            {Object.values(QuestStatus).map(status => (
+              <Picker.Item
+                key={status}
+                label={STATUS_LABELS[status]}
+                value={status}
+              />
+            ))}
+          </Picker>
+        </View>
+      </View>
+
+      {/* Team size */}
+      <View style={styles.section}>
+        <Text style={styles.label}>Desired Team Size</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="Default: 4"
+          placeholderTextColor={themeColors.text.muted}
+          value={formData.teamSize}
+          onChangeText={teamSize => setFormData({ ...formData, teamSize })}
+          keyboardType="numeric"
+        />
+      </View>
+
+      {/* Assigned characters */}
+      <View style={styles.section}>
+        <MultiSelectField
+          label="Assigned Characters"
+          placeholder="Select character to add..."
+          options={characterOptions}
+          selected={formData.assignedCharacterIds}
+          onAdd={addCharacter}
+          onRemove={removeCharacter}
+        />
+      </View>
+
+      {/* Team preferences */}
+      <CollapsibleSection title="Team Preferences" defaultCollapsed>
+        <Text style={styles.sublabel}>Desirable</Text>
+        <MultiSelectField
+          label="Tags"
+          placeholder="Select tag to add..."
+          options={TAG_OPTIONS}
+          selected={formData.desirable.tags}
+          onAdd={value => addPreference('desirable', 'tags', value)}
+          onRemove={value => removePreference('desirable', 'tags', value)}
+        />
+        <MultiSelectField
+          label="Species"
+          placeholder="Select species to add..."
+          options={SPECIES_OPTIONS}
+          selected={formData.desirable.species}
+          onAdd={value => addPreference('desirable', 'species', value)}
+          onRemove={value => removePreference('desirable', 'species', value)}
+        />
+        <MultiSelectField
+          label="Perks"
+          placeholder="Select perk to add..."
+          options={PERK_OPTIONS}
+          selected={formData.desirable.perkIds}
+          onAdd={value => addPreference('desirable', 'perkIds', value)}
+          onRemove={value => removePreference('desirable', 'perkIds', value)}
+        />
+        <MultiSelectField
+          label="Distinctions"
+          placeholder="Select distinction to add..."
+          options={DISTINCTION_OPTIONS}
+          selected={formData.desirable.distinctionIds}
+          onAdd={value => addPreference('desirable', 'distinctionIds', value)}
+          onRemove={value =>
+            removePreference('desirable', 'distinctionIds', value)
+          }
+        />
+
+        <Text style={[styles.sublabel, styles.labelMargin]}>Undesirable</Text>
+        <MultiSelectField
+          label="Tags"
+          placeholder="Select tag to add..."
+          options={TAG_OPTIONS}
+          selected={formData.undesirable.tags}
+          onAdd={value => addPreference('undesirable', 'tags', value)}
+          onRemove={value => removePreference('undesirable', 'tags', value)}
+        />
+        <MultiSelectField
+          label="Species"
+          placeholder="Select species to add..."
+          options={SPECIES_OPTIONS}
+          selected={formData.undesirable.species}
+          onAdd={value => addPreference('undesirable', 'species', value)}
+          onRemove={value => removePreference('undesirable', 'species', value)}
+        />
+        <MultiSelectField
+          label="Perks"
+          placeholder="Select perk to add..."
+          options={PERK_OPTIONS}
+          selected={formData.undesirable.perkIds}
+          onAdd={value => addPreference('undesirable', 'perkIds', value)}
+          onRemove={value => removePreference('undesirable', 'perkIds', value)}
+        />
+        <MultiSelectField
+          label="Distinctions"
+          placeholder="Select distinction to add..."
+          options={DISTINCTION_OPTIONS}
+          selected={formData.undesirable.distinctionIds}
+          onAdd={value => addPreference('undesirable', 'distinctionIds', value)}
+          onRemove={value =>
+            removePreference('undesirable', 'distinctionIds', value)
+          }
+        />
+      </CollapsibleSection>
+
+      {/* Location */}
+      <View style={styles.section}>
+        <Text style={styles.label}>Location</Text>
+        <View style={styles.pickerContainer}>
+          <Picker
+            selectedValue={formData.locationId}
+            onValueChange={locationId =>
+              setFormData({ ...formData, locationId })
+            }
+            style={styles.picker}
+            dropdownIconColor={themeColors.text.secondary}
+          >
+            <Picker.Item label="Select location..." value="" />
+            {locations.map(location => (
+              <Picker.Item
+                key={location.id}
+                label={location.name}
+                value={location.id}
+              />
+            ))}
+          </Picker>
+        </View>
+      </View>
+
+      {/* Factions */}
+      <View style={styles.section}>
+        <MultiSelectField
+          label="Related Factions"
+          placeholder="Select faction to add..."
+          options={factionOptions}
+          selected={formData.factionNames}
+          onAdd={addFaction}
+          onRemove={removeFaction}
+        />
+      </View>
+
+      {/* Events */}
+      <View style={styles.section}>
+        <MultiSelectField
+          label="Related Events"
+          placeholder="Select event to add..."
+          options={eventOptions}
+          selected={formData.eventIds}
+          onAdd={addEvent}
+          onRemove={removeEvent}
+        />
+      </View>
+
+      {/* Junktown office */}
+      <View style={styles.section}>
+        <Text style={styles.label}>Related Junktown Office</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="Office name (optional)"
+          placeholderTextColor={themeColors.text.muted}
+          value={formData.junktownOffice}
+          onChangeText={junktownOffice =>
+            setFormData({ ...formData, junktownOffice })
+          }
+        />
+      </View>
+
+      {/* Required materials */}
+      <View style={styles.section}>
+        <Text style={styles.label}>Required Materials</Text>
+        {formData.requiredMaterials.map(material => (
+          <View key={material.id} style={styles.materialRow}>
+            <TextInput
+              style={[styles.input, styles.materialNameInput]}
+              placeholder="Material name"
+              placeholderTextColor={themeColors.text.muted}
+              value={material.name}
+              onChangeText={name => updateMaterial(material.id, { name })}
+            />
+            <TextInput
+              style={[styles.input, styles.materialQtyInput]}
+              placeholder="Req"
+              placeholderTextColor={themeColors.text.muted}
+              keyboardType="numeric"
+              value={String(material.quantityRequired)}
+              onChangeText={value =>
+                updateMaterial(material.id, {
+                  quantityRequired: parseInt(value, 10) || 0,
+                })
+              }
+            />
+            <TextInput
+              style={[styles.input, styles.materialQtyInput]}
+              placeholder="Have"
+              placeholderTextColor={themeColors.text.muted}
+              keyboardType="numeric"
+              value={String(material.quantityProvided)}
+              onChangeText={value =>
+                updateMaterial(material.id, {
+                  quantityProvided: parseInt(value, 10) || 0,
+                })
+              }
+            />
+            <TouchableOpacity onPress={() => removeMaterial(material.id)}>
+              <Text style={styles.removeButton}>×</Text>
+            </TouchableOpacity>
+          </View>
+        ))}
+        <TouchableOpacity
+          style={styles.addMaterialButton}
+          onPress={addMaterial}
+        >
+          <Text style={styles.addMaterialButtonText}>+ Add Material</Text>
+        </TouchableOpacity>
+      </View>
+
+      {/* Notes */}
+      <View style={styles.section}>
+        <Text style={styles.label}>Notes</Text>
+        <TextInput
+          style={[styles.input, styles.textArea]}
+          placeholder="Additional notes about the quest"
+          placeholderTextColor={themeColors.text.muted}
+          value={formData.notes}
+          onChangeText={notes => setFormData({ ...formData, notes })}
+          multiline
+          numberOfLines={4}
+        />
+      </View>
+
+      {/* Submit */}
+      <TouchableOpacity
+        style={[
+          styles.submitButton,
+          isSubmitting && styles.submitButtonDisabled,
+        ]}
+        onPress={handleSubmit}
+        disabled={isSubmitting}
+      >
+        <Text style={styles.submitButtonText}>
+          {isSubmitting ? 'Saving...' : quest ? 'Update Quest' : 'Create Quest'}
+        </Text>
+      </TouchableOpacity>
+
+      <View style={styles.footer} />
+    </BaseFormScreen>
+  );
+};
+
+const styles = StyleSheet.create({
+  content: {
+    padding: 16,
+    paddingBottom: 100,
+  },
+  section: {
+    marginBottom: 24,
+  },
+  subField: {
+    marginBottom: 16,
+  },
+  label: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: themeColors.text.primary,
+    marginBottom: 8,
+  },
+  sublabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: themeColors.text.secondary,
+    marginBottom: 8,
+  },
+  labelMargin: {
+    marginTop: 16,
+  },
+  input: {
+    backgroundColor: themeColors.elevated,
+    borderWidth: 1,
+    borderColor: themeColors.border,
+    borderRadius: 8,
+    padding: 12,
+    color: themeColors.text.primary,
+    fontSize: 16,
+  },
+  inputError: {
+    borderColor: themeColors.accent.danger,
+  },
+  textArea: {
+    minHeight: 100,
+    textAlignVertical: 'top',
+  },
+  errorText: {
+    color: themeColors.accent.danger,
+    fontSize: 12,
+    marginTop: 4,
+  },
+  pickerContainer: {
+    backgroundColor: themeColors.elevated,
+    borderWidth: 1,
+    borderColor: themeColors.border,
+    borderRadius: 8,
+    overflow: 'hidden',
+  },
+  picker: {
+    color: themeColors.text.primary,
+  },
+  selectedList: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginTop: 12,
+  },
+  selectedChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingLeft: 12,
+    paddingRight: 8,
+    paddingVertical: 8,
+    backgroundColor: themeColors.accent.secondary,
+    borderRadius: 16,
+    gap: 6,
+  },
+  selectedChipText: {
+    fontSize: 14,
+    color: themeColors.text.primary,
+  },
+  removeButton: {
+    fontSize: 20,
+    color: themeColors.text.primary,
+    fontWeight: 'bold',
+    paddingHorizontal: 4,
+  },
+  materialRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 8,
+  },
+  materialNameInput: {
+    flex: 2,
+  },
+  materialQtyInput: {
+    flex: 1,
+  },
+  addMaterialButton: {
+    ...commonStyles.button.base,
+    ...commonStyles.button.outline,
+    marginTop: 4,
+  },
+  addMaterialButtonText: {
+    ...commonStyles.text.body,
+    fontWeight: '600',
+  },
+  submitButton: {
+    backgroundColor: themeColors.accent.primary,
+    borderRadius: 8,
+    padding: 16,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  submitButtonDisabled: {
+    opacity: 0.5,
+  },
+  submitButtonText: {
+    color: themeColors.text.primary,
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  footer: {
+    height: 50,
+  },
+});

--- a/src/screens/quest/QuestListScreen.tsx
+++ b/src/screens/quest/QuestListScreen.tsx
@@ -1,0 +1,241 @@
+import React, { useState, useCallback } from 'react';
+import { View, StyleSheet, TouchableOpacity, Text } from 'react-native';
+import { GameQuest, QuestStatus } from '@models/types';
+import { loadQuests } from '@utils/characterStorage';
+import {
+  useNavigation,
+  useFocusEffect,
+  CompositeNavigationProp,
+} from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { DrawerNavigationProp } from '@react-navigation/drawer';
+import { RootStackParamList, RootDrawerParamList } from '@/navigation/types';
+import { colors as themeColors } from '@/styles/theme';
+import { commonStyles } from '@/styles/commonStyles';
+import { Picker } from '@react-native-picker/picker';
+import { BaseListScreen, HeaderAddButton } from '@/components';
+import { formatEventDateShort } from '@utils/dateUtils';
+
+type QuestListNavigationProp = CompositeNavigationProp<
+  DrawerNavigationProp<RootDrawerParamList, 'Quests'>,
+  StackNavigationProp<RootStackParamList>
+>;
+
+const STATUS_LABELS: Record<QuestStatus, string> = {
+  [QuestStatus.NotStarted]: 'Not Started',
+  [QuestStatus.Assigned]: 'Assigned',
+  [QuestStatus.InProgress]: 'In Progress',
+  [QuestStatus.Successful]: 'Successful',
+  [QuestStatus.Failure]: 'Failure',
+};
+
+const STATUS_COLORS: Record<QuestStatus, string> = {
+  [QuestStatus.NotStarted]: themeColors.text.muted,
+  [QuestStatus.Assigned]: themeColors.accent.info,
+  [QuestStatus.InProgress]: themeColors.accent.warning,
+  [QuestStatus.Successful]: themeColors.accent.success,
+  [QuestStatus.Failure]: themeColors.accent.danger,
+};
+
+const materialsProgress = (quest: GameQuest): string | null => {
+  const materials = quest.requiredMaterials;
+  if (!materials || materials.length === 0) return null;
+
+  const complete = materials.filter(
+    m => m.quantityProvided >= m.quantityRequired
+  ).length;
+  return `${complete}/${materials.length} materials`;
+};
+
+export const QuestListScreen: React.FC = () => {
+  const [quests, setQuests] = useState<GameQuest[]>([]);
+  const [searchQuery, setSearchQuery] = useState<string>('');
+  const [filterStatus, setFilterStatus] = useState<string>('');
+  const navigation = useNavigation<QuestListNavigationProp>();
+
+  const loadData = useCallback(async () => {
+    const questsData = await loadQuests();
+    setQuests([...questsData].sort((a, b) => a.name.localeCompare(b.name)));
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      loadData();
+    }, [loadData])
+  );
+
+  const filteredQuests = React.useMemo(() => {
+    let filtered = quests;
+
+    if (searchQuery.trim()) {
+      const query = searchQuery.toLowerCase().trim();
+      filtered = filtered.filter(
+        quest =>
+          quest.name.toLowerCase().includes(query) ||
+          (quest.details && quest.details.toLowerCase().includes(query))
+      );
+    }
+
+    if (filterStatus) {
+      filtered = filtered.filter(quest => quest.status === filterStatus);
+    }
+
+    return filtered;
+  }, [quests, searchQuery, filterStatus]);
+
+  const handleQuestSelect = (quest: GameQuest) => {
+    navigation.navigate('QuestsDetail', { questId: quest.id });
+  };
+
+  const handleCreateQuest = () => {
+    navigation.navigate('QuestsForm', {});
+  };
+
+  const handleGenerateProposals = () => {
+    navigation.navigate('QuestProposals');
+  };
+
+  const renderFilters = () => (
+    <View style={styles.filterContainer}>
+      <View style={styles.pickerContainer}>
+        <Picker
+          selectedValue={filterStatus}
+          onValueChange={setFilterStatus}
+          style={styles.picker}
+          dropdownIconColor={themeColors.text.secondary}
+        >
+          <Picker.Item label="All statuses" value="" />
+          {Object.values(QuestStatus).map(status => (
+            <Picker.Item
+              key={status}
+              label={STATUS_LABELS[status]}
+              value={status}
+            />
+          ))}
+        </Picker>
+      </View>
+    </View>
+  );
+
+  const renderQuestItem = (quest: GameQuest) => {
+    const materials = materialsProgress(quest);
+    const teamCount = quest.assignedCharacterIds?.length ?? 0;
+
+    return (
+      <TouchableOpacity
+        style={styles.questCard}
+        onPress={() => handleQuestSelect(quest)}
+      >
+        <View style={styles.questHeader}>
+          <Text style={styles.questName}>{quest.name}</Text>
+          <View
+            style={[
+              styles.statusBadge,
+              { backgroundColor: STATUS_COLORS[quest.status] },
+            ]}
+          >
+            <Text style={styles.statusBadgeText}>
+              {STATUS_LABELS[quest.status]}
+            </Text>
+          </View>
+        </View>
+
+        {quest.date && (
+          <Text style={styles.questMeta}>
+            {formatEventDateShort(quest.date, quest.time)}
+          </Text>
+        )}
+
+        <View style={styles.questFooter}>
+          <Text style={styles.questMeta}>
+            {teamCount} character{teamCount !== 1 ? 's' : ''} assigned
+          </Text>
+          {materials && <Text style={styles.questMeta}>{materials}</Text>}
+        </View>
+      </TouchableOpacity>
+    );
+  };
+
+  const renderHeaderRight = () => (
+    <View style={styles.headerButtons}>
+      <TouchableOpacity
+        style={styles.headerProposalsButton}
+        onPress={handleGenerateProposals}
+      >
+        <Text style={styles.headerProposalsButtonText}>Propose</Text>
+      </TouchableOpacity>
+      <HeaderAddButton onPress={handleCreateQuest} />
+    </View>
+  );
+
+  return (
+    <BaseListScreen
+      data={filteredQuests}
+      renderItem={renderQuestItem}
+      keyExtractor={(item: GameQuest) => item.id}
+      searchQuery={searchQuery}
+      onSearchChange={setSearchQuery}
+      searchPlaceholder="Search quests by name..."
+      emptyStateTitle="No quests found"
+      emptyStateSubtitle="Create a quest to get started"
+      headerRight={renderHeaderRight()}
+      ListHeaderComponent={renderFilters()}
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  questCard: commonStyles.card.base,
+  questHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    marginBottom: 8,
+    gap: 8,
+  },
+  questName: {
+    ...commonStyles.text.h3,
+    flex: 1,
+  },
+  statusBadge: {
+    ...commonStyles.badge.small,
+  },
+  statusBadgeText: {
+    ...commonStyles.badge.text,
+    fontSize: 11,
+  },
+  questFooter: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: 4,
+  },
+  questMeta: commonStyles.text.caption,
+  filterContainer: {
+    paddingHorizontal: 16,
+    paddingBottom: 8,
+  },
+  pickerContainer: {
+    backgroundColor: themeColors.elevated,
+    borderWidth: 1,
+    borderColor: themeColors.border,
+    borderRadius: 8,
+    overflow: 'hidden',
+  },
+  picker: {
+    color: themeColors.text.primary,
+  },
+  headerButtons: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  headerProposalsButton: {
+    ...commonStyles.headerButton.add,
+    width: undefined,
+    paddingHorizontal: 12,
+  },
+  headerProposalsButtonText: {
+    ...commonStyles.headerButton.addText,
+    fontSize: 13,
+  },
+});

--- a/src/screens/quest/QuestProposalScreen.tsx
+++ b/src/screens/quest/QuestProposalScreen.tsx
@@ -1,0 +1,273 @@
+import React, { useState, useCallback, useEffect, useMemo } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, Alert } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { RootStackParamList } from '@/navigation/types';
+import {
+  loadQuests,
+  loadCharacters,
+  updateQuest,
+} from '@utils/characterStorage';
+import { GameCharacter, GameQuest, QuestStatus } from '@models/types';
+import { colors as themeColors } from '@/styles/theme';
+import { commonStyles } from '@/styles/commonStyles';
+import { BaseDetailScreen, Section } from '@/components';
+import {
+  QuestProposal,
+  generateQuestProposals,
+  scoreCharacterForQuest,
+} from '@utils/questProposal';
+
+type QuestProposalsNavigationProp = StackNavigationProp<
+  RootStackParamList,
+  'QuestProposals'
+>;
+
+export const QuestProposalScreen: React.FC = () => {
+  const navigation = useNavigation<QuestProposalsNavigationProp>();
+
+  const [loading, setLoading] = useState(true);
+  const [quests, setQuests] = useState<GameQuest[]>([]);
+  const [characters, setCharacters] = useState<GameCharacter[]>([]);
+  const [proposals, setProposals] = useState<QuestProposal[]>([]);
+  const [savedQuestIds, setSavedQuestIds] = useState<Set<string>>(new Set());
+
+  // Fetches quests/characters and (re)computes proposals. `loading` starts
+  // `true` already, so this only needs to clear it when done; callers that
+  // re-invoke this after the initial mount (e.g. the Regenerate button) set
+  // `loading` back to `true` themselves before calling it.
+  const generate = async () => {
+    try {
+      const [questsData, charactersData] = await Promise.all([
+        loadQuests(),
+        loadCharacters(),
+      ]);
+      setQuests(questsData);
+      setCharacters(charactersData);
+      setProposals(generateQuestProposals(questsData, charactersData));
+      setSavedQuestIds(new Set());
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    generate();
+  }, []);
+
+  const handleRegenerate = () => {
+    setLoading(true);
+    generate();
+  };
+
+  const questMap = useMemo(
+    () => new Map(quests.map(quest => [quest.id, quest])),
+    [quests]
+  );
+  const characterMap = useMemo(
+    () => new Map(characters.map(character => [character.id, character])),
+    [characters]
+  );
+
+  const saveProposal = useCallback(async (proposal: QuestProposal) => {
+    await updateQuest(proposal.questId, {
+      assignedCharacterIds: proposal.proposedCharacterIds,
+      status: QuestStatus.Assigned,
+    });
+    setSavedQuestIds(prev => new Set(prev).add(proposal.questId));
+  }, []);
+
+  const handleSaveAll = async () => {
+    const unsaved = proposals.filter(
+      proposal =>
+        !savedQuestIds.has(proposal.questId) &&
+        proposal.proposedCharacterIds.length > 0
+    );
+
+    if (unsaved.length === 0) return;
+
+    await Promise.all(unsaved.map(saveProposal));
+    Alert.alert('Saved', 'Proposed teams have been saved to their quests.');
+  };
+
+  const handleDiscard = () => {
+    navigation.goBack();
+  };
+
+  const renderHeaderRight = () => (
+    <View style={styles.headerButtons}>
+      <TouchableOpacity
+        style={styles.headerActionButton}
+        onPress={handleRegenerate}
+      >
+        <Text style={styles.headerActionText}>Regenerate</Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        style={[styles.headerActionButton, styles.headerSaveButton]}
+        onPress={handleSaveAll}
+      >
+        <Text style={styles.headerActionText}>Save All</Text>
+      </TouchableOpacity>
+    </View>
+  );
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.loadingText}>Generating proposals...</Text>
+      </View>
+    );
+  }
+
+  return (
+    <BaseDetailScreen headerRight={renderHeaderRight()}>
+      <Text style={styles.title}>Quest Team Proposals</Text>
+      <Text style={styles.subtitle}>
+        Proposed teams for unresolved quests that don&apos;t have a team
+        assigned yet, drawn only from present characters.
+      </Text>
+
+      {proposals.length === 0 ? (
+        <Section title="Nothing to propose">
+          <Text style={styles.emptyText}>
+            No quests currently need a proposal — every unresolved quest already
+            has a team, or there are no present characters available.
+          </Text>
+        </Section>
+      ) : (
+        proposals.map(proposal => {
+          const quest = questMap.get(proposal.questId);
+          if (!quest) return null;
+          const isSaved = savedQuestIds.has(proposal.questId);
+
+          return (
+            <Section key={proposal.questId} title={quest.name}>
+              {proposal.proposedCharacterIds.length === 0 ? (
+                <Text style={styles.emptyText}>
+                  No present characters available to propose.
+                </Text>
+              ) : (
+                <View style={styles.characterList}>
+                  {proposal.proposedCharacterIds.map(characterId => {
+                    const character = characterMap.get(characterId);
+                    if (!character) return null;
+                    const score = scoreCharacterForQuest(character, quest);
+                    return (
+                      <View key={characterId} style={styles.characterRow}>
+                        <Text style={styles.characterName}>
+                          {character.name}
+                        </Text>
+                        <Text style={styles.characterScore}>
+                          score: {score}
+                        </Text>
+                      </View>
+                    );
+                  })}
+                </View>
+              )}
+
+              <TouchableOpacity
+                style={[
+                  styles.saveButton,
+                  (isSaved || proposal.proposedCharacterIds.length === 0) &&
+                    styles.saveButtonDisabled,
+                ]}
+                disabled={isSaved || proposal.proposedCharacterIds.length === 0}
+                onPress={() => saveProposal(proposal)}
+              >
+                <Text style={styles.saveButtonText}>
+                  {isSaved ? 'Saved' : 'Save Team'}
+                </Text>
+              </TouchableOpacity>
+            </Section>
+          );
+        })
+      )}
+
+      <TouchableOpacity style={styles.discardButton} onPress={handleDiscard}>
+        <Text style={styles.discardButtonText}>Discard Proposals</Text>
+      </TouchableOpacity>
+
+      <View style={styles.footer} />
+    </BaseDetailScreen>
+  );
+};
+
+const styles = StyleSheet.create({
+  center: {
+    flex: 1,
+    backgroundColor: themeColors.primary,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  loadingText: commonStyles.text.body,
+  title: {
+    ...commonStyles.text.h1,
+    marginBottom: 8,
+  },
+  subtitle: {
+    ...commonStyles.text.body,
+    marginBottom: 20,
+  },
+  emptyText: {
+    ...commonStyles.text.body,
+    color: themeColors.text.muted,
+  },
+  characterList: {
+    gap: 8,
+    marginBottom: 12,
+  },
+  characterRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  characterName: {
+    ...commonStyles.text.body,
+    fontWeight: '600',
+  },
+  characterScore: commonStyles.text.caption,
+  saveButton: {
+    backgroundColor: themeColors.accent.primary,
+    borderRadius: 8,
+    padding: 12,
+    alignItems: 'center',
+  },
+  saveButtonDisabled: {
+    opacity: 0.5,
+  },
+  saveButtonText: {
+    color: themeColors.text.primary,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  headerButtons: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  headerActionButton: {
+    ...commonStyles.headerButton.edit,
+    marginRight: 0,
+  },
+  headerSaveButton: {
+    backgroundColor: themeColors.accent.success,
+  },
+  headerActionText: commonStyles.headerButton.text,
+  discardButton: {
+    borderWidth: 1,
+    borderColor: themeColors.accent.danger,
+    borderRadius: 8,
+    padding: 16,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  discardButtonText: {
+    color: themeColors.accent.danger,
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  footer: {
+    height: 50,
+  },
+});

--- a/src/utils/characterStorage.ts
+++ b/src/utils/characterStorage.ts
@@ -5,6 +5,8 @@ import {
   LocationDataset,
   GameEvent,
   EventDataset,
+  GameQuest,
+  QuestDataset,
   RelationshipStanding,
 } from '@models/types';
 import { v4 as uuidv4 } from 'uuid';
@@ -40,6 +42,7 @@ const STORAGE_KEY = 'gameCharacterManager';
 const FACTION_STORAGE_KEY = 'gameCharacterManager_factions';
 const LOCATION_STORAGE_KEY = 'gameCharacterManager_locations';
 const EVENT_STORAGE_KEY = 'gameCharacterManager_events';
+const QUEST_STORAGE_KEY = 'gameCharacterManager_quests';
 
 export const saveCharacters = async (
   characters: GameCharacter[]
@@ -130,6 +133,8 @@ export const exportDataset = async (): Promise<string> => {
     );
   const eventData =
     await SafeAsyncStorageJSONParser.getItem<EventDataset>(EVENT_STORAGE_KEY);
+  const questData =
+    await SafeAsyncStorageJSONParser.getItem<QuestDataset>(QUEST_STORAGE_KEY);
 
   const characters = characterData || {
     characters: [],
@@ -147,6 +152,7 @@ export const exportDataset = async (): Promise<string> => {
     lastUpdated: '',
   };
   const events = eventData || { events: [], version: '1.0', lastUpdated: '' };
+  const quests = questData || { quests: [], version: '1.0', lastUpdated: '' };
 
   // Export Discord data
   const discordData = await exportDiscordDataset();
@@ -156,6 +162,7 @@ export const exportDataset = async (): Promise<string> => {
     factions: factions.factions || [],
     locations: locations.locations || [],
     events: events.events || [],
+    quests: quests.quests || [],
     discord: discordData,
     version: '1.0',
     lastUpdated: new Date().toISOString(),
@@ -330,6 +337,16 @@ export const importDataset = async (jsonData: string): Promise<boolean> => {
         lastUpdated: dataset.lastUpdated || new Date().toISOString(),
       };
       await SafeAsyncStorageJSONParser.setItem(EVENT_STORAGE_KEY, eventDataset);
+    }
+
+    // Handle quest data if present
+    if (dataset.quests) {
+      const questDataset: QuestDataset = {
+        quests: dataset.quests,
+        version: dataset.version || '1.0',
+        lastUpdated: dataset.lastUpdated || new Date().toISOString(),
+      };
+      await SafeAsyncStorageJSONParser.setItem(QUEST_STORAGE_KEY, questDataset);
     }
 
     // Import Discord data if present
@@ -688,6 +705,7 @@ export const clearStorage = async (): Promise<void> => {
   await SafeAsyncStorageJSONParser.removeItem(FACTION_STORAGE_KEY);
   await SafeAsyncStorageJSONParser.removeItem(LOCATION_STORAGE_KEY);
   await SafeAsyncStorageJSONParser.removeItem(EVENT_STORAGE_KEY);
+  await SafeAsyncStorageJSONParser.removeItem(QUEST_STORAGE_KEY);
 };
 
 // Faction management functions
@@ -1338,5 +1356,80 @@ export const deleteEvent = async (id: string): Promise<boolean> =>
     if (filtered.length === events.length) return false;
 
     await saveEvents(filtered);
+    return true;
+  });
+
+// ============================================
+// Quest Storage Functions
+// ============================================
+
+export const saveQuests = async (quests: GameQuest[]): Promise<void> => {
+  const dataset: QuestDataset = {
+    quests,
+    version: '1.0',
+    lastUpdated: new Date().toISOString(),
+  };
+  await SafeAsyncStorageJSONParser.setItem(QUEST_STORAGE_KEY, dataset);
+};
+
+export const loadQuests = async (): Promise<GameQuest[]> => {
+  const dataset =
+    await SafeAsyncStorageJSONParser.getItem<QuestDataset>(QUEST_STORAGE_KEY);
+  if (!dataset) return [];
+
+  return dataset.quests || [];
+};
+
+export const createQuest = async (
+  quest: Omit<GameQuest, 'id' | 'createdAt' | 'updatedAt'>
+): Promise<GameQuest> => {
+  return await addQuest(quest);
+};
+
+export const addQuest = async (
+  quest: Omit<GameQuest, 'id' | 'createdAt' | 'updatedAt'>
+): Promise<GameQuest> =>
+  runExclusive(QUEST_STORAGE_KEY, async () => {
+    const quests = await loadQuests();
+    const newQuest: GameQuest = {
+      ...quest,
+      id: uuidv4(),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    await saveQuests([...quests, newQuest]);
+    return newQuest;
+  });
+
+export const updateQuest = async (
+  id: string,
+  updates: Partial<GameQuest>
+): Promise<GameQuest | null> =>
+  runExclusive(QUEST_STORAGE_KEY, async () => {
+    const quests = await loadQuests();
+    const index = quests.findIndex(q => q.id === id);
+
+    if (index === -1) return null;
+
+    const updatedQuest: GameQuest = {
+      ...quests[index],
+      ...updates,
+      updatedAt: new Date().toISOString(),
+    };
+
+    quests[index] = updatedQuest;
+    await saveQuests(quests);
+    return updatedQuest;
+  });
+
+export const deleteQuest = async (id: string): Promise<boolean> =>
+  runExclusive(QUEST_STORAGE_KEY, async () => {
+    const quests = await loadQuests();
+    const filtered = quests.filter(q => q.id !== id);
+
+    if (filtered.length === quests.length) return false;
+
+    await saveQuests(filtered);
     return true;
   });

--- a/src/utils/questProposal.ts
+++ b/src/utils/questProposal.ts
@@ -1,0 +1,173 @@
+import { GameCharacter, GameQuest, QuestStatus } from '@models/types';
+import { calculateDerivedStats } from './derivedStats';
+
+export interface QuestProposal {
+  questId: string;
+  proposedCharacterIds: string[];
+}
+
+/** Default number of characters proposed for a quest when it has no
+ * explicit `teamSize` set. */
+export const DEFAULT_TEAM_SIZE = 4;
+
+/** Tunable weights for the match score. Each point of a desirable tag score
+ * contributes `TAG_SCORE_WEIGHT`; an exact species/perk/distinction match
+ * contributes its respective weight (and undesirable matches subtract it). */
+const TAG_SCORE_WEIGHT = 1;
+const SPECIES_WEIGHT = 5;
+const PERK_WEIGHT = 3;
+const DISTINCTION_WEIGHT = 3;
+
+/**
+ * Scores how well a character fits a quest's desirable/undesirable
+ * preferences. Higher is better; the score is unbounded and only meaningful
+ * relative to other characters being compared for the same quest.
+ */
+export const scoreCharacterForQuest = (
+  character: GameCharacter,
+  quest: GameQuest
+): number => {
+  const { tagScores } = calculateDerivedStats(character);
+  const desirable = quest.desirable;
+  const undesirable = quest.undesirable;
+  let score = 0;
+
+  desirable?.tags?.forEach(tag => {
+    score += (tagScores?.get(tag) ?? 0) * TAG_SCORE_WEIGHT;
+  });
+  undesirable?.tags?.forEach(tag => {
+    score -= (tagScores?.get(tag) ?? 0) * TAG_SCORE_WEIGHT;
+  });
+
+  if (desirable?.species?.includes(character.species)) {
+    score += SPECIES_WEIGHT;
+  }
+  if (undesirable?.species?.includes(character.species)) {
+    score -= SPECIES_WEIGHT;
+  }
+
+  desirable?.perkIds?.forEach(perkId => {
+    if (character.perkIds.includes(perkId)) score += PERK_WEIGHT;
+  });
+  undesirable?.perkIds?.forEach(perkId => {
+    if (character.perkIds.includes(perkId)) score -= PERK_WEIGHT;
+  });
+
+  desirable?.distinctionIds?.forEach(distinctionId => {
+    if (character.distinctionIds.includes(distinctionId)) {
+      score += DISTINCTION_WEIGHT;
+    }
+  });
+  undesirable?.distinctionIds?.forEach(distinctionId => {
+    if (character.distinctionIds.includes(distinctionId)) {
+      score -= DISTINCTION_WEIGHT;
+    }
+  });
+
+  return score;
+};
+
+/** A quest is eligible for a proposal once it is unresolved and has no team
+ * assigned yet. */
+export const isProposalTarget = (quest: GameQuest): boolean =>
+  quest.status !== QuestStatus.Successful &&
+  quest.status !== QuestStatus.Failure &&
+  (quest.assignedCharacterIds?.length ?? 0) === 0;
+
+export const getProposalTargetQuests = (quests: GameQuest[]): GameQuest[] =>
+  quests.filter(isProposalTarget);
+
+/** Only present, non-retired characters are eligible to be proposed. */
+export const getAvailableCharacters = (
+  characters: GameCharacter[]
+): GameCharacter[] =>
+  characters.filter(
+    character => character.present === true && !character.retired
+  );
+
+const getTeamSize = (quest: GameQuest): number => {
+  const size = quest.teamSize;
+  return typeof size === 'number' && Number.isFinite(size) && size > 0
+    ? Math.floor(size)
+    : DEFAULT_TEAM_SIZE;
+};
+
+/**
+ * Proposes teams for every un-staffed, unresolved quest, drawing only from
+ * present/non-retired characters. Characters are only assigned to one quest
+ * each; the same character may be proposed for a second quest only once every
+ * available character has already been proposed for at least one quest.
+ */
+export const generateQuestProposals = (
+  quests: GameQuest[],
+  characters: GameCharacter[]
+): QuestProposal[] => {
+  const targetQuests = getProposalTargetQuests(quests);
+  const availableCharacters = getAvailableCharacters(characters);
+
+  const assignments = new Map<string, string[]>(
+    targetQuests.map(quest => [quest.id, []])
+  );
+
+  if (targetQuests.length === 0 || availableCharacters.length === 0) {
+    return targetQuests.map(quest => ({
+      questId: quest.id,
+      proposedCharacterIds: [],
+    }));
+  }
+
+  const scoresByQuest = new Map<string, Map<string, number>>(
+    targetQuests.map(quest => [
+      quest.id,
+      new Map(
+        availableCharacters.map(character => [
+          character.id,
+          scoreCharacterForQuest(character, quest),
+        ])
+      ),
+    ])
+  );
+
+  const usedAtLeastOnce = new Set<string>();
+
+  // Round-robin: each pass, every quest still short of its team size claims
+  // its best remaining candidate. Preferring characters unused anywhere keeps
+  // duplicates out until the whole present pool has been drawn from once.
+  let madeProgress = true;
+  while (madeProgress) {
+    madeProgress = false;
+
+    for (const quest of targetQuests) {
+      const assigned = assignments.get(quest.id)!;
+      if (assigned.length >= getTeamSize(quest)) continue;
+
+      let candidates = availableCharacters.filter(
+        character => !assigned.includes(character.id)
+      );
+
+      const unusedCandidates = candidates.filter(
+        character => !usedAtLeastOnce.has(character.id)
+      );
+      if (unusedCandidates.length > 0) {
+        candidates = unusedCandidates;
+      }
+
+      if (candidates.length === 0) continue;
+
+      const characterScores = scoresByQuest.get(quest.id)!;
+      candidates.sort(
+        (a, b) => characterScores.get(b.id)! - characterScores.get(a.id)!
+      );
+
+      const chosen = candidates[0];
+      assigned.push(chosen.id);
+      usedAtLeastOnce.add(chosen.id);
+      madeProgress = true;
+    }
+  }
+
+  return targetQuests.map(quest => ({
+    questId: quest.id,
+    proposedCharacterIds: assignments.get(quest.id) ?? [],
+  }));
+};

--- a/tst/screens/quest/QuestListScreen.test.tsx
+++ b/tst/screens/quest/QuestListScreen.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+import { QuestListScreen } from '@screens/quest/QuestListScreen';
+import * as characterStorage from '@utils/characterStorage';
+import { QuestStatus } from '@models/types';
+
+// Mock the character storage module
+jest.mock('@utils/characterStorage', () => ({
+  loadQuests: jest.fn(),
+}));
+
+describe('QuestListScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render without crashing', async () => {
+    (characterStorage.loadQuests as jest.Mock).mockResolvedValue([]);
+
+    const { getByText } = render(<QuestListScreen />);
+
+    await waitFor(() => {
+      expect(getByText('No quests found')).toBeTruthy();
+    });
+  });
+
+  it('should load quests on mount', async () => {
+    const mockQuests = [
+      {
+        id: 'quest-1',
+        name: 'Test Quest',
+        status: QuestStatus.NotStarted,
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+      },
+    ];
+
+    (characterStorage.loadQuests as jest.Mock).mockResolvedValue(mockQuests);
+
+    const { getByText } = render(<QuestListScreen />);
+
+    await waitFor(() => {
+      expect(characterStorage.loadQuests).toHaveBeenCalled();
+      expect(getByText('Test Quest')).toBeTruthy();
+    });
+  });
+
+  it('should display search input', async () => {
+    (characterStorage.loadQuests as jest.Mock).mockResolvedValue([]);
+
+    const { getByPlaceholderText } = render(<QuestListScreen />);
+
+    await waitFor(() => {
+      expect(getByPlaceholderText('Search quests by name...')).toBeTruthy();
+    });
+  });
+});

--- a/tst/utils/characterStorage.test.ts
+++ b/tst/utils/characterStorage.test.ts
@@ -25,6 +25,11 @@ import {
   createEvent,
   updateEvent,
   deleteEvent,
+  saveQuests,
+  loadQuests,
+  createQuest,
+  updateQuest,
+  deleteQuest,
   type StoredFaction,
 } from '@/utils/characterStorage';
 import * as CharacterStorage from '@/utils/characterStorage';
@@ -33,6 +38,8 @@ import {
   GameCharacter,
   GameLocation,
   GameEvent,
+  GameQuest,
+  QuestStatus,
   RelationshipStanding,
   Faction,
 } from '@/models/types';
@@ -1015,12 +1022,142 @@ describe('characterStorage', () => {
     });
   });
 
+  describe('Quest Operations', () => {
+    const mockQuest: GameQuest = {
+      id: 'quest-1',
+      name: 'Test Quest',
+      status: QuestStatus.NotStarted,
+      createdAt: mockDate,
+      updatedAt: mockDate,
+    };
+
+    describe('loadQuests', () => {
+      it('should return empty array when no quests exist', async () => {
+        (SafeAsyncStorageJSONParser.getItem as jest.Mock).mockResolvedValue(
+          null
+        );
+
+        const result = await loadQuests();
+
+        expect(result).toEqual([]);
+      });
+
+      it('should return quests from storage', async () => {
+        const mockDataset = {
+          quests: [mockQuest],
+          version: '1.0',
+          lastUpdated: mockDate,
+        };
+        (SafeAsyncStorageJSONParser.getItem as jest.Mock).mockResolvedValue(
+          mockDataset
+        );
+
+        const result = await loadQuests();
+
+        expect(result).toEqual([mockQuest]);
+      });
+    });
+
+    describe('saveQuests', () => {
+      it('should save quests with proper dataset structure', async () => {
+        const quests = [mockQuest];
+
+        await saveQuests(quests);
+
+        expect(SafeAsyncStorageJSONParser.setItem).toHaveBeenCalledWith(
+          'gameCharacterManager_quests',
+          {
+            quests,
+            version: '1.0',
+            lastUpdated: mockDate,
+          }
+        );
+      });
+    });
+
+    describe('createQuest', () => {
+      it('should create a new quest with generated ID', async () => {
+        (SafeAsyncStorageJSONParser.getItem as jest.Mock).mockResolvedValue({
+          quests: [],
+          version: '1.0',
+          lastUpdated: mockDate,
+        });
+
+        const newQuestData = {
+          name: 'New Quest',
+          status: QuestStatus.NotStarted,
+        };
+
+        const result = await createQuest(newQuestData);
+
+        expect(result).not.toBeNull();
+        expect(result?.id).toBe('mock-uuid-1234');
+        expect(result?.name).toBe('New Quest');
+        expect(result?.createdAt).toBe(mockDate);
+        expect(result?.updatedAt).toBe(mockDate);
+      });
+    });
+
+    describe('updateQuest', () => {
+      it('should update existing quest', async () => {
+        (SafeAsyncStorageJSONParser.getItem as jest.Mock).mockResolvedValue({
+          quests: [mockQuest],
+          version: '1.0',
+          lastUpdated: mockDate,
+        });
+
+        const result = await updateQuest('quest-1', { name: 'Updated Quest' });
+
+        expect(result).not.toBeNull();
+        expect(result?.name).toBe('Updated Quest');
+      });
+
+      it('should return null for non-existent quest', async () => {
+        (SafeAsyncStorageJSONParser.getItem as jest.Mock).mockResolvedValue({
+          quests: [],
+          version: '1.0',
+          lastUpdated: mockDate,
+        });
+
+        const result = await updateQuest('non-existent', { name: 'Test' });
+
+        expect(result).toBeNull();
+      });
+    });
+
+    describe('deleteQuest', () => {
+      it('should delete existing quest', async () => {
+        (SafeAsyncStorageJSONParser.getItem as jest.Mock).mockResolvedValue({
+          quests: [mockQuest],
+          version: '1.0',
+          lastUpdated: mockDate,
+        });
+
+        const result = await deleteQuest('quest-1');
+
+        expect(result).toBe(true);
+      });
+
+      it('should return false for non-existent quest', async () => {
+        (SafeAsyncStorageJSONParser.getItem as jest.Mock).mockResolvedValue({
+          quests: [],
+          version: '1.0',
+          lastUpdated: mockDate,
+        });
+
+        const result = await deleteQuest('non-existent');
+
+        expect(result).toBe(false);
+      });
+    });
+  });
+
   describe('Storage Management', () => {
     describe('clearStorage', () => {
       it('should remove all storage keys', async () => {
         await clearStorage();
 
-        expect(SafeAsyncStorageJSONParser.removeItem).toHaveBeenCalledTimes(4);
+        expect(SafeAsyncStorageJSONParser.removeItem).toHaveBeenCalledTimes(5);
         expect(SafeAsyncStorageJSONParser.removeItem).toHaveBeenCalledWith(
           'gameCharacterManager'
         );
@@ -1032,6 +1169,9 @@ describe('characterStorage', () => {
         );
         expect(SafeAsyncStorageJSONParser.removeItem).toHaveBeenCalledWith(
           'gameCharacterManager_events'
+        );
+        expect(SafeAsyncStorageJSONParser.removeItem).toHaveBeenCalledWith(
+          'gameCharacterManager_quests'
         );
       });
     });

--- a/tst/utils/quest.concurrency.test.ts
+++ b/tst/utils/quest.concurrency.test.ts
@@ -1,0 +1,80 @@
+import { updateQuest } from '@/utils/characterStorage';
+import { SafeAsyncStorageJSONParser } from '@/utils/safeAsyncStorageJSONParser';
+import { GameQuest, QuestStatus } from '@/models/types';
+
+jest.mock('@/utils/safeAsyncStorageJSONParser');
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'mock-uuid-1234'),
+}));
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Install a stateful in-memory backing store for SafeAsyncStorageJSONParser
+ * with an artificial async gap on read/write. The gap forces interleaving:
+ * without per-key serialization, concurrent read-modify-write operations read
+ * the same starting snapshot and clobber each other (a lost update). Mirrors
+ * the pattern in characterStorage.concurrency.test.ts.
+ */
+const installStatefulStore = (initial: Record<string, unknown>) => {
+  const store: Record<string, unknown> = clone(initial);
+
+  (SafeAsyncStorageJSONParser.getItem as jest.Mock).mockImplementation(
+    async (key: string) => {
+      await delay(1);
+      return key in store ? clone(store[key]) : null;
+    }
+  );
+  (SafeAsyncStorageJSONParser.setItem as jest.Mock).mockImplementation(
+    async (key: string, value: unknown) => {
+      await delay(1);
+      store[key] = clone(value);
+      return true;
+    }
+  );
+
+  return store;
+};
+
+describe('quest storage concurrency', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const makeQuest = (id: string): GameQuest => ({
+    id,
+    name: `Quest ${id}`,
+    status: QuestStatus.NotStarted,
+    createdAt: '2025-01-01T00:00:00.000Z',
+    updatedAt: '2025-01-01T00:00:00.000Z',
+  });
+
+  it('does not lose updates when updating several quests concurrently', async () => {
+    const store = installStatefulStore({
+      gameCharacterManager_quests: {
+        quests: [makeQuest('a'), makeQuest('b'), makeQuest('c')],
+        version: '1.0',
+        lastUpdated: '2025-01-01T00:00:00.000Z',
+      },
+    });
+
+    // Fire all three updates at once. Serialization must ensure each
+    // read-modify-write sees the previous one's result rather than clobbering
+    // it with a stale snapshot.
+    await Promise.all([
+      updateQuest('a', { status: QuestStatus.Assigned }),
+      updateQuest('b', { status: QuestStatus.Assigned }),
+      updateQuest('c', { status: QuestStatus.Assigned }),
+    ]);
+
+    const saved = store.gameCharacterManager_quests as {
+      quests: GameQuest[];
+    };
+    const assigned = saved.quests
+      .filter(q => q.status === QuestStatus.Assigned)
+      .map(q => q.id);
+    expect(assigned.sort()).toEqual(['a', 'b', 'c']);
+  });
+});

--- a/tst/utils/questProposal.test.ts
+++ b/tst/utils/questProposal.test.ts
@@ -1,0 +1,257 @@
+import {
+  scoreCharacterForQuest,
+  getProposalTargetQuests,
+  getAvailableCharacters,
+  generateQuestProposals,
+  DEFAULT_TEAM_SIZE,
+} from '@/utils/questProposal';
+import { GameCharacter, GameQuest, QuestStatus } from '@/models/types';
+import { PerkTag } from '@/models/gameData';
+
+const mockDate = '2025-01-01T00:00:00.000Z';
+
+const makeCharacter = (
+  id: string,
+  overrides: Partial<GameCharacter> = {}
+): GameCharacter => ({
+  id,
+  name: `Character ${id}`,
+  species: 'Human',
+  perkIds: [],
+  distinctionIds: [],
+  factions: [],
+  relationships: [],
+  present: true,
+  retired: false,
+  createdAt: mockDate,
+  updatedAt: mockDate,
+  ...overrides,
+});
+
+const makeQuest = (
+  id: string,
+  overrides: Partial<GameQuest> = {}
+): GameQuest => ({
+  id,
+  name: `Quest ${id}`,
+  status: QuestStatus.NotStarted,
+  createdAt: mockDate,
+  updatedAt: mockDate,
+  ...overrides,
+});
+
+describe('questProposal', () => {
+  describe('scoreCharacterForQuest', () => {
+    it('scores 0 when the quest has no preferences', () => {
+      const character = makeCharacter('a', { perkIds: ['agility_1'] });
+      const quest = makeQuest('q1');
+
+      expect(scoreCharacterForQuest(character, quest)).toBe(0);
+    });
+
+    it('rewards a desirable tag proportional to the tag score', () => {
+      const character = makeCharacter('a', {
+        perkIds: ['agility_1', 'agility_2'],
+      });
+      const quest = makeQuest('q1', {
+        desirable: { tags: [PerkTag.Agility] },
+      });
+
+      // 2 agility perks => tagScores.get(Agility) === 2, weight 1 each.
+      expect(scoreCharacterForQuest(character, quest)).toBe(2);
+    });
+
+    it('penalizes an undesirable tag proportional to the tag score', () => {
+      const character = makeCharacter('a', { perkIds: ['agility_1'] });
+      const quest = makeQuest('q1', {
+        undesirable: { tags: [PerkTag.Agility] },
+      });
+
+      expect(scoreCharacterForQuest(character, quest)).toBe(-1);
+    });
+
+    it('rewards a desirable species match', () => {
+      const character = makeCharacter('a', { species: 'Android' });
+      const quest = makeQuest('q1', {
+        desirable: { species: ['Android'] },
+      });
+
+      expect(scoreCharacterForQuest(character, quest)).toBeGreaterThan(0);
+    });
+
+    it('penalizes an undesirable species match', () => {
+      const character = makeCharacter('a', { species: 'Android' });
+      const quest = makeQuest('q1', {
+        undesirable: { species: ['Android'] },
+      });
+
+      expect(scoreCharacterForQuest(character, quest)).toBeLessThan(0);
+    });
+
+    it('rewards a desirable perk match', () => {
+      const character = makeCharacter('a', { perkIds: ['agility_1'] });
+      const quest = makeQuest('q1', {
+        desirable: { perkIds: ['agility_1'] },
+      });
+
+      expect(scoreCharacterForQuest(character, quest)).toBeGreaterThan(0);
+    });
+
+    it('penalizes an undesirable perk match', () => {
+      const character = makeCharacter('a', { perkIds: ['agility_1'] });
+      const quest = makeQuest('q1', {
+        undesirable: { perkIds: ['agility_1'] },
+      });
+
+      expect(scoreCharacterForQuest(character, quest)).toBeLessThan(0);
+    });
+
+    it('rewards a desirable distinction match', () => {
+      const character = makeCharacter('a', { distinctionIds: ['d1'] });
+      const quest = makeQuest('q1', {
+        desirable: { distinctionIds: ['d1'] },
+      });
+
+      expect(scoreCharacterForQuest(character, quest)).toBeGreaterThan(0);
+    });
+
+    it('penalizes an undesirable distinction match', () => {
+      const character = makeCharacter('a', { distinctionIds: ['d1'] });
+      const quest = makeQuest('q1', {
+        undesirable: { distinctionIds: ['d1'] },
+      });
+
+      expect(scoreCharacterForQuest(character, quest)).toBeLessThan(0);
+    });
+  });
+
+  describe('getProposalTargetQuests', () => {
+    it('excludes quests that are Successful or Failure', () => {
+      const quests = [
+        makeQuest('a', { status: QuestStatus.Successful }),
+        makeQuest('b', { status: QuestStatus.Failure }),
+        makeQuest('c', { status: QuestStatus.NotStarted }),
+      ];
+
+      expect(getProposalTargetQuests(quests).map(q => q.id)).toEqual(['c']);
+    });
+
+    it('excludes quests that already have an assigned team', () => {
+      const quests = [
+        makeQuest('a', { assignedCharacterIds: ['char-1'] }),
+        makeQuest('b', { assignedCharacterIds: [] }),
+        makeQuest('c'),
+      ];
+
+      expect(
+        getProposalTargetQuests(quests)
+          .map(q => q.id)
+          .sort()
+      ).toEqual(['b', 'c']);
+    });
+  });
+
+  describe('getAvailableCharacters', () => {
+    it('only includes present, non-retired characters', () => {
+      const characters = [
+        makeCharacter('a', { present: true, retired: false }),
+        makeCharacter('b', { present: false, retired: false }),
+        makeCharacter('c', { present: true, retired: true }),
+        makeCharacter('d', { present: undefined }),
+      ];
+
+      expect(getAvailableCharacters(characters).map(c => c.id)).toEqual(['a']);
+    });
+  });
+
+  describe('generateQuestProposals', () => {
+    it('returns no proposals when there are no target quests', () => {
+      const quests = [makeQuest('a', { status: QuestStatus.Successful })];
+      const characters = [makeCharacter('char-1')];
+
+      expect(generateQuestProposals(quests, characters)).toEqual([]);
+    });
+
+    it('proposes an empty team when no characters are present', () => {
+      const quests = [makeQuest('a')];
+      const characters = [makeCharacter('char-1', { present: false })];
+
+      expect(generateQuestProposals(quests, characters)).toEqual([
+        { questId: 'a', proposedCharacterIds: [] },
+      ]);
+    });
+
+    it('fills a team up to the default team size', () => {
+      const quest = makeQuest('a');
+      const characters = Array.from({ length: DEFAULT_TEAM_SIZE + 2 }, (_, i) =>
+        makeCharacter(`char-${i}`)
+      );
+
+      const [proposal] = generateQuestProposals([quest], characters);
+
+      expect(proposal.proposedCharacterIds).toHaveLength(DEFAULT_TEAM_SIZE);
+    });
+
+    it('respects a custom teamSize', () => {
+      const quest = makeQuest('a', { teamSize: 2 });
+      const characters = Array.from({ length: 5 }, (_, i) =>
+        makeCharacter(`char-${i}`)
+      );
+
+      const [proposal] = generateQuestProposals([quest], characters);
+
+      expect(proposal.proposedCharacterIds).toHaveLength(2);
+    });
+
+    it('prefers higher-scoring characters for a quest', () => {
+      const quest = makeQuest('a', {
+        teamSize: 1,
+        desirable: { tags: [PerkTag.Agility] },
+      });
+      const strongMatch = makeCharacter('strong', {
+        perkIds: ['agility_1', 'agility_2', 'agility_3'],
+      });
+      const weakMatch = makeCharacter('weak', { perkIds: [] });
+
+      const [proposal] = generateQuestProposals(
+        [quest],
+        [weakMatch, strongMatch]
+      );
+
+      expect(proposal.proposedCharacterIds).toEqual(['strong']);
+    });
+
+    it('avoids assigning the same character to two quests while unused characters remain', () => {
+      const quests = [
+        makeQuest('a', { teamSize: 1 }),
+        makeQuest('b', { teamSize: 1 }),
+      ];
+      const characters = [makeCharacter('char-1'), makeCharacter('char-2')];
+
+      const proposals = generateQuestProposals(quests, characters);
+      const assignedIds = proposals.flatMap(p => p.proposedCharacterIds);
+
+      expect(new Set(assignedIds).size).toBe(2);
+    });
+
+    it('allows reusing a character once every present character has been used', () => {
+      const quests = [
+        makeQuest('a', { teamSize: 1 }),
+        makeQuest('b', { teamSize: 1 }),
+        makeQuest('c', { teamSize: 1 }),
+      ];
+      const characters = [makeCharacter('char-1'), makeCharacter('char-2')];
+
+      const proposals = generateQuestProposals(quests, characters);
+
+      // Only 2 present characters for 3 quest slots: every quest still gets a
+      // proposed character (a duplicate is unavoidable once the pool of 2 is
+      // exhausted), and both characters are used at least once.
+      expect(proposals.every(p => p.proposedCharacterIds.length === 1)).toBe(
+        true
+      );
+      const usedIds = new Set(proposals.flatMap(p => p.proposedCharacterIds));
+      expect(usedIds).toEqual(new Set(['char-1', 'char-2']));
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #108.

- Adds a `Quest`/mission domain object with full CRUD, search, and status tracking (`NOTSTARTED` / `ASSIGNED` / `INPROGRESS` / `SUCCESSFUL` / `FAILURE`), following the existing Events/Location vertical-slice pattern: `src/models/types.ts` → `src/utils/characterStorage.ts` (storage, wrapped in `runExclusive`) → `Base{List,Form,Detail}Screen`-based screens → navigation wiring in `App.tsx` / `src/navigation/types.ts`.
- Quest fields: optional mission time, details, desirable/undesirable team preferences (perk tags, species, specific perks, distinctions), related location/factions/events/Junktown office, and required materials tracked as partial-vs-complete (`quantityProvided` / `quantityRequired`).
- Adds a team-proposal generator (`src/utils/questProposal.ts`) that scores present, non-retired characters against each unstaffed/unresolved quest's preferences — reusing the existing `calculateDerivedStats` tag-score primitive — and greedily fills each quest's team (default size 4, or a per-quest `teamSize`), avoiding duplicate assignments across quests until every present character has been used once.
- A new `QuestProposalScreen` lets the generated proposals be reviewed and saved (per-quest or all at once) or discarded without touching storage.

## Test plan

- [x] `npm run check-all` (type-check + lint + format:check + test) is green — 337 tests passing across 26 suites.
- [x] Added quest CRUD storage tests (`tst/utils/characterStorage.test.ts`), a concurrency test proving `runExclusive` serializes quest writes (`tst/utils/quest.concurrency.test.ts`), proposal-algorithm tests covering scoring/filtering/team-size/dedup (`tst/utils/questProposal.test.ts`), and a `QuestListScreen` render test (`tst/screens/quest/QuestListScreen.test.tsx`).
- [ ] Manual UI smoke test (create quest → generate proposals → save/discard) — attempted via headless Chromium against `expo start --web`, but the web bundle fails to render in this sandbox with `Cannot destructure property 'NativeEventEmitter' of 'ReactNative.default'`. Confirmed via `git stash` that this reproduces identically on the unmodified base branch, so it's a pre-existing environment issue unrelated to this change, not something introduced here. Flagging so a reviewer with a working device/simulator can do the manual pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kt6KHZ1gKHmV5EEZ5pESYh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kt6KHZ1gKHmV5EEZ5pESYh)_