### PR TITLE
Add contract-based tests for the remaining templated screens

### DIFF
--- a/tst/screens/character/CharacterFormScreen.test.tsx
+++ b/tst/screens/character/CharacterFormScreen.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { render, waitFor, fireEvent } from '@testing-library/react-native';
+import { CharacterFormScreen } from '@screens/character/CharacterFormScreen';
+import { getStorageMock, primeStorageDefaults } from '../../helpers/storage';
+import { makeCharacter } from '../../helpers/factories';
+import {
+  installNavigationMock,
+  installRouteParams,
+  resetNavigationMocks,
+} from '../../helpers/navigation';
+import { spyOnAlert } from '../../helpers/alertAndPlatform';
+
+// This screen validates via Alert.alert (no inline error text) and renders
+// its submit action with RN's <Button>, not a styled TouchableOpacity like
+// the other form screens, so it doesn't fit describeFormScreenContract and
+// gets a bespoke test file instead.
+jest.mock('@utils/characterStorage');
+
+const storage = getStorageMock();
+
+describe('CharacterFormScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    primeStorageDefaults();
+    installRouteParams({});
+  });
+
+  afterEach(() => {
+    resetNavigationMocks();
+    jest.restoreAllMocks();
+  });
+
+  it('shows the create action when no character is being edited', async () => {
+    const { getByText } = render(<CharacterFormScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Create Character')).toBeTruthy();
+    });
+  });
+
+  it('alerts instead of creating when the name is blank', async () => {
+    const alertSpy = spyOnAlert();
+
+    const { getByText } = render(<CharacterFormScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Create Character')).toBeTruthy();
+    });
+    fireEvent.press(getByText('Create Character'));
+
+    expect(alertSpy).toHaveBeenCalledWith('Error', 'Name is required');
+    expect(storage.addCharacter).not.toHaveBeenCalled();
+  });
+
+  it('creates the character and navigates back on success', async () => {
+    const nav = installNavigationMock();
+    storage.addCharacter.mockResolvedValue(
+      makeCharacter({ id: 'new-1', name: 'Newbie' })
+    );
+    storage.saveCharacters.mockResolvedValue(undefined);
+
+    const { getByText, getByPlaceholderText } = render(<CharacterFormScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Create Character')).toBeTruthy();
+    });
+    fireEvent.changeText(getByPlaceholderText('Character Name'), 'Newbie');
+    fireEvent.press(getByText('Create Character'));
+
+    await waitFor(() => {
+      expect(storage.addCharacter).toHaveBeenCalled();
+      expect(nav.goBack).toHaveBeenCalled();
+    });
+  });
+
+  it('prefills existing data and updates instead of creating', async () => {
+    const nav = installNavigationMock();
+    const existing = makeCharacter({ id: 'char-1', name: 'Alice' });
+    installRouteParams({ character: existing });
+    storage.updateCharacter.mockResolvedValue(existing);
+    storage.loadCharacters.mockResolvedValue([existing]);
+    storage.saveCharacters.mockResolvedValue(undefined);
+
+    const { getByText, getByDisplayValue } = render(<CharacterFormScreen />);
+
+    await waitFor(() => {
+      expect(getByDisplayValue('Alice')).toBeTruthy();
+      expect(getByText('Update Character')).toBeTruthy();
+    });
+    fireEvent.press(getByText('Update Character'));
+
+    await waitFor(() => {
+      expect(storage.updateCharacter).toHaveBeenCalledWith(
+        'char-1',
+        expect.objectContaining({ name: 'Alice' })
+      );
+      expect(nav.goBack).toHaveBeenCalled();
+    });
+    expect(storage.addCharacter).not.toHaveBeenCalled();
+  });
+});

