### PR TITLE
Add clickable location markers, long-press placement, and pan clamping to the map

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -78,20 +78,64 @@ jest.mock('react-native-safe-area-context', () => ({
 }));
 
 // Mock react-native-gesture-handler
-jest.mock('react-native-gesture-handler', () => ({
-  TouchableOpacity: 'TouchableOpacity',
-  ScrollView: 'ScrollView',
-  State: {},
-  PanGestureHandler: 'PanGestureHandler',
-  TouchableWithoutFeedback: 'TouchableWithoutFeedback',
-  FlatList: 'FlatList',
-}));
+jest.mock('react-native-gesture-handler', () => {
+  // Chainable stub matching the `Gesture.Pan()/.onUpdate(cb).onEnd(cb)` API.
+  // Every `.on*` call is a jest.fn() that both records the callback (so
+  // tests can invoke it directly) and returns the stub for chaining.
+  const createGestureStub = () => {
+    const stub = {
+      callbacks: {},
+    };
+    ['onStart', 'onUpdate', 'onEnd', 'onFinalize'].forEach(method => {
+      stub[method] = jest.fn(cb => {
+        stub.callbacks[method] = cb;
+        return stub;
+      });
+    });
+    ['numberOfTaps', 'minDuration', 'maxDistance'].forEach(method => {
+      stub[method] = jest.fn(() => stub);
+    });
+    return stub;
+  };
+
+  return {
+    GestureDetector: ({ children }) => children,
+    Gesture: {
+      Pan: jest.fn(createGestureStub),
+      Pinch: jest.fn(createGestureStub),
+      Tap: jest.fn(createGestureStub),
+      LongPress: jest.fn(createGestureStub),
+      Simultaneous: jest.fn((...gestures) => gestures),
+    },
+    TouchableOpacity: 'TouchableOpacity',
+    ScrollView: 'ScrollView',
+    State: {},
+    PanGestureHandler: 'PanGestureHandler',
+    TouchableWithoutFeedback: 'TouchableWithoutFeedback',
+    FlatList: 'FlatList',
+  };
+});
 
 // Mock react-native-reanimated
 jest.mock('react-native-reanimated', () => ({
+  // Without this, Babel's default-import interop (`import Animated from
+  // 'react-native-reanimated'`) sees no `__esModule` marker, assumes this is
+  // a plain CJS export, and wraps the *whole* mock object as `Animated`
+  // instead of unwrapping to the `default` below — so `Animated.View` is
+  // undefined everywhere it's used as a component.
+  __esModule: true,
   default: {
+    View: 'Animated.View',
+    Image: 'Animated.Image',
     createAnimatedComponent: component => component,
   },
+  useSharedValue: initial => ({ value: initial }),
+  useAnimatedStyle: factory => factory(),
+  withTiming: value => value,
+  runOnJS:
+    fn =>
+    (...args) =>
+      fn(...args),
   Easing: {
     bezier: () => ({ factory: () => x => x }),
   },

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,3 +10,6 @@ export { Section } from './common/Section';
 export { CollapsibleSection } from './common/CollapsibleSection';
 export { Card } from './common/Card';
 export { InfoButton } from './common/InfoButton';
+export { LocationMarker } from './map/LocationMarker';
+export { MapInfoCard } from './map/MapInfoCard';
+export { MapLocationPickerModal } from './map/MapLocationPickerModal';

--- a/src/components/map/LocationMarker.tsx
+++ b/src/components/map/LocationMarker.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { TouchableOpacity, View, StyleSheet } from 'react-native';
+import Animated, {
+  useAnimatedStyle,
+  SharedValue,
+} from 'react-native-reanimated';
+import { GameLocation } from '@models/types';
+import { colors, borderRadius, shadows } from '@/styles/theme';
+import { normalizedToImagePoint } from '@/utils/mapCoordinates';
+
+const MARKER_SIZE = 44;
+const DOT_SIZE = 20;
+
+interface LocationMarkerProps {
+  location: GameLocation;
+  imageWidth: number;
+  imageHeight: number;
+  scale: SharedValue<number>;
+  onPress: (location: GameLocation) => void;
+}
+
+export const LocationMarker: React.FC<LocationMarkerProps> = ({
+  location,
+  imageWidth,
+  imageHeight,
+  scale,
+  onPress,
+}) => {
+  const counterScaleStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: 1 / scale.value }],
+  }));
+
+  if (!location.mapCoordinates) {
+    return null;
+  }
+
+  const { x, y } = normalizedToImagePoint(location.mapCoordinates, {
+    width: imageWidth,
+    height: imageHeight,
+  });
+
+  return (
+    <Animated.View
+      style={[
+        styles.touchArea,
+        {
+          left: x - MARKER_SIZE / 2,
+          top: y - MARKER_SIZE / 2,
+        },
+        counterScaleStyle,
+      ]}
+    >
+      <TouchableOpacity
+        style={styles.touchAreaInner}
+        onPress={() => onPress(location)}
+        activeOpacity={0.7}
+        accessibilityRole="button"
+        accessibilityLabel={location.name}
+      >
+        <View style={styles.dot} />
+      </TouchableOpacity>
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  touchArea: {
+    position: 'absolute',
+    width: MARKER_SIZE,
+    height: MARKER_SIZE,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  touchAreaInner: {
+    width: '100%',
+    height: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  dot: {
+    width: DOT_SIZE,
+    height: DOT_SIZE,
+    borderRadius: borderRadius.full,
+    backgroundColor: colors.accent.primary,
+    borderWidth: 2,
+    borderColor: colors.text.primary,
+    ...shadows.small,
+  },
+});

--- a/src/components/map/MapInfoCard.tsx
+++ b/src/components/map/MapInfoCard.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { GameLocation } from '@models/types';
+import { colors, spacing, borderRadius, shadows } from '@/styles/theme';
+import { commonStyles } from '@/styles/commonStyles';
+
+interface MapInfoCardProps {
+  location: GameLocation;
+  onViewDetails: (locationId: string) => void;
+  onClose: () => void;
+}
+
+export const MapInfoCard: React.FC<MapInfoCardProps> = ({
+  location,
+  onViewDetails,
+  onClose,
+}) => {
+  return (
+    <View style={styles.card}>
+      <View style={styles.header}>
+        <Text style={styles.name} numberOfLines={1}>
+          {location.name}
+        </Text>
+        <TouchableOpacity
+          onPress={onClose}
+          accessibilityRole="button"
+          accessibilityLabel="Close"
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        >
+          <Text style={styles.closeIcon}>✕</Text>
+        </TouchableOpacity>
+      </View>
+
+      {location.description ? (
+        <Text style={styles.description} numberOfLines={3}>
+          {location.description}
+        </Text>
+      ) : null}
+
+      <TouchableOpacity
+        style={styles.detailsButton}
+        onPress={() => onViewDetails(location.id)}
+        accessibilityRole="button"
+        accessibilityLabel={`View details for ${location.name}`}
+      >
+        <Text style={styles.detailsButtonText}>View details</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    position: 'absolute',
+    left: spacing.base,
+    right: spacing.base,
+    bottom: spacing.base,
+    backgroundColor: colors.surface,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: spacing.lg,
+    ...shadows.large,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.sm,
+  },
+  name: {
+    ...commonStyles.text.h3,
+    flex: 1,
+    marginRight: spacing.md,
+  },
+  closeIcon: {
+    color: colors.text.secondary,
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  description: {
+    ...commonStyles.text.body,
+    marginBottom: spacing.base,
+  },
+  detailsButton: {
+    ...commonStyles.button.base,
+    ...commonStyles.button.primary,
+  },
+  detailsButtonText: commonStyles.button.text,
+});

--- a/src/components/map/MapLocationPickerModal.tsx
+++ b/src/components/map/MapLocationPickerModal.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  TouchableOpacity,
+  ScrollView,
+  StyleSheet,
+} from 'react-native';
+import { GameLocation } from '@models/types';
+import { colors, spacing, borderRadius } from '@/styles/theme';
+import { commonStyles } from '@/styles/commonStyles';
+
+interface MapLocationPickerModalProps {
+  visible: boolean;
+  locations: GameLocation[];
+  onSelect: (locationId: string) => void;
+  onCancel: () => void;
+}
+
+export const MapLocationPickerModal: React.FC<MapLocationPickerModalProps> = ({
+  visible,
+  locations,
+  onSelect,
+  onCancel,
+}) => {
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onCancel}
+    >
+      <View style={styles.overlay}>
+        <View style={styles.content}>
+          <Text style={styles.title}>Place a location</Text>
+
+          {locations.length === 0 ? (
+            <Text style={styles.emptyText}>
+              No saved locations yet. Create one first.
+            </Text>
+          ) : (
+            <ScrollView style={styles.list}>
+              {locations.map(location => (
+                <TouchableOpacity
+                  key={location.id}
+                  style={styles.row}
+                  onPress={() => onSelect(location.id)}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Place ${location.name} here`}
+                >
+                  <Text style={styles.rowName} numberOfLines={1}>
+                    {location.name}
+                  </Text>
+                  {location.mapCoordinates && (
+                    <View style={styles.placedBadge}>
+                      <Text style={styles.placedBadgeText}>placed</Text>
+                    </View>
+                  )}
+                </TouchableOpacity>
+              ))}
+            </ScrollView>
+          )}
+
+          <TouchableOpacity
+            style={styles.cancelButton}
+            onPress={onCancel}
+            accessibilityRole="button"
+            accessibilityLabel="Cancel"
+          >
+            <Text style={styles.cancelButtonText}>Cancel</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.7)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: spacing.xl,
+  },
+  content: {
+    backgroundColor: colors.surface,
+    borderRadius: borderRadius.lg,
+    padding: spacing.xl,
+    width: '100%',
+    maxWidth: 500,
+    maxHeight: '80%',
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  title: {
+    ...commonStyles.text.h2,
+    marginBottom: spacing.base,
+    textAlign: 'center',
+  },
+  emptyText: {
+    ...commonStyles.text.body,
+    textAlign: 'center',
+    marginVertical: spacing.lg,
+  },
+  list: {
+    maxHeight: 400,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  rowName: {
+    ...commonStyles.text.body,
+    color: colors.text.primary,
+    flex: 1,
+    marginRight: spacing.md,
+  },
+  placedBadge: {
+    ...commonStyles.badge.small,
+    backgroundColor: colors.accent.success,
+  },
+  placedBadgeText: {
+    ...commonStyles.badge.text,
+    fontSize: 10,
+  },
+  cancelButton: {
+    ...commonStyles.button.base,
+    ...commonStyles.button.outline,
+    marginTop: spacing.lg,
+  },
+  cancelButtonText: {
+    ...commonStyles.button.text,
+    color: colors.text.primary,
+  },
+});

--- a/src/screens/location/LocationMapScreen.tsx
+++ b/src/screens/location/LocationMapScreen.tsx
@@ -1,19 +1,56 @@
-import React, { useState } from 'react';
-import { View, Image, StyleSheet, Dimensions, Text } from 'react-native';
+import React, { useCallback, useState } from 'react';
+import {
+  View,
+  Image,
+  StyleSheet,
+  Dimensions,
+  Text,
+  LayoutChangeEvent,
+} from 'react-native';
 import { GestureDetector, Gesture } from 'react-native-gesture-handler';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
   withTiming,
+  runOnJS,
 } from 'react-native-reanimated';
+import { useNavigation, useFocusEffect } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { RootStackParamList } from '@/navigation/types';
+import { GameLocation } from '@models/types';
+import { loadLocations, updateLocation } from '@utils/characterStorage';
 import { colors as themeColors } from '@/styles/theme';
 import { commonStyles } from '@/styles/commonStyles';
+import {
+  LocationMarker,
+  MapInfoCard,
+  MapLocationPickerModal,
+} from '@/components';
+import {
+  containerPointToNormalized,
+  clampTranslation,
+  Point,
+  Size,
+} from '@/utils/mapCoordinates';
 import mapImage from '../../../assets/JunktownMap.png';
 
 const { width: screenWidth, height: screenHeight } = Dimensions.get('window');
 
+type LocationMapNavigationProp = StackNavigationProp<RootStackParamList>;
+
 export const LocationMapScreen: React.FC = () => {
-  const [imageSize, setImageSize] = useState({ width: 0, height: 0 });
+  const navigation = useNavigation<LocationMapNavigationProp>();
+
+  const [imageSize, setImageSize] = useState<Size>({ width: 0, height: 0 });
+  const [containerSize, setContainerSize] = useState<Size>({
+    width: 0,
+    height: 0,
+  });
+  const [locations, setLocations] = useState<GameLocation[]>([]);
+  const [selectedLocation, setSelectedLocation] = useState<GameLocation | null>(
+    null
+  );
+  const [pendingCoords, setPendingCoords] = useState<Point | null>(null);
 
   const scale = useSharedValue(1);
   const savedScale = useSharedValue(1);
@@ -21,6 +58,12 @@ export const LocationMapScreen: React.FC = () => {
   const translateY = useSharedValue(0);
   const savedTranslateX = useSharedValue(0);
   const savedTranslateY = useSharedValue(0);
+
+  useFocusEffect(
+    useCallback(() => {
+      loadLocations().then(setLocations);
+    }, [])
+  );
 
   // Get the actual image dimensions
   React.useEffect(() => {
@@ -41,24 +84,77 @@ export const LocationMapScreen: React.FC = () => {
     }
   }, []);
 
+  const handleContainerLayout = (event: LayoutChangeEvent) => {
+    const { width, height } = event.nativeEvent.layout;
+    setContainerSize({ width, height });
+  };
+
+  const handleLongPress = (coords: Point) => {
+    setPendingCoords(coords);
+  };
+
+  const handlePlaceLocation = async (locationId: string) => {
+    if (!pendingCoords) {
+      return;
+    }
+    await updateLocation(locationId, { mapCoordinates: pendingCoords });
+    setPendingCoords(null);
+    const updated = await loadLocations();
+    setLocations(updated);
+  };
+
+  const handleViewDetails = (locationId: string) => {
+    setSelectedLocation(null);
+    navigation.navigate('LocationDetails', { locationId });
+  };
+
   const pinchGesture = Gesture.Pinch()
     .onUpdate(e => {
       scale.value = savedScale.value * e.scale;
+      const clamped = clampTranslation(
+        translateX.value,
+        translateY.value,
+        scale.value,
+        imageSize,
+        containerSize
+      );
+      translateX.value = clamped.x;
+      translateY.value = clamped.y;
     })
     .onEnd(() => {
       // Constrain scale between 1 and 3
-      if (scale.value < 1) {
-        scale.value = withTiming(1);
-      } else if (scale.value > 3) {
-        scale.value = withTiming(3);
+      let targetScale = scale.value;
+      if (targetScale < 1) {
+        targetScale = 1;
+      } else if (targetScale > 3) {
+        targetScale = 3;
       }
-      savedScale.value = scale.value;
+      const clamped = clampTranslation(
+        translateX.value,
+        translateY.value,
+        targetScale,
+        imageSize,
+        containerSize
+      );
+      scale.value = withTiming(targetScale);
+      translateX.value = withTiming(clamped.x);
+      translateY.value = withTiming(clamped.y);
+      savedScale.value = targetScale;
+      savedTranslateX.value = clamped.x;
+      savedTranslateY.value = clamped.y;
     });
 
   const panGesture = Gesture.Pan()
     .onUpdate(e => {
-      translateX.value = savedTranslateX.value + e.translationX;
-      translateY.value = savedTranslateY.value + e.translationY;
+      const clamped = clampTranslation(
+        savedTranslateX.value + e.translationX,
+        savedTranslateY.value + e.translationY,
+        scale.value,
+        imageSize,
+        containerSize
+      );
+      translateX.value = clamped.x;
+      translateY.value = clamped.y;
     })
     .onEnd(() => {
       savedTranslateX.value = translateX.value;
@@ -78,14 +174,43 @@ export const LocationMapScreen: React.FC = () => {
         savedTranslateY.value = 0;
       } else {
         // Zoom in to 2x
-        scale.value = withTiming(2);
-        savedScale.value = 2;
+        const targetScale = 2;
+        const clamped = clampTranslation(
+          translateX.value,
+          translateY.value,
+          targetScale,
+          imageSize,
+          containerSize
+        );
+        scale.value = withTiming(targetScale);
+        savedScale.value = targetScale;
+        translateX.value = withTiming(clamped.x);
+        translateY.value = withTiming(clamped.y);
+        savedTranslateX.value = clamped.x;
+        savedTranslateY.value = clamped.y;
       }
     });
 
+  const longPress = Gesture.LongPress().onStart(e => {
+    const normalized = containerPointToNormalized(
+      { x: e.x, y: e.y },
+      containerSize,
+      imageSize,
+      {
+        scale: scale.value,
+        translateX: translateX.value,
+        translateY: translateY.value,
+      }
+    );
+    if (normalized) {
+      runOnJS(handleLongPress)(normalized);
+    }
+  });
+
   const composedGesture = Gesture.Simultaneous(
     doubleTap,
-    Gesture.Simultaneous(pinchGesture, panGesture)
+    Gesture.Simultaneous(pinchGesture, panGesture),
+    longPress
   );
 
   const animatedStyle = useAnimatedStyle(() => ({
@@ -96,13 +221,14 @@ export const LocationMapScreen: React.FC = () => {
     ],
   }));
 
+  const placedLocations = locations.filter(location => location.mapCoordinates);
+
   return (
     <View style={styles.container}>
       <GestureDetector gesture={composedGesture}>
-        <Animated.View style={styles.imageContainer}>
+        <View style={styles.imageContainer} onLayout={handleContainerLayout}>
           {imageSize.width > 0 ? (
-            <Animated.Image
-              source={mapImage}
+            <Animated.View
               style={[
                 {
                   width: imageSize.width,
@@ -110,15 +236,45 @@ export const LocationMapScreen: React.FC = () => {
                 },
                 animatedStyle,
               ]}
-              resizeMode="contain"
-            />
+            >
+              <Image
+                source={mapImage}
+                style={styles.mapImage}
+                resizeMode="contain"
+              />
+              {placedLocations.map(location => (
+                <LocationMarker
+                  key={location.id}
+                  location={location}
+                  imageWidth={imageSize.width}
+                  imageHeight={imageSize.height}
+                  scale={scale}
+                  onPress={setSelectedLocation}
+                />
+              ))}
+            </Animated.View>
           ) : (
             <View style={styles.loadingContainer}>
               <Text style={styles.loadingText}>Loading map...</Text>
             </View>
           )}
-        </Animated.View>
+        </View>
       </GestureDetector>
+
+      {selectedLocation && (
+        <MapInfoCard
+          location={selectedLocation}
+          onViewDetails={handleViewDetails}
+          onClose={() => setSelectedLocation(null)}
+        />
+      )}
+
+      <MapLocationPickerModal
+        visible={pendingCoords !== null}
+        locations={locations}
+        onSelect={handlePlaceLocation}
+        onCancel={() => setPendingCoords(null)}
+      />
     </View>
   );
 };
@@ -131,6 +287,10 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  mapImage: {
+    width: '100%',
+    height: '100%',
   },
   loadingContainer: {
     flex: 1,

--- a/src/utils/mapCoordinates.ts
+++ b/src/utils/mapCoordinates.ts
@@ -1,0 +1,83 @@
+export interface Size {
+  width: number;
+  height: number;
+}
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface MapTransform {
+  scale: number;
+  translateX: number;
+  translateY: number;
+}
+
+/**
+ * Converts a normalized (0-1) image coordinate to a position relative to the
+ * top-left of the image, in the image's own (untransformed) pixel space.
+ */
+export function normalizedToImagePoint(coords: Point, image: Size): Point {
+  'worklet';
+  return {
+    x: coords.x * image.width,
+    y: coords.y * image.height,
+  };
+}
+
+/**
+ * Converts a point in the (untransformed) map container's coordinate space
+ * — e.g. a long-press event's `x`/`y` — into normalized (0-1) image
+ * coordinates, accounting for the image being centered in the container and
+ * transformed by `[translateX, translateY, scale]` about its own center.
+ *
+ * Returns `null` when the point falls outside the image bounds (the
+ * letterboxed area around it).
+ */
+export function containerPointToNormalized(
+  point: Point,
+  container: Size,
+  image: Size,
+  transform: MapTransform
+): Point | null {
+  'worklet';
+  const { scale, translateX, translateY } = transform;
+
+  const localX =
+    (point.x - container.width / 2 - translateX) / scale + image.width / 2;
+  const localY =
+    (point.y - container.height / 2 - translateY) / scale + image.height / 2;
+
+  const x = image.width > 0 ? localX / image.width : 0;
+  const y = image.height > 0 ? localY / image.height : 0;
+
+  if (x < 0 || x > 1 || y < 0 || y > 1) {
+    return null;
+  }
+
+  return { x, y };
+}
+
+/**
+ * Clamps pan translation so the scaled image can never be panned away from
+ * fully covering (or, when smaller than the container, staying centered
+ * within) the container. At scale 1 the image is fit-to-screen, so both
+ * bounds collapse to 0 and translation is pinned to the origin.
+ */
+export function clampTranslation(
+  translateX: number,
+  translateY: number,
+  scale: number,
+  image: Size,
+  container: Size
+): Point {
+  'worklet';
+  const maxX = Math.max(0, (scale * image.width - container.width) / 2);
+  const maxY = Math.max(0, (scale * image.height - container.height) / 2);
+
+  return {
+    x: Math.min(maxX, Math.max(-maxX, translateX)) || 0,
+    y: Math.min(maxY, Math.max(-maxY, translateY)) || 0,
+  };
+}

--- a/tst/components/map/MapInfoCard.test.tsx
+++ b/tst/components/map/MapInfoCard.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { MapInfoCard } from '@components/map/MapInfoCard';
+import { makeLocation } from '../../helpers/factories';
+
+describe('MapInfoCard', () => {
+  it('renders the location name and description', () => {
+    const location = makeLocation({
+      name: 'The Docks',
+      description: 'A rundown pier on the east side.',
+    });
+
+    const { getByText } = render(
+      <MapInfoCard
+        location={location}
+        onViewDetails={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(getByText('The Docks')).toBeTruthy();
+    expect(getByText('A rundown pier on the east side.')).toBeTruthy();
+  });
+
+  it('calls onViewDetails with the location id when the button is pressed', () => {
+    const location = makeLocation({ id: 'loc-42', name: 'The Docks' });
+    const onViewDetails = jest.fn();
+
+    const { getByText } = render(
+      <MapInfoCard
+        location={location}
+        onViewDetails={onViewDetails}
+        onClose={jest.fn()}
+      />
+    );
+
+    fireEvent.press(getByText('View details'));
+
+    expect(onViewDetails).toHaveBeenCalledWith('loc-42');
+  });
+
+  it('calls onClose when the close button is pressed', () => {
+    const location = makeLocation({ name: 'The Docks' });
+    const onClose = jest.fn();
+
+    const { getByText } = render(
+      <MapInfoCard
+        location={location}
+        onViewDetails={jest.fn()}
+        onClose={onClose}
+      />
+    );
+
+    fireEvent.press(getByText('✕'));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/tst/components/map/MapLocationPickerModal.test.tsx
+++ b/tst/components/map/MapLocationPickerModal.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { MapLocationPickerModal } from '@components/map/MapLocationPickerModal';
+import { makeLocation } from '../../helpers/factories';
+
+describe('MapLocationPickerModal', () => {
+  it('lists every saved location', () => {
+    const locations = [
+      makeLocation({ id: 'loc-1', name: 'The Docks' }),
+      makeLocation({ id: 'loc-2', name: 'Rust Alley' }),
+    ];
+
+    const { getByText } = render(
+      <MapLocationPickerModal
+        visible
+        locations={locations}
+        onSelect={jest.fn()}
+        onCancel={jest.fn()}
+      />
+    );
+
+    expect(getByText('The Docks')).toBeTruthy();
+    expect(getByText('Rust Alley')).toBeTruthy();
+  });
+
+  it('shows a "placed" badge only for locations that already have coordinates', () => {
+    const locations = [
+      makeLocation({
+        id: 'loc-1',
+        name: 'The Docks',
+        mapCoordinates: { x: 0.5, y: 0.5 },
+      }),
+      makeLocation({ id: 'loc-2', name: 'Rust Alley' }),
+    ];
+
+    const { getAllByText } = render(
+      <MapLocationPickerModal
+        visible
+        locations={locations}
+        onSelect={jest.fn()}
+        onCancel={jest.fn()}
+      />
+    );
+
+    expect(getAllByText('placed')).toHaveLength(1);
+  });
+
+  it('shows an empty state when there are no saved locations', () => {
+    const { getByText } = render(
+      <MapLocationPickerModal
+        visible
+        locations={[]}
+        onSelect={jest.fn()}
+        onCancel={jest.fn()}
+      />
+    );
+
+    expect(getByText('No saved locations yet. Create one first.')).toBeTruthy();
+  });
+
+  it('calls onSelect with the location id when a row is pressed', () => {
+    const locations = [makeLocation({ id: 'loc-1', name: 'The Docks' })];
+    const onSelect = jest.fn();
+
+    const { getByText } = render(
+      <MapLocationPickerModal
+        visible
+        locations={locations}
+        onSelect={onSelect}
+        onCancel={jest.fn()}
+      />
+    );
+
+    fireEvent.press(getByText('The Docks'));
+
+    expect(onSelect).toHaveBeenCalledWith('loc-1');
+  });
+
+  it('calls onCancel when the cancel button is pressed', () => {
+    const onCancel = jest.fn();
+
+    const { getByText } = render(
+      <MapLocationPickerModal
+        visible
+        locations={[]}
+        onSelect={jest.fn()}
+        onCancel={onCancel}
+      />
+    );
+
+    fireEvent.press(getByText('Cancel'));
+
+    expect(onCancel).toHaveBeenCalled();
+  });
+});

--- a/tst/screens/location/LocationMapScreen.test.tsx
+++ b/tst/screens/location/LocationMapScreen.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { Image } from 'react-native';
+import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
+import { Gesture } from 'react-native-gesture-handler';
+import { LocationMapScreen } from '@screens/location/LocationMapScreen';
+import { getStorageMock, primeStorageDefaults } from '../../helpers/storage';
+import { makeLocation } from '../../helpers/factories';
+import {
+  installNavigationMock,
+  resetNavigationMocks,
+} from '../../helpers/navigation';
+
+jest.mock('@utils/characterStorage');
+
+const storage = getStorageMock();
+
+// Small, well below any real screen size, so the fit-to-screen scale in
+// LocationMapScreen never kicks in and imageSize == {300, 200} exactly.
+const IMAGE_SIZE = { width: 300, height: 200 };
+
+const getLatestLongPressStub = () => {
+  const results = (Gesture.LongPress as jest.Mock).mock.results;
+  return results[results.length - 1].value;
+};
+
+describe('LocationMapScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    primeStorageDefaults();
+    jest.spyOn(Image, 'resolveAssetSource').mockReturnValue({
+      width: IMAGE_SIZE.width,
+      height: IMAGE_SIZE.height,
+      uri: 'test-map-uri',
+      scale: 1,
+    });
+  });
+
+  afterEach(() => {
+    resetNavigationMocks();
+  });
+
+  it('renders markers only for locations that have map coordinates', async () => {
+    storage.loadLocations.mockResolvedValue([
+      makeLocation({
+        id: 'loc-placed',
+        name: 'The Docks',
+        mapCoordinates: { x: 0.5, y: 0.5 },
+      }),
+      makeLocation({ id: 'loc-unplaced', name: 'Rust Alley' }),
+    ]);
+
+    const { getByLabelText, queryByLabelText } = render(<LocationMapScreen />);
+
+    await waitFor(() => {
+      expect(getByLabelText('The Docks')).toBeTruthy();
+    });
+    expect(queryByLabelText('Rust Alley')).toBeNull();
+  });
+
+  it('shows the info card with a "View details" link when a marker is pressed', async () => {
+    storage.loadLocations.mockResolvedValue([
+      makeLocation({
+        id: 'loc-1',
+        name: 'The Docks',
+        description: 'A rundown pier.',
+        mapCoordinates: { x: 0.5, y: 0.5 },
+      }),
+    ]);
+
+    const { getByLabelText, findByText } = render(<LocationMapScreen />);
+
+    const marker = await waitFor(() => getByLabelText('The Docks'));
+    fireEvent.press(marker);
+
+    expect(await findByText('A rundown pier.')).toBeTruthy();
+    expect(await findByText('View details')).toBeTruthy();
+  });
+
+  it('navigates to LocationDetails with the location id from the info card', async () => {
+    storage.loadLocations.mockResolvedValue([
+      makeLocation({
+        id: 'loc-1',
+        name: 'The Docks',
+        mapCoordinates: { x: 0.5, y: 0.5 },
+      }),
+    ]);
+    const nav = installNavigationMock();
+
+    const { getByLabelText, findByText } = render(<LocationMapScreen />);
+
+    const marker = await waitFor(() => getByLabelText('The Docks'));
+    fireEvent.press(marker);
+
+    fireEvent.press(await findByText('View details'));
+
+    expect(nav.navigate).toHaveBeenCalledWith('LocationDetails', {
+      locationId: 'loc-1',
+    });
+  });
+
+  it('places a location at the long-pressed coordinates via the picker', async () => {
+    storage.loadLocations.mockResolvedValue([
+      makeLocation({ id: 'loc-1', name: 'The Docks' }),
+    ]);
+    storage.updateLocation.mockResolvedValue(
+      makeLocation({
+        id: 'loc-1',
+        name: 'The Docks',
+        mapCoordinates: { x: 0.5, y: 0.5 },
+      })
+    );
+
+    const { findByText } = render(<LocationMapScreen />);
+
+    // Let the initial `loadLocations()` from `useFocusEffect` resolve before
+    // long-pressing, so the picker has the location to list.
+    const loadCallsBeforePlacement = () =>
+      storage.loadLocations.mock.calls.length;
+    await waitFor(() => expect(loadCallsBeforePlacement()).toBeGreaterThan(0));
+    const callsBeforePlacement = loadCallsBeforePlacement();
+
+    const longPressStub = getLatestLongPressStub();
+    act(() => {
+      longPressStub.callbacks.onStart({ x: 0, y: 0 });
+    });
+
+    fireEvent.press(await findByText('The Docks'));
+
+    await waitFor(() => {
+      expect(storage.updateLocation).toHaveBeenCalledWith('loc-1', {
+        mapCoordinates: { x: 0.5, y: 0.5 },
+      });
+    });
+    // Placement reloads the location list so the new marker appears.
+    await waitFor(() => {
+      expect(loadCallsBeforePlacement()).toBeGreaterThan(callsBeforePlacement);
+    });
+  });
+});

--- a/tst/utils/mapCoordinates.test.ts
+++ b/tst/utils/mapCoordinates.test.ts
@@ -1,0 +1,204 @@
+import {
+  normalizedToImagePoint,
+  containerPointToNormalized,
+  clampTranslation,
+} from '@/utils/mapCoordinates';
+
+describe('mapCoordinates', () => {
+  describe('normalizedToImagePoint', () => {
+    it('scales normalized coordinates to image pixel space', () => {
+      expect(
+        normalizedToImagePoint({ x: 0.5, y: 0.25 }, { width: 400, height: 200 })
+      ).toEqual({ x: 200, y: 50 });
+    });
+
+    it('maps corners to image bounds', () => {
+      const image = { width: 300, height: 150 };
+      expect(normalizedToImagePoint({ x: 0, y: 0 }, image)).toEqual({
+        x: 0,
+        y: 0,
+      });
+      expect(normalizedToImagePoint({ x: 1, y: 1 }, image)).toEqual({
+        x: 300,
+        y: 150,
+      });
+    });
+  });
+
+  describe('containerPointToNormalized', () => {
+    const image = { width: 400, height: 200 };
+    const container = { width: 400, height: 200 };
+
+    it('round-trips with normalizedToImagePoint at scale 1, no translation', () => {
+      const transform = { scale: 1, translateX: 0, translateY: 0 };
+      const cases = [
+        { x: 0, y: 0 },
+        { x: 1, y: 1 },
+        { x: 0.5, y: 0.5 },
+        { x: 0.25, y: 0.75 },
+      ];
+
+      for (const norm of cases) {
+        const imagePoint = normalizedToImagePoint(norm, image);
+        // Container is centered on the image at scale 1 with no translation,
+        // so container-space == image-space here.
+        const result = containerPointToNormalized(
+          imagePoint,
+          container,
+          image,
+          transform
+        );
+        expect(result?.x).toBeCloseTo(norm.x);
+        expect(result?.y).toBeCloseTo(norm.y);
+      }
+    });
+
+    it('round-trips at scale 2 with nonzero translation', () => {
+      const scale = 2;
+      const translateX = 30;
+      const translateY = -15;
+      const transform = { scale, translateX, translateY };
+
+      const norm = { x: 0.75, y: 0.2 };
+      const local = normalizedToImagePoint(norm, image);
+      const screenPoint = {
+        x:
+          container.width / 2 +
+          translateX +
+          scale * (local.x - image.width / 2),
+        y:
+          container.height / 2 +
+          translateY +
+          scale * (local.y - image.height / 2),
+      };
+
+      const result = containerPointToNormalized(
+        screenPoint,
+        container,
+        image,
+        transform
+      );
+      expect(result?.x).toBeCloseTo(norm.x);
+      expect(result?.y).toBeCloseTo(norm.y);
+    });
+
+    it('round-trips at scale 3 with nonzero translation', () => {
+      const scale = 3;
+      const translateX = -50;
+      const translateY = 40;
+      const transform = { scale, translateX, translateY };
+
+      const norm = { x: 0.1, y: 0.9 };
+      const local = normalizedToImagePoint(norm, image);
+      const screenPoint = {
+        x:
+          container.width / 2 +
+          translateX +
+          scale * (local.x - image.width / 2),
+        y:
+          container.height / 2 +
+          translateY +
+          scale * (local.y - image.height / 2),
+      };
+
+      const result = containerPointToNormalized(
+        screenPoint,
+        container,
+        image,
+        transform
+      );
+      expect(result?.x).toBeCloseTo(norm.x);
+      expect(result?.y).toBeCloseTo(norm.y);
+    });
+
+    it('returns null for a press on the letterboxed area', () => {
+      const transform = { scale: 1, translateX: 0, translateY: 0 };
+      // Way outside the image bounds.
+      const result = containerPointToNormalized(
+        { x: -100, y: -100 },
+        container,
+        image,
+        transform
+      );
+      expect(result).toBeNull();
+    });
+
+    it('returns null just past each edge of the image', () => {
+      const transform = { scale: 1, translateX: 0, translateY: 0 };
+      expect(
+        containerPointToNormalized(
+          { x: -1, y: 100 },
+          container,
+          image,
+          transform
+        )
+      ).toBeNull();
+      expect(
+        containerPointToNormalized(
+          { x: 401, y: 100 },
+          container,
+          image,
+          transform
+        )
+      ).toBeNull();
+      expect(
+        containerPointToNormalized(
+          { x: 200, y: -1 },
+          container,
+          image,
+          transform
+        )
+      ).toBeNull();
+      expect(
+        containerPointToNormalized(
+          { x: 200, y: 201 },
+          container,
+          image,
+          transform
+        )
+      ).toBeNull();
+    });
+  });
+
+  describe('clampTranslation', () => {
+    const image = { width: 300, height: 150 };
+    const container = { width: 300, height: 150 };
+
+    it('pins translation to 0 at scale 1 (fit-to-screen)', () => {
+      expect(clampTranslation(80, -40, 1, image, container)).toEqual({
+        x: 0,
+        y: 0,
+      });
+    });
+
+    it('clamps to symmetric bounds of (scale*size - container)/2 when zoomed', () => {
+      const scale = 2;
+      // scale*width - container.width = 600 - 300 = 300, so maxX = 150
+      // scale*height - container.height = 300 - 150 = 150, so maxY = 75
+      expect(clampTranslation(1000, 1000, scale, image, container)).toEqual({
+        x: 150,
+        y: 75,
+      });
+      expect(clampTranslation(-1000, -1000, scale, image, container)).toEqual({
+        x: -150,
+        y: -75,
+      });
+    });
+
+    it('leaves in-bounds translation untouched', () => {
+      const scale = 3;
+      expect(clampTranslation(10, -5, scale, image, container)).toEqual({
+        x: 10,
+        y: -5,
+      });
+    });
+
+    it('stays 0 on an axis where the scaled image still fits the container', () => {
+      // A container much taller than the image means the height axis never
+      // needs to pan even when zoomed in.
+      const tallContainer = { width: 300, height: 1000 };
+      const result = clampTranslation(50, 500, 2, image, tallContainer);
+      expect(result.y).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #103.

- Renders clickable markers on `LocationMapScreen` for saved locations that have `mapCoordinates`; markers stay anchored to their image coordinates through pan, pinch-zoom, and double-tap-zoom (they're mounted inside the transformed view and counter-scale to keep a constant screen size).
- Tapping a marker shows a bottom info card with the location's name, description, and a "View details" button that navigates to `LocationDetails`.
- Long-pressing the map opens a picker of saved locations; selecting one places (or repositions) it at the pressed spot via `updateLocation`.
- Pans and zooms are now clamped so the map image can never be dragged off-screen — at the fit-to-screen scale (1x) translation is pinned to the origin, matching the issue's requirement.
- Adds `src/utils/mapCoordinates.ts`, a small set of pure "worklet" functions for the forward/inverse coordinate math and pan clamping, unit-tested independently of any gesture/reanimated machinery.
- Adds `src/components/map/{LocationMarker,MapInfoCard,MapLocationPickerModal}.tsx`, exported from the components barrel.
- Extends the `react-native-gesture-handler` / `react-native-reanimated` mocks in `jest.setup.js` (previously too thin to render this screen at all) so `LocationMapScreen` can finally be tested.

No data-format or storage-signature changes — `GameLocation.mapCoordinates` and `updateLocation` already supported this and were simply unused until now.

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint` (0 errors; pre-existing warnings elsewhere untouched)
- [x] `npm run format:check`
- [x] `npm test` — 38 suites / 405 tests passing, including new coverage:
  - `tst/utils/mapCoordinates.test.ts` — coordinate round-trips at multiple scales/translations, letterbox rejection, pan-clamp bounds
  - `tst/components/map/MapInfoCard.test.tsx`, `tst/components/map/MapLocationPickerModal.test.tsx`
  - `tst/screens/location/LocationMapScreen.test.tsx` — marker rendering, marker tap → info card → navigation, and the long-press → picker → `updateLocation` → reload flow
- [ ] Manual verification in Expo (pan/zoom clamping at screen edges, marker anchoring while pinching/panning, long-press placement) — not done in this sandboxed session; recommended before merging a UI-heavy change like this.


---
_Generated by [Claude Code](https://claude.ai/code/session_011h7TF3pN1dwWF2uT63ggJf)_