### PR TITLE
Add reusable screen-contract test helpers and templated screen tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,8 +6,10 @@ module.exports = {
   // transformed instead of failing to parse — this only matters once
   // coverage collection actually loads files like exportImport.ts and
   // gitIntegration.ts that were previously excluded from the report.
+  // `uuid` ships ESM-only and must be transformed so test files can automock
+  // modules that import it (e.g. `jest.mock('@utils/characterStorage')`).
   transformIgnorePatterns: [
-    'node_modules/(?!(react-native|@react-native|@react-navigation|expo|expo-.*|@expo|@unimodules|@octokit|react-native-.*)/)',
+    'node_modules/(?!(react-native|@react-native|@react-navigation|expo|expo-.*|@expo|@unimodules|@octokit|react-native-.*|uuid)/)',
   ],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   moduleNameMapper: {

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -31,6 +31,7 @@ jest.mock('expo-document-picker', () => ({
 
 jest.mock('expo-image-picker', () => ({
   launchImageLibraryAsync: jest.fn(),
+  requestMediaLibraryPermissionsAsync: jest.fn(),
   MediaTypeOptions: {
     Images: 'Images',
   },
@@ -99,9 +100,10 @@ jest.mock('react-native-reanimated', () => ({
 // Global __DEV__ variable for development checks
 global.__DEV__ = false;
 
-// Suppress console warnings in tests
+// Suppress console output in tests (some screens log lifecycle debug info)
 global.console = {
   ...console,
+  log: jest.fn(),
   warn: jest.fn(),
   error: jest.fn(),
 };

--- a/tst/components/screens/BaseDetailScreen.test.tsx
+++ b/tst/components/screens/BaseDetailScreen.test.tsx
@@ -1,0 +1,225 @@
+import React from 'react';
+import { render, waitFor, fireEvent } from '@testing-library/react-native';
+import { Text } from 'react-native';
+import { BaseDetailScreen } from '@/components';
+import {
+  installNavigationMock,
+  resetNavigationMocks,
+  getLastHeaderRight,
+  NavMock,
+} from '../../helpers/navigation';
+import {
+  spyOnAlert,
+  pressAlertButton,
+  setPlatformOS,
+  restorePlatformOS,
+  installWindowConfirm,
+  removeWindowConfirm,
+} from '../../helpers/alertAndPlatform';
+
+describe('BaseDetailScreen', () => {
+  let nav: NavMock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    nav = installNavigationMock();
+  });
+
+  afterEach(() => {
+    resetNavigationMocks();
+    restorePlatformOS();
+    removeWindowConfirm();
+    jest.restoreAllMocks();
+  });
+
+  const renderHeader = () => render(getLastHeaderRight(nav));
+
+  it('renders its children', () => {
+    const { getByText } = render(
+      <BaseDetailScreen>
+        <Text>Detail Content</Text>
+      </BaseDetailScreen>
+    );
+
+    expect(getByText('Detail Content')).toBeTruthy();
+  });
+
+  it('does not configure a header when no header props are given', () => {
+    render(
+      <BaseDetailScreen>
+        <Text>Detail Content</Text>
+      </BaseDetailScreen>
+    );
+
+    expect(nav.setOptions).not.toHaveBeenCalled();
+  });
+
+  it('prefers a custom headerRight over the edit/delete buttons', () => {
+    render(
+      <BaseDetailScreen
+        headerRight={<Text>Custom Action</Text>}
+        onEditPress={jest.fn()}
+      >
+        <Text>Detail Content</Text>
+      </BaseDetailScreen>
+    );
+
+    const header = renderHeader();
+    expect(header.getByText('Custom Action')).toBeTruthy();
+    expect(header.queryByText('Edit')).toBeNull();
+  });
+
+  it('renders an Edit header button that calls onEditPress', () => {
+    const onEditPress = jest.fn();
+    render(
+      <BaseDetailScreen onEditPress={onEditPress}>
+        <Text>Detail Content</Text>
+      </BaseDetailScreen>
+    );
+
+    const header = renderHeader();
+    fireEvent.press(header.getByText('Edit'));
+
+    expect(onEditPress).toHaveBeenCalled();
+  });
+
+  describe('delete flow (native)', () => {
+    const makeDeleteConfig = (
+      overrides: Partial<{
+        itemName: string;
+        onDelete: () => Promise<void>;
+        confirmTitle: string;
+        confirmMessage: string;
+      }> = {}
+    ) => ({
+      itemName: 'Test Item',
+      onDelete: jest.fn().mockResolvedValue(undefined),
+      ...overrides,
+    });
+
+    it('shows a confirmation with default title and message', async () => {
+      const alertSpy = spyOnAlert();
+      const deleteConfig = makeDeleteConfig();
+      render(
+        <BaseDetailScreen deleteConfig={deleteConfig}>
+          <Text>Detail Content</Text>
+        </BaseDetailScreen>
+      );
+
+      fireEvent.press(renderHeader().getByText('Delete'));
+
+      await waitFor(() => {
+        expect(alertSpy).toHaveBeenCalledWith(
+          'Delete Item',
+          'Are you sure you want to delete Test Item? This action cannot be undone.',
+          expect.any(Array)
+        );
+      });
+    });
+
+    it('uses the custom confirmation title and message when provided', async () => {
+      const alertSpy = spyOnAlert();
+      const deleteConfig = makeDeleteConfig({
+        confirmTitle: 'Remove Widget',
+        confirmMessage: 'Really remove this widget?',
+      });
+      render(
+        <BaseDetailScreen deleteConfig={deleteConfig}>
+          <Text>Detail Content</Text>
+        </BaseDetailScreen>
+      );
+
+      fireEvent.press(renderHeader().getByText('Delete'));
+
+      await waitFor(() => {
+        expect(alertSpy).toHaveBeenCalledWith(
+          'Remove Widget',
+          'Really remove this widget?',
+          expect.any(Array)
+        );
+      });
+    });
+
+    it('does nothing when the confirmation is cancelled', async () => {
+      const alertSpy = spyOnAlert();
+      const deleteConfig = makeDeleteConfig();
+      render(
+        <BaseDetailScreen deleteConfig={deleteConfig}>
+          <Text>Detail Content</Text>
+        </BaseDetailScreen>
+      );
+
+      fireEvent.press(renderHeader().getByText('Delete'));
+      await waitFor(() => {
+        expect(alertSpy).toHaveBeenCalled();
+      });
+      await pressAlertButton(alertSpy, 'Cancel');
+
+      expect(deleteConfig.onDelete).not.toHaveBeenCalled();
+      expect(nav.goBack).not.toHaveBeenCalled();
+    });
+
+    it('runs onDelete and navigates back when confirmed', async () => {
+      const alertSpy = spyOnAlert();
+      const deleteConfig = makeDeleteConfig();
+      render(
+        <BaseDetailScreen deleteConfig={deleteConfig}>
+          <Text>Detail Content</Text>
+        </BaseDetailScreen>
+      );
+
+      fireEvent.press(renderHeader().getByText('Delete'));
+      await waitFor(() => {
+        expect(alertSpy).toHaveBeenCalled();
+      });
+      await pressAlertButton(alertSpy, 'Delete');
+
+      await waitFor(() => {
+        expect(deleteConfig.onDelete).toHaveBeenCalled();
+        expect(nav.goBack).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('delete flow (web)', () => {
+    it('deletes via window.confirm when accepted', async () => {
+      setPlatformOS('web');
+      const confirmMock = installWindowConfirm(true);
+      const onDelete = jest.fn().mockResolvedValue(undefined);
+      render(
+        <BaseDetailScreen deleteConfig={{ itemName: 'Test Item', onDelete }}>
+          <Text>Detail Content</Text>
+        </BaseDetailScreen>
+      );
+
+      fireEvent.press(renderHeader().getByText('Delete'));
+
+      await waitFor(() => {
+        expect(confirmMock).toHaveBeenCalledWith(
+          'Are you sure you want to delete Test Item? This action cannot be undone.'
+        );
+        expect(onDelete).toHaveBeenCalled();
+        expect(nav.goBack).toHaveBeenCalled();
+      });
+    });
+
+    it('does nothing when window.confirm is declined', async () => {
+      setPlatformOS('web');
+      const confirmMock = installWindowConfirm(false);
+      const onDelete = jest.fn().mockResolvedValue(undefined);
+      render(
+        <BaseDetailScreen deleteConfig={{ itemName: 'Test Item', onDelete }}>
+          <Text>Detail Content</Text>
+        </BaseDetailScreen>
+      );
+
+      fireEvent.press(renderHeader().getByText('Delete'));
+
+      await waitFor(() => {
+        expect(confirmMock).toHaveBeenCalled();
+      });
+      expect(onDelete).not.toHaveBeenCalled();
+      expect(nav.goBack).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tst/components/screens/BaseFormScreen.test.tsx
+++ b/tst/components/screens/BaseFormScreen.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { Text, KeyboardAvoidingView } from 'react-native';
+import { BaseFormScreen } from '@/components';
+
+describe('BaseFormScreen', () => {
+  it('renders its children', () => {
+    const { getByText } = render(
+      <BaseFormScreen>
+        <Text>Form Content</Text>
+      </BaseFormScreen>
+    );
+
+    expect(getByText('Form Content')).toBeTruthy();
+  });
+
+  it('wraps content in a KeyboardAvoidingView by default', () => {
+    const { UNSAFE_getByType } = render(
+      <BaseFormScreen>
+        <Text>Form Content</Text>
+      </BaseFormScreen>
+    );
+
+    expect(UNSAFE_getByType(KeyboardAvoidingView)).toBeTruthy();
+  });
+
+  it('omits the KeyboardAvoidingView when keyboard avoidance is disabled', () => {
+    const { UNSAFE_queryByType, getByText } = render(
+      <BaseFormScreen enableKeyboardAvoidance={false}>
+        <Text>Form Content</Text>
+      </BaseFormScreen>
+    );
+
+    expect(UNSAFE_queryByType(KeyboardAvoidingView)).toBeNull();
+    expect(getByText('Form Content')).toBeTruthy();
+  });
+
+  it('passes scrollViewProps through to the ScrollView', () => {
+    const { getByTestId } = render(
+      <BaseFormScreen scrollViewProps={{ testID: 'form-scroll' }}>
+        <Text>Form Content</Text>
+      </BaseFormScreen>
+    );
+
+    expect(getByTestId('form-scroll')).toBeTruthy();
+  });
+});

--- a/tst/helpers/alertAndPlatform.ts
+++ b/tst/helpers/alertAndPlatform.ts
@@ -1,0 +1,97 @@
+import { Alert, Platform } from 'react-native';
+import { act } from '@testing-library/react-native';
+
+interface AlertButton {
+  text?: string;
+  onPress?: () => void;
+}
+
+/**
+ * Spies on `Alert.alert` with a no-op implementation so tests can assert on
+ * the confirmation dialogs screens raise and press their buttons via
+ * `pressAlertButton`. Restore with `jest.restoreAllMocks()` in `afterEach`.
+ */
+export function spyOnAlert(): jest.SpyInstance {
+  return jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+}
+
+/**
+ * Finds the button with the given label in the most recent `Alert.alert` call
+ * and invokes its `onPress` inside a synchronous `act()`, then yields one
+ * macrotask so async continuations (delete → goBack flows) can run. An async
+ * `act` would await full React idle, which never arrives for screens whose
+ * mocked `useFocusEffect` re-fires their data load on every render.
+ */
+export async function pressAlertButton(
+  alertSpy: jest.SpyInstance,
+  label: string
+): Promise<void> {
+  const calls = alertSpy.mock.calls;
+  if (calls.length === 0) {
+    throw new Error('Alert.alert was never called');
+  }
+  const buttons = (calls[calls.length - 1][2] ?? []) as AlertButton[];
+  const button = buttons.find(b => b.text === label);
+  if (!button) {
+    const labels = buttons.map(b => b.text).join(', ');
+    throw new Error(
+      `No alert button labeled "${label}" (available: ${labels})`
+    );
+  }
+  act(() => {
+    button.onPress?.();
+  });
+  await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+let replacedPlatformOS: { restore(): void } | undefined;
+
+/**
+ * Overrides `Platform.OS` for the current test (e.g. to exercise the web
+ * `window.confirm` branch of delete flows). Call `restorePlatformOS` in
+ * `afterEach`.
+ */
+export function setPlatformOS(os: 'ios' | 'android' | 'web'): void {
+  replacedPlatformOS = jest.replaceProperty(Platform, 'OS', os);
+}
+
+export function restorePlatformOS(): void {
+  replacedPlatformOS?.restore();
+  replacedPlatformOS = undefined;
+}
+
+interface GlobalWithWindow {
+  window?: { confirm?: unknown };
+}
+
+let hadWindow = false;
+let previousConfirm: unknown;
+
+/**
+ * Installs a `window.confirm` mock returning the given result, for the
+ * `Platform.OS === 'web'` confirmation branch (the jest environment is node,
+ * so `window` may not exist). Call `removeWindowConfirm` in `afterEach`.
+ */
+export function installWindowConfirm(result: boolean): jest.Mock {
+  const g = globalThis as GlobalWithWindow;
+  hadWindow = g.window !== undefined;
+  if (!g.window) {
+    g.window = {};
+  }
+  previousConfirm = g.window.confirm;
+  const confirmMock = jest.fn(() => result);
+  g.window.confirm = confirmMock;
+  return confirmMock;
+}
+
+export function removeWindowConfirm(): void {
+  const g = globalThis as GlobalWithWindow;
+  if (!g.window) {
+    return;
+  }
+  if (hadWindow) {
+    g.window.confirm = previousConfirm;
+  } else {
+    delete g.window;
+  }
+}

--- a/tst/helpers/factories.ts
+++ b/tst/helpers/factories.ts
@@ -1,0 +1,64 @@
+import {
+  GameCharacter,
+  GameEvent,
+  GameLocation,
+  GameQuest,
+  QuestStatus,
+} from '@models/types';
+import type { StoredFaction } from '@utils/characterStorage';
+
+const TEST_TIMESTAMP = '2026-01-01T00:00:00.000Z';
+
+export const makeCharacter = (
+  overrides: Partial<GameCharacter> = {}
+): GameCharacter => ({
+  id: 'character-1',
+  name: 'Test Character',
+  species: 'Human',
+  perkIds: [],
+  distinctionIds: [],
+  factions: [],
+  relationships: [],
+  createdAt: TEST_TIMESTAMP,
+  updatedAt: TEST_TIMESTAMP,
+  ...overrides,
+});
+
+export const makeStoredFaction = (
+  overrides: Partial<StoredFaction> = {}
+): StoredFaction => ({
+  name: 'Test Faction',
+  description: '',
+  createdAt: TEST_TIMESTAMP,
+  updatedAt: TEST_TIMESTAMP,
+  ...overrides,
+});
+
+export const makeLocation = (
+  overrides: Partial<GameLocation> = {}
+): GameLocation => ({
+  id: 'location-1',
+  name: 'Test Location',
+  description: '',
+  createdAt: TEST_TIMESTAMP,
+  updatedAt: TEST_TIMESTAMP,
+  ...overrides,
+});
+
+export const makeEvent = (overrides: Partial<GameEvent> = {}): GameEvent => ({
+  id: 'event-1',
+  title: 'Test Event',
+  date: '2026-01-01',
+  createdAt: TEST_TIMESTAMP,
+  updatedAt: TEST_TIMESTAMP,
+  ...overrides,
+});
+
+export const makeQuest = (overrides: Partial<GameQuest> = {}): GameQuest => ({
+  id: 'quest-1',
+  name: 'Test Quest',
+  status: QuestStatus.NotStarted,
+  createdAt: TEST_TIMESTAMP,
+  updatedAt: TEST_TIMESTAMP,
+  ...overrides,
+});

--- a/tst/helpers/navigation.ts
+++ b/tst/helpers/navigation.ts
@@ -1,0 +1,83 @@
+import type { ReactElement } from 'react';
+
+/**
+ * Helpers for controlling the global `@react-navigation/native` mock from
+ * `jest.setup.js`. The global mock returns a fresh object with new `jest.fn()`s
+ * on every `useNavigation()` call, which makes asserting on `setOptions`,
+ * `goBack`, or `navigate` impossible. `installNavigationMock` swaps in a single
+ * stable mock for the current test; `installRouteParams` does the same for
+ * `useRoute`. Both are restored by `resetNavigationMocks` (call in `afterEach`).
+ */
+
+export interface NavMock {
+  navigate: jest.Mock;
+  goBack: jest.Mock;
+  push: jest.Mock;
+  setOptions: jest.Mock;
+  addListener: jest.Mock;
+  removeListener: jest.Mock;
+}
+
+interface MockedNavigationModule {
+  useNavigation: () => unknown;
+  useRoute: () => { params: Record<string, unknown> };
+}
+
+const getMockModule = (): MockedNavigationModule =>
+  jest.requireMock('@react-navigation/native') as MockedNavigationModule;
+
+let originalUseNavigation: MockedNavigationModule['useNavigation'] | undefined;
+let originalUseRoute: MockedNavigationModule['useRoute'] | undefined;
+
+export function installNavigationMock(): NavMock {
+  const mockModule = getMockModule();
+  if (!originalUseNavigation) {
+    originalUseNavigation = mockModule.useNavigation;
+  }
+  const nav: NavMock = {
+    navigate: jest.fn(),
+    goBack: jest.fn(),
+    push: jest.fn(),
+    setOptions: jest.fn(),
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+  };
+  mockModule.useNavigation = () => nav;
+  return nav;
+}
+
+export function installRouteParams(params: Record<string, unknown>): void {
+  const mockModule = getMockModule();
+  if (!originalUseRoute) {
+    originalUseRoute = mockModule.useRoute;
+  }
+  mockModule.useRoute = () => ({ params });
+}
+
+export function resetNavigationMocks(): void {
+  const mockModule = getMockModule();
+  if (originalUseNavigation) {
+    mockModule.useNavigation = originalUseNavigation;
+  }
+  if (originalUseRoute) {
+    mockModule.useRoute = originalUseRoute;
+  }
+}
+
+/**
+ * Screens configure header buttons by passing a `headerRight` render function
+ * to `navigation.setOptions`. Returns the element produced by the most recent
+ * such call so tests can `render()` it and press the buttons.
+ */
+export function getLastHeaderRight(nav: NavMock): ReactElement {
+  const calls = nav.setOptions.mock.calls;
+  for (let i = calls.length - 1; i >= 0; i--) {
+    const options = calls[i][0] as { headerRight?: () => ReactElement };
+    if (options && typeof options.headerRight === 'function') {
+      return options.headerRight();
+    }
+  }
+  throw new Error(
+    'navigation.setOptions was never called with a headerRight function'
+  );
+}

--- a/tst/helpers/screenContracts.ts
+++ b/tst/helpers/screenContracts.ts
@@ -1,0 +1,327 @@
+import { render, waitFor, fireEvent } from '@testing-library/react-native';
+import {
+  installNavigationMock,
+  installRouteParams,
+  resetNavigationMocks,
+  getLastHeaderRight,
+  NavMock,
+} from './navigation';
+import { spyOnAlert, pressAlertButton } from './alertAndPlatform';
+import { primeStorageDefaults } from './storage';
+
+/**
+ * Reusable behavior suites ("contracts") for screens built on the
+ * `Base{List,Form,Detail}Screen` templates. Each generator registers a
+ * `describe` block with the tests every screen of that shape must pass, so a
+ * concrete screen's test file reduces to a config object plus any
+ * screen-specific extras.
+ *
+ * Requirements for callers:
+ * - the test file must call `jest.mock('@utils/characterStorage')` (plus mocks
+ *   for any other storage modules the screen imports),
+ * - per-test data is primed through the `prime*` callbacks using
+ *   `getStorageMock()` from `./storage` and the factories from `./factories`.
+ */
+
+type RenderResult = ReturnType<typeof render>;
+
+export interface ListScreenContractConfig {
+  name: string;
+  renderScreen: () => RenderResult;
+  emptyStateTitle: string;
+  searchPlaceholder: string;
+  /** Mock functions the screen must call to load its data on mount. */
+  loadFns: () => unknown[];
+  /** Primes storage so the screen renders `populatedTexts`. */
+  primePopulated: () => void;
+  populatedTexts: string[];
+  /** Extra priming applied in every test (both empty and populated). */
+  prime?: () => void;
+}
+
+export function describeListScreenContract(
+  config: ListScreenContractConfig
+): void {
+  describe(`${config.name} — list screen contract`, () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      primeStorageDefaults();
+      config.prime?.();
+    });
+
+    it('renders the empty state when there is no data', async () => {
+      const { getByText } = config.renderScreen();
+
+      await waitFor(() => {
+        expect(getByText(config.emptyStateTitle)).toBeTruthy();
+      });
+    });
+
+    it('calls its data loaders on mount', async () => {
+      config.renderScreen();
+
+      await waitFor(() => {
+        config.loadFns().forEach(loadFn => {
+          expect(loadFn).toHaveBeenCalled();
+        });
+      });
+    });
+
+    it('shows the search input', async () => {
+      const { getByPlaceholderText } = config.renderScreen();
+
+      await waitFor(() => {
+        expect(getByPlaceholderText(config.searchPlaceholder)).toBeTruthy();
+      });
+    });
+
+    it('renders loaded items', async () => {
+      config.primePopulated();
+
+      const { getByText } = config.renderScreen();
+
+      await waitFor(() => {
+        config.populatedTexts.forEach(text => {
+          expect(getByText(text)).toBeTruthy();
+        });
+      });
+    });
+  });
+}
+
+export interface DetailScreenContractConfig {
+  name: string;
+  renderScreen: () => RenderResult;
+  routeParams?: Record<string, unknown>;
+  /** Per-test priming beyond `primeStorageDefaults()`. */
+  prime?: () => void;
+  /** Texts (or patterns) that must appear once the screen has loaded. */
+  expectedContent: Array<string | RegExp>;
+  /** Expected `navigation.navigate` target of the header Edit button. */
+  edit?: { expectedScreen: string; expectedParams: unknown };
+  /** Delete flow driven by the header Delete button (native Alert path). */
+  del?: { deleteFn: () => unknown; primeDelete?: () => void };
+}
+
+export function describeDetailScreenContract(
+  config: DetailScreenContractConfig
+): void {
+  describe(`${config.name} — detail screen contract`, () => {
+    let nav: NavMock;
+    let alertSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      primeStorageDefaults();
+      nav = installNavigationMock();
+      installRouteParams(config.routeParams ?? {});
+      alertSpy = spyOnAlert();
+      config.prime?.();
+    });
+
+    afterEach(() => {
+      resetNavigationMocks();
+      jest.restoreAllMocks();
+    });
+
+    const renderHeaderButtons = async (): Promise<RenderResult> => {
+      config.renderScreen();
+      await waitFor(() => {
+        expect(nav.setOptions).toHaveBeenCalled();
+      });
+      return render(getLastHeaderRight(nav));
+    };
+
+    it('renders the screen content', async () => {
+      const { getByText } = config.renderScreen();
+
+      await waitFor(() => {
+        config.expectedContent.forEach(content => {
+          expect(getByText(content)).toBeTruthy();
+        });
+      });
+    });
+
+    it('configures header actions via navigation.setOptions', async () => {
+      const header = await renderHeaderButtons();
+
+      if (config.edit) {
+        expect(header.getByText('Edit')).toBeTruthy();
+      }
+      if (config.del) {
+        expect(header.getByText('Delete')).toBeTruthy();
+      }
+    });
+
+    if (config.edit) {
+      const edit = config.edit;
+      it('navigates to the edit screen from the header Edit button', async () => {
+        const header = await renderHeaderButtons();
+
+        fireEvent.press(header.getByText('Edit'));
+
+        expect(nav.navigate).toHaveBeenCalledWith(
+          edit.expectedScreen,
+          edit.expectedParams
+        );
+      });
+    }
+
+    if (config.del) {
+      const del = config.del;
+
+      it('does not delete when the confirmation is cancelled', async () => {
+        del.primeDelete?.();
+        const header = await renderHeaderButtons();
+
+        fireEvent.press(header.getByText('Delete'));
+
+        await waitFor(() => {
+          expect(alertSpy).toHaveBeenCalled();
+        });
+        await pressAlertButton(alertSpy, 'Cancel');
+
+        expect(del.deleteFn()).not.toHaveBeenCalled();
+        expect(nav.goBack).not.toHaveBeenCalled();
+      });
+
+      it('deletes and navigates back when the confirmation is accepted', async () => {
+        del.primeDelete?.();
+        const header = await renderHeaderButtons();
+
+        fireEvent.press(header.getByText('Delete'));
+
+        await waitFor(() => {
+          expect(alertSpy).toHaveBeenCalled();
+        });
+        await pressAlertButton(alertSpy, 'Delete');
+
+        await waitFor(() => {
+          expect(del.deleteFn()).toHaveBeenCalled();
+          expect(nav.goBack).toHaveBeenCalled();
+        });
+      });
+    }
+  });
+}
+
+export interface FormScreenContractConfig {
+  name: string;
+  renderScreen: () => RenderResult;
+  requiredFieldPlaceholder: string;
+  requiredFieldValue: string;
+  validationErrorText: string;
+  submitLabels: { create: string; update: string };
+  createFn: () => unknown;
+  updateFn: () => unknown;
+  /** Primes the create call to succeed (e.g. `createFn.mockResolvedValue(...)`). */
+  primeCreate: () => void;
+  edit?: {
+    routeParams: Record<string, unknown>;
+    /** Primes existing data + a successful update call. */
+    prime: () => void;
+    /** Expected display value of the required field once prefilled. */
+    prefilledValue: string;
+  };
+}
+
+export function describeFormScreenContract(
+  config: FormScreenContractConfig
+): void {
+  describe(`${config.name} — form screen contract`, () => {
+    let nav: NavMock;
+    let alertSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      primeStorageDefaults();
+      nav = installNavigationMock();
+      installRouteParams({});
+      alertSpy = spyOnAlert();
+    });
+
+    afterEach(() => {
+      resetNavigationMocks();
+      jest.restoreAllMocks();
+    });
+
+    it('shows the create action when no item is being edited', async () => {
+      const { getByText } = config.renderScreen();
+
+      await waitFor(() => {
+        expect(getByText(config.submitLabels.create)).toBeTruthy();
+      });
+    });
+
+    it('shows a validation error instead of submitting an empty form', async () => {
+      const { getByText } = config.renderScreen();
+
+      await waitFor(() => {
+        expect(getByText(config.submitLabels.create)).toBeTruthy();
+      });
+      fireEvent.press(getByText(config.submitLabels.create));
+
+      await waitFor(() => {
+        expect(getByText(config.validationErrorText)).toBeTruthy();
+      });
+      expect(config.createFn()).not.toHaveBeenCalled();
+    });
+
+    it('creates the item and navigates back on success', async () => {
+      config.primeCreate();
+
+      const { getByText, getByPlaceholderText } = config.renderScreen();
+
+      await waitFor(() => {
+        expect(getByText(config.submitLabels.create)).toBeTruthy();
+      });
+      fireEvent.changeText(
+        getByPlaceholderText(config.requiredFieldPlaceholder),
+        config.requiredFieldValue
+      );
+      fireEvent.press(getByText(config.submitLabels.create));
+
+      await waitFor(() => {
+        expect(config.createFn()).toHaveBeenCalled();
+        expect(alertSpy).toHaveBeenCalledWith(
+          'Success',
+          expect.any(String),
+          expect.any(Array)
+        );
+      });
+      await pressAlertButton(alertSpy, 'OK');
+
+      expect(nav.goBack).toHaveBeenCalled();
+    });
+
+    if (config.edit) {
+      const edit = config.edit;
+
+      it('prefills existing data and updates instead of creating', async () => {
+        installRouteParams(edit.routeParams);
+        edit.prime();
+
+        const { getByText, getByDisplayValue } = config.renderScreen();
+
+        await waitFor(() => {
+          expect(getByDisplayValue(edit.prefilledValue)).toBeTruthy();
+          expect(getByText(config.submitLabels.update)).toBeTruthy();
+        });
+        fireEvent.press(getByText(config.submitLabels.update));
+
+        await waitFor(() => {
+          expect(config.updateFn()).toHaveBeenCalled();
+          expect(alertSpy).toHaveBeenCalledWith(
+            'Success',
+            expect.any(String),
+            expect.any(Array)
+          );
+        });
+        expect(config.createFn()).not.toHaveBeenCalled();
+
+        await pressAlertButton(alertSpy, 'OK');
+        expect(nav.goBack).toHaveBeenCalled();
+      });
+    }
+  });
+}

--- a/tst/helpers/storage.ts
+++ b/tst/helpers/storage.ts
@@ -1,0 +1,27 @@
+import * as characterStorage from '@utils/characterStorage';
+
+/**
+ * Typed access to the automocked `@utils/characterStorage` module. Test files
+ * must call `jest.mock('@utils/characterStorage')` themselves — the helper
+ * only assumes the mock is already registered.
+ */
+export const getStorageMock = () => jest.mocked(characterStorage);
+
+/**
+ * Primes every loader the templated screens touch with benign values so an
+ * automocked module (whose functions resolve `undefined` by default) doesn't
+ * crash screens on `.find(...)`/`.forEach(...)`. Call in `beforeEach` before
+ * any per-test priming.
+ */
+export function primeStorageDefaults(): void {
+  const storage = getStorageMock();
+  storage.loadCharacters.mockResolvedValue([]);
+  storage.loadFactions.mockResolvedValue([]);
+  storage.loadLocations.mockResolvedValue([]);
+  storage.loadEvents.mockResolvedValue([]);
+  storage.loadQuests.mockResolvedValue([]);
+  storage.getFactionDescription.mockResolvedValue('');
+  storage.migrateFactionDescriptions.mockResolvedValue(undefined);
+  storage.getLocation.mockResolvedValue(null);
+  storage.getAllStoredFactions.mockResolvedValue([]);
+}

--- a/tst/screens/character/CharacterDetailScreen.test.tsx
+++ b/tst/screens/character/CharacterDetailScreen.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { CharacterDetailScreen } from '@screens/character/CharacterDetailScreen';
+import { describeDetailScreenContract } from '../../helpers/screenContracts';
+import { getStorageMock } from '../../helpers/storage';
+import { makeCharacter } from '../../helpers/factories';
+import * as discordStorage from '@/utils/discordStorage';
+
+jest.mock('@utils/characterStorage');
+jest.mock('@/utils/discordStorage');
+
+const storage = getStorageMock();
+const character = makeCharacter({ id: 'char-1', name: 'Alice' });
+
+describeDetailScreenContract({
+  name: 'CharacterDetailScreen',
+  renderScreen: () => render(<CharacterDetailScreen />),
+  routeParams: { character },
+  prime: () => {
+    storage.loadCharacters.mockResolvedValue([character]);
+    jest
+      .mocked(discordStorage.getDiscordMessagesForCharacter)
+      .mockResolvedValue([]);
+  },
+  expectedContent: ['Alice', /Species: Human/],
+  edit: {
+    expectedScreen: 'CharacterForm',
+    expectedParams: { character },
+  },
+  del: {
+    deleteFn: () => storage.deleteCharacter,
+    primeDelete: () => {
+      storage.deleteCharacter.mockResolvedValue(true);
+    },
+  },
+});

--- a/tst/screens/character/CharacterListScreen.test.tsx
+++ b/tst/screens/character/CharacterListScreen.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import { CharacterListScreen } from '@screens/character/CharacterListScreen';
+import { RelationshipStanding } from '@models/types';
 import { describeListScreenContract } from '../../helpers/screenContracts';
 import { getStorageMock } from '../../helpers/storage';
 import { makeCharacter } from '../../helpers/factories';
@@ -17,8 +18,23 @@ describeListScreenContract({
   loadFns: () => [storage.loadCharacters],
   primePopulated: () => {
     storage.loadCharacters.mockResolvedValue([
-      makeCharacter({ name: 'Alice' }),
+      makeCharacter({
+        id: 'char-1',
+        name: 'Alice',
+        present: true,
+        factions: [
+          { name: 'Iron Legion', standing: RelationshipStanding.Ally },
+        ],
+      }),
+      makeCharacter({ id: 'char-2', name: 'Bob' }),
     ]);
   },
-  populatedTexts: ['Alice', 'No factions'],
+  populatedTexts: [
+    'Alice',
+    'Present',
+    'Iron Legion',
+    'Bob',
+    'Absent',
+    'No factions',
+  ],
 });

--- a/tst/screens/character/CharacterListScreen.test.tsx
+++ b/tst/screens/character/CharacterListScreen.test.tsx
@@ -1,60 +1,24 @@
 import React from 'react';
-import { render, waitFor } from '@testing-library/react-native';
+import { render } from '@testing-library/react-native';
 import { CharacterListScreen } from '@screens/character/CharacterListScreen';
-import * as characterStorage from '@utils/characterStorage';
+import { describeListScreenContract } from '../../helpers/screenContracts';
+import { getStorageMock } from '../../helpers/storage';
+import { makeCharacter } from '../../helpers/factories';
 
-// Mock the character storage module
-jest.mock('@utils/characterStorage', () => ({
-  loadCharacters: jest.fn(),
-  toggleCharacterPresent: jest.fn(),
-  resetAllPresentStatus: jest.fn(),
-}));
+jest.mock('@utils/characterStorage');
 
-describe('CharacterListScreen', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
+const storage = getStorageMock();
 
-  it('should render without crashing', async () => {
-    (characterStorage.loadCharacters as jest.Mock).mockResolvedValue([]);
-
-    const { getByText } = render(<CharacterListScreen />);
-
-    await waitFor(() => {
-      expect(getByText('No characters found')).toBeTruthy();
-    });
-  });
-
-  it('should load characters on mount', async () => {
-    const mockCharacters = [
-      {
-        id: '1',
-        name: 'Test Character',
-        species: 'Human',
-        factionId: 'faction1',
-        stats: {},
-        skills: {},
-      },
-    ];
-
-    (characterStorage.loadCharacters as jest.Mock).mockResolvedValue(
-      mockCharacters
-    );
-
-    render(<CharacterListScreen />);
-
-    await waitFor(() => {
-      expect(characterStorage.loadCharacters).toHaveBeenCalled();
-    });
-  });
-
-  it('should display search input', async () => {
-    (characterStorage.loadCharacters as jest.Mock).mockResolvedValue([]);
-
-    const { getByPlaceholderText } = render(<CharacterListScreen />);
-
-    await waitFor(() => {
-      expect(getByPlaceholderText('Search characters by name...')).toBeTruthy();
-    });
-  });
+describeListScreenContract({
+  name: 'CharacterListScreen',
+  renderScreen: () => render(<CharacterListScreen />),
+  emptyStateTitle: 'No characters found',
+  searchPlaceholder: 'Search characters by name...',
+  loadFns: () => [storage.loadCharacters],
+  primePopulated: () => {
+    storage.loadCharacters.mockResolvedValue([
+      makeCharacter({ name: 'Alice' }),
+    ]);
+  },
+  populatedTexts: ['Alice', 'No factions'],
 });

--- a/tst/screens/events/EventsListScreen.test.tsx
+++ b/tst/screens/events/EventsListScreen.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, waitFor, fireEvent } from '@testing-library/react-native';
+import { EventsTimelineScreen } from '@screens/events/EventsListScreen';
+import { describeListScreenContract } from '../../helpers/screenContracts';
+import { getStorageMock, primeStorageDefaults } from '../../helpers/storage';
+import { makeEvent } from '../../helpers/factories';
+import {
+  installNavigationMock,
+  resetNavigationMocks,
+  getLastHeaderRight,
+} from '../../helpers/navigation';
+
+jest.mock('@utils/characterStorage');
+
+const storage = getStorageMock();
+
+describeListScreenContract({
+  name: 'EventsTimelineScreen',
+  renderScreen: () => render(<EventsTimelineScreen />),
+  emptyStateTitle: 'No events found',
+  searchPlaceholder: 'Search events...',
+  loadFns: () => [
+    storage.loadEvents,
+    storage.loadCharacters,
+    storage.loadLocations,
+    storage.loadFactions,
+  ],
+  primePopulated: () => {
+    storage.loadEvents.mockResolvedValue([
+      makeEvent({ title: 'The Great Fire' }),
+    ]);
+  },
+  populatedTexts: ['The Great Fire'],
+});
+
+describe('EventsTimelineScreen — header actions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    primeStorageDefaults();
+  });
+
+  afterEach(() => {
+    resetNavigationMocks();
+  });
+
+  it('navigates to the create form from the header add button', async () => {
+    const nav = installNavigationMock();
+    render(<EventsTimelineScreen />);
+
+    await waitFor(() => {
+      expect(nav.setOptions).toHaveBeenCalled();
+    });
+    const header = render(getLastHeaderRight(nav));
+
+    fireEvent.press(header.getByText('+'));
+    expect(nav.navigate).toHaveBeenCalledWith('EventsForm', {});
+  });
+});

--- a/tst/screens/faction/FactionDetailScreen.test.tsx
+++ b/tst/screens/faction/FactionDetailScreen.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { FactionDetailsScreen } from '@screens/faction/FactionDetailScreen';
+import { describeDetailScreenContract } from '../../helpers/screenContracts';
+import { getStorageMock } from '../../helpers/storage';
+import { makeStoredFaction } from '../../helpers/factories';
+
+jest.mock('@utils/characterStorage');
+
+const storage = getStorageMock();
+const FACTION_NAME = 'Iron Legion';
+
+describeDetailScreenContract({
+  name: 'FactionDetailsScreen',
+  renderScreen: () => render(<FactionDetailsScreen />),
+  routeParams: { factionName: FACTION_NAME },
+  prime: () => {
+    storage.loadFactions.mockResolvedValue([
+      makeStoredFaction({ name: FACTION_NAME }),
+    ]);
+  },
+  expectedContent: [FACTION_NAME, 'No description provided', 'Statistics'],
+  edit: {
+    expectedScreen: 'FactionForm',
+    expectedParams: { factionName: FACTION_NAME },
+  },
+  del: {
+    deleteFn: () => storage.deleteFactionCompletely,
+    primeDelete: () => {
+      storage.deleteFactionCompletely.mockResolvedValue({
+        success: true,
+        charactersUpdated: 0,
+      });
+    },
+  },
+});

--- a/tst/screens/faction/FactionFormScreen.test.tsx
+++ b/tst/screens/faction/FactionFormScreen.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { FactionFormScreen } from '@screens/faction/FactionFormScreen';
+import { describeFormScreenContract } from '../../helpers/screenContracts';
+import { getStorageMock } from '../../helpers/storage';
+import { makeStoredFaction } from '../../helpers/factories';
+
+jest.mock('@utils/characterStorage');
+
+const storage = getStorageMock();
+const FACTION_NAME = 'Iron Legion';
+
+describeFormScreenContract({
+  name: 'FactionFormScreen',
+  renderScreen: () => render(<FactionFormScreen />),
+  requiredFieldPlaceholder: 'Enter faction name',
+  requiredFieldValue: 'New Faction',
+  validationErrorText: 'Faction name is required',
+  submitLabels: { create: 'Create Faction', update: 'Update Faction' },
+  createFn: () => storage.createFaction,
+  updateFn: () => storage.updateFaction,
+  primeCreate: () => {
+    storage.createFaction.mockResolvedValue(true);
+  },
+  edit: {
+    routeParams: { factionName: FACTION_NAME },
+    prime: () => {
+      storage.loadFactions.mockResolvedValue([
+        makeStoredFaction({ name: FACTION_NAME, description: 'Old guard' }),
+      ]);
+      storage.updateFaction.mockResolvedValue(
+        makeStoredFaction({ name: FACTION_NAME })
+      );
+    },
+    prefilledValue: FACTION_NAME,
+  },
+});

--- a/tst/screens/faction/FactionListScreen.test.tsx
+++ b/tst/screens/faction/FactionListScreen.test.tsx
@@ -1,61 +1,28 @@
 import React from 'react';
-import { render, waitFor } from '@testing-library/react-native';
+import { render } from '@testing-library/react-native';
 import { FactionListScreen } from '@screens/faction/FactionListScreen';
-import * as characterStorage from '@utils/characterStorage';
+import { describeListScreenContract } from '../../helpers/screenContracts';
+import { getStorageMock } from '../../helpers/storage';
+import { makeStoredFaction } from '../../helpers/factories';
 
-// Mock the character storage module
-jest.mock('@utils/characterStorage', () => ({
-  loadFactions: jest.fn(),
-  loadCharacters: jest.fn(),
-  migrateFactionDescriptions: jest.fn(),
-  getFactionDescription: jest.fn(),
-}));
+jest.mock('@utils/characterStorage');
 
-describe('FactionListScreen', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
+const storage = getStorageMock();
 
-  it('should render without crashing', async () => {
-    (characterStorage.loadFactions as jest.Mock).mockResolvedValue([]);
-    (characterStorage.loadCharacters as jest.Mock).mockResolvedValue([]);
-
-    const { getByText } = render(<FactionListScreen />);
-
-    await waitFor(() => {
-      expect(getByText('No factions found')).toBeTruthy();
-    });
-  });
-
-  it('should load factions on mount', async () => {
-    const mockFactions = [
-      {
-        id: '1',
-        name: 'Test Faction',
-        members: [],
-      },
-    ];
-
-    (characterStorage.loadFactions as jest.Mock).mockResolvedValue(
-      mockFactions
-    );
-    (characterStorage.loadCharacters as jest.Mock).mockResolvedValue([]);
-
-    render(<FactionListScreen />);
-
-    await waitFor(() => {
-      expect(characterStorage.loadFactions).toHaveBeenCalled();
-    });
-  });
-
-  it('should display search input', async () => {
-    (characterStorage.loadFactions as jest.Mock).mockResolvedValue([]);
-    (characterStorage.loadCharacters as jest.Mock).mockResolvedValue([]);
-
-    const { getByPlaceholderText } = render(<FactionListScreen />);
-
-    await waitFor(() => {
-      expect(getByPlaceholderText('Search factions by name...')).toBeTruthy();
-    });
-  });
+describeListScreenContract({
+  name: 'FactionListScreen',
+  renderScreen: () => render(<FactionListScreen />),
+  emptyStateTitle: 'No factions found',
+  searchPlaceholder: 'Search factions by name...',
+  loadFns: () => [
+    storage.migrateFactionDescriptions,
+    storage.loadCharacters,
+    storage.loadFactions,
+  ],
+  primePopulated: () => {
+    storage.loadFactions.mockResolvedValue([
+      makeStoredFaction({ name: 'Iron Legion' }),
+    ]);
+  },
+  populatedTexts: ['Iron Legion'],
 });

--- a/tst/screens/location/LocationFormScreen.test.tsx
+++ b/tst/screens/location/LocationFormScreen.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { LocationFormScreen } from '@screens/location/LocationFormScreen';
+import { describeFormScreenContract } from '../../helpers/screenContracts';
+import { getStorageMock } from '../../helpers/storage';
+import { makeLocation } from '../../helpers/factories';
+
+jest.mock('@utils/characterStorage');
+
+const storage = getStorageMock();
+const existingLocation = makeLocation({ id: 'loc-1', name: 'Old Docks' });
+
+describeFormScreenContract({
+  name: 'LocationFormScreen',
+  renderScreen: () => render(<LocationFormScreen />),
+  requiredFieldPlaceholder: 'Enter location name',
+  requiredFieldValue: 'The Docks',
+  validationErrorText: 'Location name is required',
+  submitLabels: { create: 'Create Location', update: 'Update Location' },
+  createFn: () => storage.createLocation,
+  updateFn: () => storage.updateLocation,
+  primeCreate: () => {
+    storage.createLocation.mockResolvedValue(makeLocation());
+  },
+  edit: {
+    routeParams: { location: existingLocation },
+    prime: () => {
+      storage.updateLocation.mockResolvedValue(existingLocation);
+    },
+    prefilledValue: 'Old Docks',
+  },
+});

--- a/tst/screens/location/LocationListScreen.test.tsx
+++ b/tst/screens/location/LocationListScreen.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, waitFor, fireEvent } from '@testing-library/react-native';
+import { LocationListScreen } from '@screens/location/LocationListScreen';
+import { describeListScreenContract } from '../../helpers/screenContracts';
+import { getStorageMock, primeStorageDefaults } from '../../helpers/storage';
+import { makeLocation } from '../../helpers/factories';
+import {
+  installNavigationMock,
+  resetNavigationMocks,
+  getLastHeaderRight,
+} from '../../helpers/navigation';
+
+jest.mock('@utils/characterStorage');
+
+const storage = getStorageMock();
+
+describeListScreenContract({
+  name: 'LocationListScreen',
+  renderScreen: () => render(<LocationListScreen />),
+  emptyStateTitle: 'No locations found',
+  searchPlaceholder: 'Search locations by name...',
+  loadFns: () => [storage.loadCharacters, storage.loadLocations],
+  primePopulated: () => {
+    storage.loadLocations.mockResolvedValue([
+      makeLocation({ name: 'The Docks' }),
+    ]);
+  },
+  populatedTexts: ['The Docks'],
+});
+
+describe('LocationListScreen — header actions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    primeStorageDefaults();
+  });
+
+  afterEach(() => {
+    resetNavigationMocks();
+  });
+
+  it('navigates to the map and the create form from the header buttons', async () => {
+    const nav = installNavigationMock();
+    render(<LocationListScreen />);
+
+    await waitFor(() => {
+      expect(nav.setOptions).toHaveBeenCalled();
+    });
+    const header = render(getLastHeaderRight(nav));
+
+    fireEvent.press(header.getByText('🗺️'));
+    expect(nav.navigate).toHaveBeenCalledWith('LocationMap');
+
+    fireEvent.press(header.getByText('+'));
+    expect(nav.navigate).toHaveBeenCalledWith('LocationForm', {});
+  });
+});

--- a/tst/screens/quest/QuestListScreen.test.tsx
+++ b/tst/screens/quest/QuestListScreen.test.tsx
@@ -1,57 +1,24 @@
 import React from 'react';
-import { render, waitFor } from '@testing-library/react-native';
+import { render } from '@testing-library/react-native';
 import { QuestListScreen } from '@screens/quest/QuestListScreen';
-import * as characterStorage from '@utils/characterStorage';
-import { QuestStatus } from '@models/types';
+import { describeListScreenContract } from '../../helpers/screenContracts';
+import { getStorageMock } from '../../helpers/storage';
+import { makeQuest } from '../../helpers/factories';
 
-// Mock the character storage module
-jest.mock('@utils/characterStorage', () => ({
-  loadQuests: jest.fn(),
-}));
+jest.mock('@utils/characterStorage');
 
-describe('QuestListScreen', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
+const storage = getStorageMock();
 
-  it('should render without crashing', async () => {
-    (characterStorage.loadQuests as jest.Mock).mockResolvedValue([]);
-
-    const { getByText } = render(<QuestListScreen />);
-
-    await waitFor(() => {
-      expect(getByText('No quests found')).toBeTruthy();
-    });
-  });
-
-  it('should load quests on mount', async () => {
-    const mockQuests = [
-      {
-        id: 'quest-1',
-        name: 'Test Quest',
-        status: QuestStatus.NotStarted,
-        createdAt: '2025-01-01T00:00:00.000Z',
-        updatedAt: '2025-01-01T00:00:00.000Z',
-      },
-    ];
-
-    (characterStorage.loadQuests as jest.Mock).mockResolvedValue(mockQuests);
-
-    const { getByText } = render(<QuestListScreen />);
-
-    await waitFor(() => {
-      expect(characterStorage.loadQuests).toHaveBeenCalled();
-      expect(getByText('Test Quest')).toBeTruthy();
-    });
-  });
-
-  it('should display search input', async () => {
-    (characterStorage.loadQuests as jest.Mock).mockResolvedValue([]);
-
-    const { getByPlaceholderText } = render(<QuestListScreen />);
-
-    await waitFor(() => {
-      expect(getByPlaceholderText('Search quests by name...')).toBeTruthy();
-    });
-  });
+describeListScreenContract({
+  name: 'QuestListScreen',
+  renderScreen: () => render(<QuestListScreen />),
+  emptyStateTitle: 'No quests found',
+  searchPlaceholder: 'Search quests by name...',
+  loadFns: () => [storage.loadQuests],
+  primePopulated: () => {
+    storage.loadQuests.mockResolvedValue([
+      makeQuest({ name: 'Recover the Cargo' }),
+    ]);
+  },
+  populatedTexts: ['Recover the Cargo'],
 });


### PR DESCRIPTION
## Summary

Adds shared, reusable test infrastructure so screens built on the `Base{List,Form,Detail}Screen` templates are cheap to test, then uses it to close the biggest coverage gaps called out in AGENTS.md.

**Coverage: ~26% → ~34% statements overall.** `BaseDetailScreen` 7% → 100% lines, `BaseFormScreen` 17% → 100% lines; six previously-untested screens now have contract-based tests.

### Shared helpers (`tst/helpers/`)

- **`factories.ts`** — typed factories (`makeCharacter`, `makeStoredFaction`, `makeLocation`, `makeEvent`, `makeQuest`) with `Partial<T>` overrides.
- **`navigation.ts`** — per-test overrides for the global `@react-navigation/native` mock: a stable `useNavigation()` mock (the global one returns fresh `jest.fn()`s per call, making `setOptions`/`goBack` assertions impossible), `installRouteParams`, and `getLastHeaderRight` to render and press header buttons passed to `navigation.setOptions`.
- **`alertAndPlatform.ts`** — `Alert.alert` spy + `pressAlertButton`, `Platform.OS` override, and a `window.confirm` stub for the web confirmation branch.
- **`storage.ts`** — typed access to the automocked `@utils/characterStorage` plus `primeStorageDefaults()` so automocked loaders don't crash screens.
- **`screenContracts.ts`** — `describeListScreenContract`, `describeDetailScreenContract`, `describeFormScreenContract`: reusable behavior suites (empty state, loaders, search; header edit/delete wiring, confirm/cancel delete → `goBack`; validation, create/update submit → success alert → `goBack`). A concrete screen test is now a small config object plus screen-specific extras.

### New tests

- `BaseFormScreen` (children, keyboard avoidance toggle, scrollViewProps passthrough)
- `BaseDetailScreen` (header wiring, custom headerRight precedence, native Alert delete flow with default/custom messages, web `window.confirm` flow)
- `LocationListScreen`, `EventsListScreen` (list contract + header navigation extras)
- `FactionDetailScreen`, `CharacterDetailScreen` (detail contract: content, edit navigation, delete confirm/cancel)
- `FactionFormScreen`, `LocationFormScreen` (form contract: validation, create, prefilled edit/update)

### Refactors

- `CharacterListScreen`/`FactionListScreen`/`QuestListScreen` tests moved onto the list contract, each gaining a populated-data rendering case.

### Config changes

- `jest.config.js`: allow `uuid` through `transformIgnorePatterns` (ESM-only; required for automocking `characterStorage`).
- `jest.setup.js`: add `requestMediaLibraryPermissionsAsync` to the `expo-image-picker` mock; silence `console.log` alongside the already-silenced `warn`/`error`.

## Testing

- `npm run check-all` passes (type-check + lint + format:check + 382 tests across 34 suites).
- Remaining templated screens (Quest/Events detail + form, LocationDetail, QuestProposal, CharacterForm) are a mechanical follow-up using the same contracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUTLiekyaofWrGPVnrrWSZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUTLiekyaofWrGPVnrrWSZ)_