--- a/tst/screens/events/EventsDetailScreen.test.tsx
+++ b/tst/screens/events/EventsDetailScreen.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { EventsDetailScreen } from '@screens/events/EventsDetailScreen';
+import { describeDetailScreenContract } from '../../helpers/screenContracts';
+import { getStorageMock } from '../../helpers/storage';
+import { makeEvent } from '../../helpers/factories';
+
+jest.mock('@utils/characterStorage');
+
+const storage = getStorageMock();
+const EVENT_ID = 'event-1';
+const event = makeEvent({ id: EVENT_ID, title: 'The Great Fire' });
+
+describeDetailScreenContract({
+  name: 'EventsDetailScreen',
+  renderScreen: () => render(<EventsDetailScreen />),
+  routeParams: { eventId: EVENT_ID },
+  prime: () => {
+    storage.loadEvents.mockResolvedValue([event]);
+  },
+  expectedContent: ['The Great Fire', 'Confirmed', 'Date:'],
+  edit: {
+    expectedScreen: 'EventsForm',
+    expectedParams: {
+      event: { ...event, characterNames: [] },
+    },
+  },
+  del: {
+    deleteFn: () => storage.deleteEvent,
+    primeDelete: () => {
+      storage.deleteEvent.mockResolvedValue(true);
+    },
+  },
+});

--- a/tst/screens/events/EventsFormScreen.test.tsx
+++ b/tst/screens/events/EventsFormScreen.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { EventsFormScreen } from '@screens/events/EventsFormScreen';
+import { describeFormScreenContract } from '../../helpers/screenContracts';
+import { getStorageMock } from '../../helpers/storage';
+import { makeEvent } from '../../helpers/factories';
+
+jest.mock('@utils/characterStorage');
+
+const storage = getStorageMock();
+const existingEvent = makeEvent({ id: 'event-1', title: 'Old Gathering' });
+
+describeFormScreenContract({
+  name: 'EventsFormScreen',
+  renderScreen: () => render(<EventsFormScreen />),
+  requiredFieldPlaceholder: 'Event title',
+  requiredFieldValue: 'The Wedding',
+  validationErrorText: 'Title is required',
+  submitLabels: { create: 'Create Event', update: 'Update Event' },
+  createFn: () => storage.createEvent,
+  updateFn: () => storage.updateEvent,
+  primeCreate: () => {
+    storage.createEvent.mockResolvedValue(makeEvent());
+  },
+  edit: {
+    routeParams: { event: existingEvent },
+    prime: () => {
+      storage.updateEvent.mockResolvedValue(existingEvent);
+    },
+    prefilledValue: 'Old Gathering',
+  },
+});

--- a/tst/screens/location/LocationDetailScreen.test.tsx
+++ b/tst/screens/location/LocationDetailScreen.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { LocationDetailsScreen } from '@screens/location/LocationDetailScreen';
+import { describeDetailScreenContract } from '../../helpers/screenContracts';
+import { getStorageMock } from '../../helpers/storage';
+import { makeLocation } from '../../helpers/factories';
+
+jest.mock('@utils/characterStorage');
+
+const storage = getStorageMock();
+const LOCATION_ID = 'location-1';
+const location = makeLocation({ id: LOCATION_ID, name: 'The Docks' });
+
+describeDetailScreenContract({
+  name: 'LocationDetailsScreen',
+  renderScreen: () => render(<LocationDetailsScreen />),
+  routeParams: { locationId: LOCATION_ID },
+  prime: () => {
+    storage.getLocation.mockResolvedValue(location);
+  },
+  expectedContent: ['The Docks', 'Statistics', 'Total Characters'],
+  edit: {
+    expectedScreen: 'LocationForm',
+    expectedParams: { location },
+  },
+  del: {
+    deleteFn: () => storage.deleteLocationCompletely,
+    primeDelete: () => {
+      storage.deleteLocationCompletely.mockResolvedValue({
+        success: true,
+        charactersUpdated: 0,
+      });
+    },
+  },
+});

--- a/tst/screens/quest/QuestDetailScreen.test.tsx
+++ b/tst/screens/quest/QuestDetailScreen.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { QuestDetailScreen } from '@screens/quest/QuestDetailScreen';
+import { describeDetailScreenContract } from '../../helpers/screenContracts';
+import { getStorageMock } from '../../helpers/storage';
+import { makeQuest } from '../../helpers/factories';
+
+jest.mock('@utils/characterStorage');
+
+const storage = getStorageMock();
+const QUEST_ID = 'quest-1';
+const quest = makeQuest({ id: QUEST_ID, name: 'Recover the Cargo' });
+
+describeDetailScreenContract({
+  name: 'QuestDetailScreen',
+  renderScreen: () => render(<QuestDetailScreen />),
+  routeParams: { questId: QUEST_ID },
+  prime: () => {
+    storage.loadQuests.mockResolvedValue([quest]);
+  },
+  expectedContent: [
+    'Recover the Cargo',
+    'Not Started',
+    'Team Size Goal',
+    'Default',
+  ],
+  edit: {
+    expectedScreen: 'QuestsForm',
+    expectedParams: {
+      quest: { ...quest, characterNames: [], eventTitles: [] },
+    },
+  },
+  del: {
+    deleteFn: () => storage.deleteQuest,
+    primeDelete: () => {
+      storage.deleteQuest.mockResolvedValue(true);
+    },
+  },
+});

--- a/tst/screens/quest/QuestFormScreen.test.tsx
+++ b/tst/screens/quest/QuestFormScreen.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { QuestFormScreen } from '@screens/quest/QuestFormScreen';
+import { describeFormScreenContract } from '../../helpers/screenContracts';
+import { getStorageMock } from '../../helpers/storage';
+import { makeQuest } from '../../helpers/factories';
+
+jest.mock('@utils/characterStorage');
+
+const storage = getStorageMock();
+const existingQuest = makeQuest({ id: 'quest-1', name: 'Old Mission' });
+
+describeFormScreenContract({
+  name: 'QuestFormScreen',
+  renderScreen: () => render(<QuestFormScreen />),
+  requiredFieldPlaceholder: 'Mission name',
+  requiredFieldValue: 'Retrieve Artifact',
+  validationErrorText: 'Mission name is required',
+  submitLabels: { create: 'Create Quest', update: 'Update Quest' },
+  createFn: () => storage.createQuest,
+  updateFn: () => storage.updateQuest,
+  primeCreate: () => {
+    storage.createQuest.mockResolvedValue(makeQuest());
+  },
+  edit: {
+    routeParams: { quest: existingQuest },
+    prime: () => {
+      storage.updateQuest.mockResolvedValue(existingQuest);
+    },
+    prefilledValue: 'Old Mission',
+  },
+});

--- a/tst/screens/quest/QuestProposalScreen.test.tsx
+++ b/tst/screens/quest/QuestProposalScreen.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { render, waitFor, fireEvent } from '@testing-library/react-native';
+import { QuestProposalScreen } from '@screens/quest/QuestProposalScreen';
+import { QuestStatus } from '@models/types';
+import { getStorageMock, primeStorageDefaults } from '../../helpers/storage';
+import { makeCharacter, makeQuest } from '../../helpers/factories';
+import {
+  installNavigationMock,
+  resetNavigationMocks,
+  getLastHeaderRight,
+} from '../../helpers/navigation';
+
+// This screen has no route params and drives its own headerRight buttons
+// (Regenerate/Save All) rather than the edit/delete shape the other detail
+// screens share, so it doesn't fit describeDetailScreenContract and gets a
+// bespoke test file instead.
+jest.mock('@utils/characterStorage');
+
+const storage = getStorageMock();
+
+const quest = makeQuest({
+  id: 'quest-1',
+  name: 'Recover the Cargo',
+  status: QuestStatus.NotStarted,
+});
+const character = makeCharacter({
+  id: 'char-1',
+  name: 'Alice',
+  present: true,
+});
+
+describe('QuestProposalScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    primeStorageDefaults();
+  });
+
+  afterEach(() => {
+    resetNavigationMocks();
+  });
+
+  it('shows a loading state before rendering the generated proposals', async () => {
+    storage.loadQuests.mockResolvedValue([quest]);
+    storage.loadCharacters.mockResolvedValue([character]);
+
+    const { getByText } = render(<QuestProposalScreen />);
+
+    expect(getByText('Generating proposals...')).toBeTruthy();
+
+    await waitFor(() => {
+      expect(getByText('Recover the Cargo')).toBeTruthy();
+      expect(getByText('Alice')).toBeTruthy();
+    });
+  });
+
+  it('shows the empty state when there is nothing to propose', async () => {
+    const { getByText } = render(<QuestProposalScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Nothing to propose')).toBeTruthy();
+    });
+  });
+
+  it('saves a proposed team and marks it saved', async () => {
+    storage.loadQuests.mockResolvedValue([quest]);
+    storage.loadCharacters.mockResolvedValue([character]);
+    storage.updateQuest.mockResolvedValue(quest);
+
+    const { getByText } = render(<QuestProposalScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Save Team')).toBeTruthy();
+    });
+    fireEvent.press(getByText('Save Team'));
+
+    await waitFor(() => {
+      expect(storage.updateQuest).toHaveBeenCalledWith('quest-1', {
+        assignedCharacterIds: ['char-1'],
+        status: QuestStatus.Assigned,
+      });
+      expect(getByText('Saved')).toBeTruthy();
+    });
+  });
+
+  it('navigates back when discarding', async () => {
+    const nav = installNavigationMock();
+
+    const { getByText } = render(<QuestProposalScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Discard Proposals')).toBeTruthy();
+    });
+    fireEvent.press(getByText('Discard Proposals'));
+
+    expect(nav.goBack).toHaveBeenCalled();
+  });
+
+  it('regenerates proposals from the header Regenerate button', async () => {
+    const nav = installNavigationMock();
+    storage.loadQuests.mockResolvedValue([quest]);
+    storage.loadCharacters.mockResolvedValue([character]);
+
+    render(<QuestProposalScreen />);
+
+    await waitFor(() => {
+      expect(nav.setOptions).toHaveBeenCalled();
+    });
+    const header = render(getLastHeaderRight(nav));
+
+    fireEvent.press(header.getByText('Regenerate'));
+
+    await waitFor(() => {
+      expect(storage.loadQuests).toHaveBeenCalledTimes(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #113. Uses the `describeListScreenContract`/`describeDetailScreenContract`/`describeFormScreenContract` helpers introduced there to cover the remaining templated screens that had no tests.

**Coverage: ~34% → ~41% statements overall.** Every templated list/form/detail screen now has at least one test.

### New tests (via the shared contracts)

- `QuestDetailScreen`, `EventsDetailScreen`, `LocationDetailScreen` — detail contract: content renders, header Edit button navigates with the screen's enriched route params (e.g. quest/event augmented with resolved location/character names), header Delete button's confirm/cancel flow.
- `QuestFormScreen`, `EventsFormScreen` — form contract: validation error on empty submit, create flow, prefilled edit mode that calls update instead of create.

### New tests (bespoke)

Two screens don't fit the shared contracts, so they get dedicated test files instead of being forced through the generators:

- **`QuestProposalScreen`** — no route params at all, and its header renders `Regenerate`/`Save All` actions rather than the Edit/Delete shape the detail contract assumes. Tests cover the loading → generated-proposals transition, the empty state, saving a proposed team, discarding, and regenerating from the header button.
- **`CharacterFormScreen`** — validates via `Alert.alert` (no inline error `<Text>` like the other forms) and submits through React Native's `<Button>` rather than a styled `TouchableOpacity`. Tests cover create, the alert-based validation path, and prefilled edit/update.

## Testing

- `npm run check-all` passes (type-check + lint + format:check + 414 tests across 41 suites).
- `npm run test:coverage` confirms all seven newly-tested screens moved off 0%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUTLiekyaofWrGPVnrrWSZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUTLiekyaofWrGPVnrrWSZ)_