### PR TITLE
Complete single→multi image migration (imageUri → imageUris[])

### DIFF
--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -13,7 +13,6 @@ export interface GameLocation {
   id: string;
   name: string;
   description: string;
-  imageUri?: string; // Deprecated: Use imageUris instead
   imageUris?: string[];
   mapCoordinates?: {
     x: number; // Normalized coordinate (0-1) representing position on map
@@ -88,7 +87,6 @@ export interface GameCharacter {
   distinctionIds: DistinctionId[];
   factions: Faction[];
   relationships: Relationship[];
-  imageUri?: string; // Deprecated: Use imageUris instead
   imageUris?: string[];
   notes?: string;
   locationId?: string; // Reference to GameLocation.id
@@ -121,7 +119,6 @@ export interface GameEvent {
   characterIds?: string[]; // References to GameCharacter.id
   factionNames?: string[]; // Faction names involved in the event
   notes?: string;
-  imageUri?: string; // Deprecated: Use imageUris instead
   imageUris?: string[];
   certaintyLevel?: CertaintyLevel; // Certainty level: unconfirmed, confirmed, or disputed
   createdAt: string;
@@ -176,7 +173,6 @@ export interface GameQuest {
   requiredMaterials?: QuestMaterial[];
   teamSize?: number; // Desired team size for proposal generation
   notes?: string;
-  imageUri?: string; // Deprecated: Use imageUris instead
   imageUris?: string[];
   createdAt: string;
   updatedAt: string;

--- a/src/screens/character/CharacterDetailScreen.tsx
+++ b/src/screens/character/CharacterDetailScreen.tsx
@@ -478,20 +478,14 @@ export const CharacterDetailScreen: React.FC = () => {
       }}
     >
       <View style={styles.header}>
-        {((character.imageUris && character.imageUris.length > 0) ||
-          character.imageUri) && (
+        {character.imageUris && character.imageUris.length > 0 && (
           <ScrollView
             horizontal
             showsHorizontalScrollIndicator={false}
             style={styles.imageGallery}
             contentContainerStyle={styles.imageGalleryContent}
           >
-            {(character.imageUris && character.imageUris.length > 0
-              ? character.imageUris
-              : character.imageUri
-                ? [character.imageUri]
-                : []
-            ).map((uri, index) => (
+            {character.imageUris.map((uri, index) => (
               <View key={index} style={styles.imageContainer}>
                 <Image source={{ uri }} style={styles.characterImage} />
               </View>

--- a/src/screens/character/CharacterFormScreen.tsx
+++ b/src/screens/character/CharacterFormScreen.tsx
@@ -73,10 +73,7 @@ export const CharacterFormScreen: React.FC = () => {
           relationships: [...(editingCharacter.relationships || [])],
           notes: editingCharacter.notes || '',
           occupation: editingCharacter.occupation || '',
-          imageUri: editingCharacter.imageUri,
-          imageUris:
-            editingCharacter.imageUris ||
-            (editingCharacter.imageUri ? [editingCharacter.imageUri] : []),
+          imageUris: editingCharacter.imageUris || [],
           locationId: editingCharacter.locationId,
           retired: editingCharacter.retired,
           cyberware: [...(editingCharacter.cyberware || [])],
@@ -90,7 +87,6 @@ export const CharacterFormScreen: React.FC = () => {
           relationships: [],
           notes: '',
           occupation: '',
-          imageUri: undefined,
           imageUris: [],
           locationId: undefined,
           retired: false,
@@ -226,10 +222,6 @@ export const CharacterFormScreen: React.FC = () => {
       const newImageUri = result.assets[0].uri;
       const currentImages = form.imageUris || [];
       handleChange('imageUris', [...currentImages, newImageUri]);
-      // Keep imageUri for backward compatibility (first image)
-      if (currentImages.length === 0) {
-        handleChange('imageUri', newImageUri);
-      }
     }
   };
 
@@ -237,8 +229,6 @@ export const CharacterFormScreen: React.FC = () => {
     const currentImages = form.imageUris || [];
     const newImages = currentImages.filter((_, i) => i !== index);
     handleChange('imageUris', newImages);
-    // Update imageUri for backward compatibility
-    handleChange('imageUri', newImages.length > 0 ? newImages[0] : undefined);
   };
 
   const handleSubmit = async () => {

--- a/src/screens/character/CharacterListScreen.tsx
+++ b/src/screens/character/CharacterListScreen.tsx
@@ -12,6 +12,7 @@ import {
   loadCharacters,
   toggleCharacterPresent,
   resetAllPresentStatus,
+  migrateImageUris,
 } from '@utils/characterStorage';
 import {
   useNavigation,
@@ -40,6 +41,9 @@ export const CharacterListScreen: React.FC = () => {
   const navigation = useNavigation<NavigationProp>();
 
   const loadData = React.useCallback(async () => {
+    // Run migration on first load (idempotent operation)
+    await migrateImageUris();
+
     const data = await loadCharacters();
     setCharacters(data);
   }, []);

--- a/src/screens/events/EventsDetailScreen.tsx
+++ b/src/screens/events/EventsDetailScreen.tsx
@@ -96,14 +96,9 @@ export const EventsDetailScreen: React.FC = () => {
       }}
     >
       {/* Event Images */}
-      {((event.imageUris && event.imageUris.length > 0) || event.imageUri) && (
+      {event.imageUris && event.imageUris.length > 0 && (
         <View style={styles.imageGallery}>
-          {(event.imageUris && event.imageUris.length > 0
-            ? event.imageUris
-            : event.imageUri
-              ? [event.imageUri]
-              : []
-          ).map((uri, index) => (
+          {event.imageUris.map((uri, index) => (
             <View key={index} style={styles.imageContainer}>
               <Image source={{ uri }} style={styles.eventImage} />
             </View>

--- a/src/screens/events/EventsFormScreen.tsx
+++ b/src/screens/events/EventsFormScreen.tsx
@@ -40,7 +40,6 @@ interface EventFormData {
   characterIds: string[];
   factionNames: string[];
   notes: string;
-  imageUri?: string;
   imageUris?: string[];
   certaintyLevel: CertaintyLevel;
 }
@@ -66,7 +65,6 @@ export const EventsFormScreen: React.FC = () => {
     characterIds: [],
     factionNames: [],
     notes: '',
-    imageUri: undefined,
     imageUris: [],
     certaintyLevel: 'confirmed',
   });
@@ -111,8 +109,7 @@ export const EventsFormScreen: React.FC = () => {
         characterIds: event.characterIds || [],
         factionNames: event.factionNames || [],
         notes: event.notes || '',
-        imageUri: event.imageUri,
-        imageUris: event.imageUris || (event.imageUri ? [event.imageUri] : []),
+        imageUris: event.imageUris || [],
         certaintyLevel: event.certaintyLevel || 'confirmed',
       });
     }
@@ -145,7 +142,6 @@ export const EventsFormScreen: React.FC = () => {
       setFormData({
         ...formData,
         imageUris: newImages,
-        imageUri: newImages[0], // Keep first image for backward compatibility
       });
     }
   };
@@ -156,7 +152,6 @@ export const EventsFormScreen: React.FC = () => {
     setFormData({
       ...formData,
       imageUris: newImages,
-      imageUri: newImages.length > 0 ? newImages[0] : undefined,
     });
   };
 

--- a/src/screens/events/EventsListScreen.tsx
+++ b/src/screens/events/EventsListScreen.tsx
@@ -177,9 +177,9 @@ export const EventsTimelineScreen: React.FC = () => {
             {formatEventDateShort(item.date, item.time)}
           </Text>
         </View>
-        {item.imageUri && (
+        {item.imageUris && item.imageUris.length > 0 && (
           <Image
-            source={{ uri: item.imageUri }}
+            source={{ uri: item.imageUris[0] }}
             style={styles.eventThumbnail}
           />
         )}

--- a/src/screens/faction/FactionFormScreen.tsx
+++ b/src/screens/faction/FactionFormScreen.tsx
@@ -35,7 +35,6 @@ type FactionFormRouteProp = RouteProp<RootStackParamList, 'FactionForm'>;
 interface FactionFormData {
   name: string;
   description: string;
-  imageUri?: string;
   imageUris?: string[];
   relationships?: FactionRelationship[];
   retired?: boolean;
@@ -49,7 +48,6 @@ export const FactionFormScreen: React.FC = () => {
   const [formData, setFormData] = useState<FactionFormData>({
     name: '',
     description: '',
-    imageUri: undefined,
     imageUris: [],
     relationships: [],
     retired: false,
@@ -81,9 +79,7 @@ export const FactionFormScreen: React.FC = () => {
           setFormData({
             name: faction.name,
             description: faction.description,
-            imageUri: faction.imageUri,
-            imageUris:
-              faction.imageUris || (faction.imageUri ? [faction.imageUri] : []),
+            imageUris: faction.imageUris || [],
             relationships: faction.relationships || [],
             retired: faction.retired ?? false,
           });
@@ -126,7 +122,6 @@ export const FactionFormScreen: React.FC = () => {
       setFormData({
         ...formData,
         imageUris: [...currentImages, newImageUri],
-        imageUri: currentImages.length === 0 ? newImageUri : formData.imageUri,
       });
     }
   };
@@ -137,7 +132,6 @@ export const FactionFormScreen: React.FC = () => {
     setFormData({
       ...formData,
       imageUris: newImages,
-      imageUri: newImages.length > 0 ? newImages[0] : undefined,
     });
   };
 
@@ -248,7 +242,6 @@ export const FactionFormScreen: React.FC = () => {
         const updated = await updateFaction(factionName, {
           name: formData.name.trim(),
           description: formData.description.trim(),
-          imageUri: formData.imageUri,
           imageUris: formData.imageUris,
           relationships: formData.relationships || [],
           retired: formData.retired,
@@ -273,7 +266,6 @@ export const FactionFormScreen: React.FC = () => {
         const success = await createFaction({
           name: formData.name.trim(),
           description: formData.description.trim(),
-          imageUri: formData.imageUri,
           imageUris: formData.imageUris,
           relationships: formData.relationships || [],
           retired: formData.retired,

--- a/src/screens/location/LocationDetailScreen.tsx
+++ b/src/screens/location/LocationDetailScreen.tsx
@@ -157,20 +157,14 @@ export const LocationDetailsScreen: React.FC = () => {
         <Text style={styles.locationName}>{location.name}</Text>
 
         {/* Location Images */}
-        {((location.imageUris && location.imageUris.length > 0) ||
-          location.imageUri) && (
+        {location.imageUris && location.imageUris.length > 0 && (
           <ScrollView
             horizontal
             showsHorizontalScrollIndicator={false}
             style={styles.imageGallery}
             contentContainerStyle={styles.imageGalleryContent}
           >
-            {(location.imageUris && location.imageUris.length > 0
-              ? location.imageUris
-              : location.imageUri
-                ? [location.imageUri]
-                : []
-            ).map((uri, index) => (
+            {location.imageUris.map((uri, index) => (
               <View key={index} style={styles.imageContainer}>
                 <Image
                   source={{ uri }}

--- a/src/screens/location/LocationFormScreen.tsx
+++ b/src/screens/location/LocationFormScreen.tsx
@@ -27,7 +27,6 @@ type LocationFormRouteProp = RouteProp<RootStackParamList, 'LocationForm'>;
 interface LocationFormData {
   name: string;
   description: string;
-  imageUri?: string;
   imageUris?: string[];
 }
 
@@ -39,7 +38,6 @@ export const LocationFormScreen: React.FC = () => {
   const [formData, setFormData] = useState<LocationFormData>({
     name: '',
     description: '',
-    imageUri: undefined,
     imageUris: [],
   });
 
@@ -52,9 +50,7 @@ export const LocationFormScreen: React.FC = () => {
       setFormData({
         name: location.name,
         description: location.description,
-        imageUri: location.imageUri,
-        imageUris:
-          location.imageUris || (location.imageUri ? [location.imageUri] : []),
+        imageUris: location.imageUris || [],
       });
     }
   }, [location]);
@@ -86,7 +82,6 @@ export const LocationFormScreen: React.FC = () => {
       setFormData({
         ...formData,
         imageUris: newImages,
-        imageUri: newImages[0], // Keep first image for backward compatibility
       });
     }
   };
@@ -97,7 +92,6 @@ export const LocationFormScreen: React.FC = () => {
     setFormData({
       ...formData,
       imageUris: newImages,
-      imageUri: newImages.length > 0 ? newImages[0] : undefined,
     });
   };
 
@@ -127,7 +121,6 @@ export const LocationFormScreen: React.FC = () => {
         const updated = await updateLocation(location.id, {
           name: formData.name.trim(),
           description: formData.description.trim(),
-          imageUri: formData.imageUri,
           imageUris: formData.imageUris,
         });
 
@@ -146,7 +139,6 @@ export const LocationFormScreen: React.FC = () => {
         const newLocation = await createLocation({
           name: formData.name.trim(),
           description: formData.description.trim(),
-          imageUri: formData.imageUri,
           imageUris: formData.imageUris,
         });
 

--- a/src/utils/characterStorage.ts
+++ b/src/utils/characterStorage.ts
@@ -24,7 +24,6 @@ export interface FactionRelationship {
 export interface StoredFaction {
   name: string;
   description: string;
-  imageUri?: string; // Deprecated: Use imageUris instead
   imageUris?: string[];
   relationships?: FactionRelationship[];
   retired?: boolean;
@@ -37,6 +36,35 @@ interface FactionDataset {
   version: string;
   lastUpdated: string;
 }
+
+// Runtime-only shape for entities that may still carry the deprecated single
+// `imageUri` field. The domain types (GameCharacter, GameLocation, GameEvent,
+// GameQuest, StoredFaction) no longer declare it, but data persisted before
+// this migration still has it on disk.
+interface LegacyImageEntity {
+  imageUri?: string;
+  imageUris?: string[];
+}
+
+// Backfill a legacy single `imageUri` into `imageUris` (when `imageUris` is
+// empty) and strip the deprecated field. Used both for in-memory
+// normalization on every load and for the one-time persisted migration
+// below (`migrateImageUris`).
+const normalizeImageUris = <T extends { imageUris?: string[] }>(
+  entity: T
+): T => {
+  const raw = entity as unknown as T & LegacyImageEntity;
+  if (raw.imageUri === undefined) return entity;
+
+  const { imageUri, ...rest } = raw;
+  const imageUris =
+    rest.imageUris && rest.imageUris.length > 0 ? rest.imageUris : [imageUri];
+
+  return { ...rest, imageUris } as T;
+};
+
+const hasLegacyImageUri = (entity: { imageUris?: string[] }): boolean =>
+  (entity as unknown as LegacyImageEntity).imageUri !== undefined;
 
 const STORAGE_KEY = 'gameCharacterManager';
 const FACTION_STORAGE_KEY = 'gameCharacterManager_factions';
@@ -61,12 +89,14 @@ export const loadCharacters = async (): Promise<GameCharacter[]> => {
   if (!dataset || !dataset.characters) return [];
 
   // Handle backward compatibility - set defaults for missing properties
-  return dataset.characters.map(character => ({
-    ...character,
-    present: character.present ?? false,
-    retired: character.retired ?? false,
-    relationships: character.relationships ?? [],
-  }));
+  return dataset.characters.map(character =>
+    normalizeImageUris({
+      ...character,
+      present: character.present ?? false,
+      retired: character.retired ?? false,
+      relationships: character.relationships ?? [],
+    })
+  );
 };
 
 export const addCharacter = async (
@@ -280,8 +310,11 @@ export const importDataset = async (jsonData: string): Promise<boolean> => {
       const existingLocations = await loadLocations();
       const mergedLocations = [...existingLocations];
 
-      // Add or update locations from import
-      for (const importedLocation of dataset.locations) {
+      // Add or update locations from import. Normalize any legacy single
+      // `imageUri` from an older export/repo into `imageUris` so storage
+      // never picks the deprecated field back up.
+      for (const rawImportedLocation of dataset.locations) {
+        const importedLocation = normalizeImageUris(rawImportedLocation);
         const existingIndex = mergedLocations.findIndex(
           l => l.id === importedLocation.id
         );
@@ -308,9 +341,10 @@ export const importDataset = async (jsonData: string): Promise<boolean> => {
       await ensureLocationsExist(dataset.characters);
     }
 
-    // Handle character data
+    // Handle character data. Normalize any legacy single `imageUri` from an
+    // older export/repo into `imageUris` before persisting.
     const characterDataset: CharacterDataset = {
-      characters: dataset.characters || [],
+      characters: (dataset.characters || []).map(normalizeImageUris),
       version: dataset.version || '1.0',
       lastUpdated: dataset.lastUpdated || new Date().toISOString(),
     };
@@ -319,7 +353,7 @@ export const importDataset = async (jsonData: string): Promise<boolean> => {
     // Handle faction data if present
     if (dataset.factions) {
       const factionDataset: FactionDataset = {
-        factions: dataset.factions,
+        factions: dataset.factions.map(normalizeImageUris),
         version: dataset.version || '1.0',
         lastUpdated: dataset.lastUpdated || new Date().toISOString(),
       };
@@ -332,7 +366,7 @@ export const importDataset = async (jsonData: string): Promise<boolean> => {
     // Handle event data if present
     if (dataset.events) {
       const eventDataset: EventDataset = {
-        events: dataset.events,
+        events: dataset.events.map(normalizeImageUris),
         version: dataset.version || '1.0',
         lastUpdated: dataset.lastUpdated || new Date().toISOString(),
       };
@@ -342,7 +376,7 @@ export const importDataset = async (jsonData: string): Promise<boolean> => {
     // Handle quest data if present
     if (dataset.quests) {
       const questDataset: QuestDataset = {
-        quests: dataset.quests,
+        quests: dataset.quests.map(normalizeImageUris),
         version: dataset.version || '1.0',
         lastUpdated: dataset.lastUpdated || new Date().toISOString(),
       };
@@ -463,7 +497,6 @@ const mergeCharacterProperties = (
     'name',
     'species',
     'locationId',
-    'imageUri',
     'notes',
   ];
 
@@ -500,7 +533,9 @@ const mergeImportedCharacters = (
   const addedCharacters: GameCharacter[] = [];
   const conflicts: MergeConflict[] = [];
 
-  for (const importedChar of importedCharacters) {
+  // Normalize any legacy single `imageUri` from an older export/repo into
+  // `imageUris` before it can be merged/pushed into storage.
+  for (const importedChar of importedCharacters.map(normalizeImageUris)) {
     const existingIndex = currentData.findIndex(
       current => current.id === importedChar.id
     );
@@ -544,7 +579,9 @@ const applyFactionMerge = async (
   const mergedFactions = [...currentFactions];
   const existingFactionNames = new Set(currentFactions.map(f => f.name));
 
-  for (const importedFaction of importedFactions) {
+  // Normalize any legacy single `imageUri` from an older export/repo into
+  // `imageUris` before it can be merged/pushed into storage.
+  for (const importedFaction of importedFactions.map(normalizeImageUris)) {
     if (!existingFactionNames.has(importedFaction.name)) {
       mergedFactions.push(importedFaction);
     } else {
@@ -572,7 +609,9 @@ const applyLocationMerge = async (
   const mergedLocations = [...currentLocations];
   const existingLocationIds = new Set(currentLocations.map(l => l.id));
 
-  for (const importedLocation of importedLocations) {
+  // Normalize any legacy single `imageUri` from an older export/repo into
+  // `imageUris` before it can be merged/pushed into storage.
+  for (const importedLocation of importedLocations.map(normalizeImageUris)) {
     if (!existingLocationIds.has(importedLocation.id)) {
       mergedLocations.push(importedLocation);
     } else {
@@ -728,11 +767,13 @@ export const loadFactions = async (): Promise<StoredFaction[]> => {
   if (!dataset) return [];
 
   // Handle backward compatibility - set defaults for missing properties
-  return (dataset.factions || []).map(faction => ({
-    ...faction,
-    retired: faction.retired ?? false,
-    relationships: faction.relationships ?? [],
-  }));
+  return (dataset.factions || []).map(faction =>
+    normalizeImageUris({
+      ...faction,
+      retired: faction.retired ?? false,
+      relationships: faction.relationships ?? [],
+    })
+  );
 };
 
 export const getFactionDescription = async (
@@ -843,7 +884,6 @@ export const deleteFactionCompletely = async (
 export const createFaction = async (factionData: {
   name: string;
   description: string;
-  imageUri?: string;
   imageUris?: string[];
   relationships?: FactionRelationship[];
   retired?: boolean;
@@ -863,7 +903,6 @@ export const createFaction = async (factionData: {
     const newFaction: StoredFaction = {
       name: factionData.name,
       description: factionData.description,
-      imageUri: factionData.imageUri,
       imageUris: factionData.imageUris,
       relationships: factionData.relationships || [],
       retired: factionData.retired ?? false,
@@ -906,7 +945,6 @@ export const updateFaction = async (
   updates: {
     name?: string;
     description?: string;
-    imageUri?: string;
     imageUris?: string[];
     relationships?: FactionRelationship[];
     retired?: boolean;
@@ -1145,6 +1183,84 @@ export const migrateFactionDescriptions = async (): Promise<void> => {
   }
 };
 
+// Migration function to backfill the deprecated single `imageUri` field into
+// `imageUris` and strip it from persisted records. Idempotent - safe to call
+// on every app start (see CharacterListScreen.loadData).
+export const migrateImageUris = async (): Promise<void> => {
+  try {
+    await runExclusive(STORAGE_KEY, async () => {
+      const dataset =
+        await SafeAsyncStorageJSONParser.getItem<CharacterDataset>(STORAGE_KEY);
+      const characters = dataset?.characters;
+      if (!characters?.some(hasLegacyImageUri)) return;
+
+      await saveCharacters(characters.map(normalizeImageUris));
+    });
+  } catch (error) {
+    console.error('Error migrating character image URIs:', error);
+  }
+
+  try {
+    await runExclusive(FACTION_STORAGE_KEY, async () => {
+      const dataset =
+        await SafeAsyncStorageJSONParser.getItem<FactionDataset>(
+          FACTION_STORAGE_KEY
+        );
+      const factions = dataset?.factions;
+      if (!factions?.some(hasLegacyImageUri)) return;
+
+      await saveFactions(factions.map(normalizeImageUris));
+    });
+  } catch (error) {
+    console.error('Error migrating faction image URIs:', error);
+  }
+
+  try {
+    await runExclusive(LOCATION_STORAGE_KEY, async () => {
+      const dataset =
+        await SafeAsyncStorageJSONParser.getItem<LocationDataset>(
+          LOCATION_STORAGE_KEY
+        );
+      const locations = dataset?.locations;
+      if (!locations?.some(hasLegacyImageUri)) return;
+
+      await saveLocations(locations.map(normalizeImageUris));
+    });
+  } catch (error) {
+    console.error('Error migrating location image URIs:', error);
+  }
+
+  try {
+    await runExclusive(EVENT_STORAGE_KEY, async () => {
+      const dataset =
+        await SafeAsyncStorageJSONParser.getItem<EventDataset>(
+          EVENT_STORAGE_KEY
+        );
+      const events = dataset?.events;
+      if (!events?.some(hasLegacyImageUri)) return;
+
+      await saveEvents(events.map(normalizeImageUris));
+    });
+  } catch (error) {
+    console.error('Error migrating event image URIs:', error);
+  }
+
+  try {
+    await runExclusive(QUEST_STORAGE_KEY, async () => {
+      const dataset =
+        await SafeAsyncStorageJSONParser.getItem<QuestDataset>(
+          QUEST_STORAGE_KEY
+        );
+      const quests = dataset?.quests;
+      if (!quests?.some(hasLegacyImageUri)) return;
+
+      await saveQuests(quests.map(normalizeImageUris));
+    });
+  } catch (error) {
+    console.error('Error migrating quest image URIs:', error);
+  }
+};
+
 // Location management functions
 export const saveLocations = async (
   locations: GameLocation[]
@@ -1164,7 +1280,7 @@ export const loadLocations = async (): Promise<GameLocation[]> => {
     );
   if (!dataset) return [];
 
-  return dataset.locations || [];
+  return (dataset.locations || []).map(normalizeImageUris);
 };
 
 export const getLocation = async (
@@ -1177,7 +1293,6 @@ export const getLocation = async (
 export const createLocation = async (locationData: {
   name: string;
   description: string;
-  imageUri?: string;
   imageUris?: string[];
 }): Promise<GameLocation | null> =>
   runExclusive(LOCATION_STORAGE_KEY, async () => {
@@ -1196,7 +1311,6 @@ export const createLocation = async (locationData: {
       id: uuidv4(),
       name: locationData.name,
       description: locationData.description,
-      imageUri: locationData.imageUri,
       imageUris: locationData.imageUris,
       createdAt: now,
       updatedAt: now,
@@ -1302,7 +1416,7 @@ export const loadEvents = async (): Promise<GameEvent[]> => {
     await SafeAsyncStorageJSONParser.getItem<EventDataset>(EVENT_STORAGE_KEY);
   if (!dataset) return [];
 
-  return dataset.events || [];
+  return (dataset.events || []).map(normalizeImageUris);
 };
 
 export const createEvent = async (
@@ -1377,7 +1491,7 @@ export const loadQuests = async (): Promise<GameQuest[]> => {
     await SafeAsyncStorageJSONParser.getItem<QuestDataset>(QUEST_STORAGE_KEY);
   if (!dataset) return [];
 
-  return dataset.quests || [];
+  return (dataset.quests || []).map(normalizeImageUris);
 };
 
 export const createQuest = async (

--- a/src/utils/exportImport.ts
+++ b/src/utils/exportImport.ts
@@ -154,13 +154,15 @@ const exportCharacterDataNative = async (): Promise<void> => {
           }
           if (processedUris.length > 0) {
             character.imageUris = processedUris;
-            character.imageUri = processedUris[0];
           }
         }
-        // Handle legacy single image
+        // Handle a legacy single image from data that predates the
+        // imageUris migration. Read-only tolerance: normalize onto
+        // imageUris and never write the deprecated field back out.
         else if (character.imageUri) {
-          if (character.imageUri.startsWith('data:')) {
-            const imageData = extractImageData(character.imageUri);
+          const legacyUri = character.imageUri;
+          if (legacyUri.startsWith('data:')) {
+            const imageData = extractImageData(legacyUri);
             if (imageData) {
               const filename = `images/characters/${character.id}.${imageData.extension}`;
               const filePath = tempDir + filename;
@@ -171,31 +173,33 @@ const exportCharacterDataNative = async (): Promise<void> => {
                   encoding: FileSystem.EncodingType.Base64,
                 }
               );
-              character.imageUri = filename;
               character.imageUris = [filename];
               imageCounter++;
             }
           } else if (
-            character.imageUri.startsWith('file://') ||
-            character.imageUri.startsWith('/')
+            legacyUri.startsWith('file://') ||
+            legacyUri.startsWith('/')
           ) {
             // Handle file URI - copy file directly
             try {
               const extension =
-                character.imageUri.split('.').pop()?.toLowerCase() || 'jpg';
+                legacyUri.split('.').pop()?.toLowerCase() || 'jpg';
               const filename = `images/characters/${character.id}.${extension}`;
               const filePath = tempDir + filename;
               await FileSystem.copyAsync({
-                from: character.imageUri,
+                from: legacyUri,
                 to: filePath,
               });
-              character.imageUri = filename;
               character.imageUris = [filename];
               imageCounter++;
             } catch {
               // Image file not accessible, skip
             }
+          } else {
+            // Already a relative/remote path - carry it over as-is.
+            character.imageUris = [legacyUri];
           }
+          delete character.imageUri;
         }
       }
     }
@@ -245,13 +249,15 @@ const exportCharacterDataNative = async (): Promise<void> => {
           }
           if (processedUris.length > 0) {
             location.imageUris = processedUris;
-            location.imageUri = processedUris[0];
           }
         }
-        // Handle legacy single image
+        // Handle a legacy single image from data that predates the
+        // imageUris migration. Read-only tolerance: normalize onto
+        // imageUris and never write the deprecated field back out.
         else if (location.imageUri) {
-          if (location.imageUri.startsWith('data:')) {
-            const imageData = extractImageData(location.imageUri);
+          const legacyUri = location.imageUri;
+          if (legacyUri.startsWith('data:')) {
+            const imageData = extractImageData(legacyUri);
             if (imageData) {
               const filename = `images/locations/${location.id}.${imageData.extension}`;
               const filePath = tempDir + filename;
@@ -262,31 +268,33 @@ const exportCharacterDataNative = async (): Promise<void> => {
                   encoding: FileSystem.EncodingType.Base64,
                 }
               );
-              location.imageUri = filename;
               location.imageUris = [filename];
               imageCounter++;
             }
           } else if (
-            location.imageUri.startsWith('file://') ||
-            location.imageUri.startsWith('/')
+            legacyUri.startsWith('file://') ||
+            legacyUri.startsWith('/')
           ) {
             // Handle file URI - copy file directly
             try {
               const extension =
-                location.imageUri.split('.').pop()?.toLowerCase() || 'jpg';
+                legacyUri.split('.').pop()?.toLowerCase() || 'jpg';
               const filename = `images/locations/${location.id}.${extension}`;
               const filePath = tempDir + filename;
               await FileSystem.copyAsync({
-                from: location.imageUri,
+                from: legacyUri,
                 to: filePath,
               });
-              location.imageUri = filename;
               location.imageUris = [filename];
               imageCounter++;
             } catch {
               // Image file not accessible, skip
             }
+          } else {
+            // Already a relative/remote path - carry it over as-is.
+            location.imageUris = [legacyUri];
           }
+          delete location.imageUri;
         }
       }
     }
@@ -336,13 +344,15 @@ const exportCharacterDataNative = async (): Promise<void> => {
           }
           if (processedUris.length > 0) {
             event.imageUris = processedUris;
-            event.imageUri = processedUris[0];
           }
         }
-        // Handle legacy single image
+        // Handle a legacy single image from data that predates the
+        // imageUris migration. Read-only tolerance: normalize onto
+        // imageUris and never write the deprecated field back out.
         else if (event.imageUri) {
-          if (event.imageUri.startsWith('data:')) {
-            const imageData = extractImageData(event.imageUri);
+          const legacyUri = event.imageUri;
+          if (legacyUri.startsWith('data:')) {
+            const imageData = extractImageData(legacyUri);
             if (imageData) {
               const filename = `images/events/${event.id}.${imageData.extension}`;
               const filePath = tempDir + filename;
@@ -353,31 +363,33 @@ const exportCharacterDataNative = async (): Promise<void> => {
                   encoding: FileSystem.EncodingType.Base64,
                 }
               );
-              event.imageUri = filename;
               event.imageUris = [filename];
               imageCounter++;
             }
           } else if (
-            event.imageUri.startsWith('file://') ||
-            event.imageUri.startsWith('/')
+            legacyUri.startsWith('file://') ||
+            legacyUri.startsWith('/')
           ) {
             // Handle file URI - copy file directly
             try {
               const extension =
-                event.imageUri.split('.').pop()?.toLowerCase() || 'jpg';
+                legacyUri.split('.').pop()?.toLowerCase() || 'jpg';
               const filename = `images/events/${event.id}.${extension}`;
               const filePath = tempDir + filename;
               await FileSystem.copyAsync({
-                from: event.imageUri,
+                from: legacyUri,
                 to: filePath,
               });
-              event.imageUri = filename;
               event.imageUris = [filename];
               imageCounter++;
             } catch {
               // Image file not accessible, skip
             }
+          } else {
+            // Already a relative/remote path - carry it over as-is.
+            event.imageUris = [legacyUri];
           }
+          delete event.imageUri;
         }
       }
     }
@@ -430,13 +442,15 @@ const exportCharacterDataNative = async (): Promise<void> => {
           }
           if (processedUris.length > 0) {
             faction.imageUris = processedUris;
-            faction.imageUri = processedUris[0];
           }
         }
-        // Handle legacy single image
+        // Handle a legacy single image from data that predates the
+        // imageUris migration. Read-only tolerance: normalize onto
+        // imageUris and never write the deprecated field back out.
         else if (faction.imageUri) {
-          if (faction.imageUri.startsWith('data:')) {
-            const imageData = extractImageData(faction.imageUri);
+          const legacyUri = faction.imageUri;
+          if (legacyUri.startsWith('data:')) {
+            const imageData = extractImageData(legacyUri);
             if (imageData) {
               const safeName = faction.name.replace(/[^a-zA-Z0-9]/g, '_');
               const filename = `images/factions/${safeName}.${imageData.extension}`;
@@ -448,32 +462,34 @@ const exportCharacterDataNative = async (): Promise<void> => {
                   encoding: FileSystem.EncodingType.Base64,
                 }
               );
-              faction.imageUri = filename;
               faction.imageUris = [filename];
               imageCounter++;
             }
           } else if (
-            faction.imageUri.startsWith('file://') ||
-            faction.imageUri.startsWith('/')
+            legacyUri.startsWith('file://') ||
+            legacyUri.startsWith('/')
           ) {
             // Handle file URI - copy file directly
             try {
               const extension =
-                faction.imageUri.split('.').pop()?.toLowerCase() || 'jpg';
+                legacyUri.split('.').pop()?.toLowerCase() || 'jpg';
               const safeName = faction.name.replace(/[^a-zA-Z0-9]/g, '_');
               const filename = `images/factions/${safeName}.${extension}`;
               const filePath = tempDir + filename;
               await FileSystem.copyAsync({
-                from: faction.imageUri,
+                from: legacyUri,
                 to: filePath,
               });
-              faction.imageUri = filename;
               faction.imageUris = [filename];
               imageCounter++;
             } catch {
               // Image file not accessible, skip
             }
+          } else {
+            // Already a relative/remote path - carry it over as-is.
+            faction.imageUris = [legacyUri];
           }
+          delete faction.imageUri;
         }
       }
     }
@@ -785,10 +801,9 @@ const importCharacterDataNative = async (): Promise<boolean> => {
           );
           if (character) {
             console.log(
-              `[ZIP Import] Found character ${character.name}, updating imageUri from "${character.imageUri}" to "${sortedImages[0]}"`
+              `[ZIP Import] Found character ${character.name}, setting imageUris to ${sortedImages.length} image(s)`
             );
             character.imageUris = sortedImages;
-            character.imageUri = sortedImages[0]; // Backward compatibility
           } else {
             console.warn(
               `[ZIP Import] Character ${entityId} not found in dataset`
@@ -800,10 +815,9 @@ const importCharacterDataNative = async (): Promise<boolean> => {
           );
           if (location) {
             console.log(
-              `[ZIP Import] Found location ${location.name}, updating imageUri`
+              `[ZIP Import] Found location ${location.name}, updating imageUris`
             );
             location.imageUris = sortedImages;
-            location.imageUri = sortedImages[0]; // Backward compatibility
           } else {
             console.warn(
               `[ZIP Import] Location ${entityId} not found in dataset`
@@ -813,10 +827,9 @@ const importCharacterDataNative = async (): Promise<boolean> => {
           const event = dataset.events?.find((e: any) => e.id === entityId);
           if (event) {
             console.log(
-              `[ZIP Import] Found event ${event.title}, updating imageUri`
+              `[ZIP Import] Found event ${event.title}, updating imageUris`
             );
             event.imageUris = sortedImages;
-            event.imageUri = sortedImages[0]; // Backward compatibility
           } else {
             console.warn(`[ZIP Import] Event ${entityId} not found in dataset`);
           }
@@ -827,10 +840,9 @@ const importCharacterDataNative = async (): Promise<boolean> => {
           );
           if (faction) {
             console.log(
-              `[ZIP Import] Found faction ${faction.name}, updating imageUri`
+              `[ZIP Import] Found faction ${faction.name}, updating imageUris`
             );
             faction.imageUris = sortedImages;
-            faction.imageUri = sortedImages[0]; // Backward compatibility
           } else {
             console.warn(
               `[ZIP Import] Faction ${entityId} not found in dataset`
@@ -867,7 +879,10 @@ const importCharacterDataNative = async (): Promise<boolean> => {
         return false;
       }
     } else {
-      // Handle JSON file (without images - strip imageUri fields)
+      // Handle JSON file (without images). This path explicitly skips
+      // images, so a legacy single `imageUri` (often a data: URI or a
+      // device-local file:// path) is dropped rather than backfilled into
+      // imageUris - there is no image asset coming along with it.
       const fileContent = await FileSystem.readAsStringAsync(fileUri);
       const dataset = JSON.parse(fileContent);
 
@@ -882,6 +897,20 @@ const importCharacterDataNative = async (): Promise<boolean> => {
       if (dataset.locations) {
         dataset.locations.forEach((location: any) => {
           delete location.imageUri;
+        });
+      }
+
+      // Strip imageUri from all events
+      if (dataset.events) {
+        dataset.events.forEach((event: any) => {
+          delete event.imageUri;
+        });
+      }
+
+      // Strip imageUri from all factions
+      if (dataset.factions) {
+        dataset.factions.forEach((faction: any) => {
+          delete faction.imageUri;
         });
       }
 
@@ -1080,7 +1109,6 @@ const mergeCharacterDataNative = async (): Promise<boolean> => {
           );
           if (character) {
             character.imageUris = sortedImages;
-            character.imageUri = sortedImages[0];
           }
         } else if (entityType === 'location') {
           const location = dataset.locations?.find(
@@ -1088,13 +1116,11 @@ const mergeCharacterDataNative = async (): Promise<boolean> => {
           );
           if (location) {
             location.imageUris = sortedImages;
-            location.imageUri = sortedImages[0];
           }
         } else if (entityType === 'event') {
           const event = dataset.events?.find((e: any) => e.id === entityId);
           if (event) {
             event.imageUris = sortedImages;
-            event.imageUri = sortedImages[0];
           }
         } else if (entityType === 'faction') {
           // For factions, entityId is the sanitized faction name
@@ -1103,7 +1129,6 @@ const mergeCharacterDataNative = async (): Promise<boolean> => {
           );
           if (faction) {
             faction.imageUris = sortedImages;
-            faction.imageUri = sortedImages[0];
           }
         }
       }
@@ -1113,7 +1138,10 @@ const mergeCharacterDataNative = async (): Promise<boolean> => {
 
       fileContent = JSON.stringify(dataset);
     } else {
-      // Handle JSON file (without images - strip imageUri fields)
+      // Handle JSON file (without images). This path explicitly skips
+      // images, so a legacy single `imageUri` (often a data: URI or a
+      // device-local file:// path) is dropped rather than backfilled into
+      // imageUris - there is no image asset coming along with it.
       const jsonContent = await FileSystem.readAsStringAsync(fileUri);
       const dataset = JSON.parse(jsonContent);
 
@@ -1128,6 +1156,20 @@ const mergeCharacterDataNative = async (): Promise<boolean> => {
       if (dataset.locations) {
         dataset.locations.forEach((location: any) => {
           delete location.imageUri;
+        });
+      }
+
+      // Strip imageUri from all events
+      if (dataset.events) {
+        dataset.events.forEach((event: any) => {
+          delete event.imageUri;
+        });
+      }
+
+      // Strip imageUri from all factions
+      if (dataset.factions) {
+        dataset.factions.forEach((faction: any) => {
+          delete faction.imageUri;
         });
       }
 

--- a/src/utils/gitIntegration.ts
+++ b/src/utils/gitIntegration.ts
@@ -302,7 +302,6 @@ export const exportToGitHub = async (): Promise<{
         );
         if (images.length > 0) {
           character.imageUris = images;
-          character.imageUri = images[0];
           totalImages += images.length;
           console.log(
             `[GitHub Export] Processed ${images.length} images for character: ${character.name}`
@@ -320,7 +319,6 @@ export const exportToGitHub = async (): Promise<{
         );
         if (images.length > 0) {
           location.imageUris = images;
-          location.imageUri = images[0];
           totalImages += images.length;
           console.log(
             `[GitHub Export] Processed ${images.length} images for location: ${location.name}`
@@ -334,7 +332,6 @@ export const exportToGitHub = async (): Promise<{
         const images = await processEntityImages(event, 'events', event.id);
         if (images.length > 0) {
           event.imageUris = images;
-          event.imageUri = images[0];
           totalImages += images.length;
           console.log(
             `[GitHub Export] Processed ${images.length} images for event: ${event.title}`
@@ -349,7 +346,6 @@ export const exportToGitHub = async (): Promise<{
         const images = await processEntityImages(faction, 'factions', safeName);
         if (images.length > 0) {
           faction.imageUris = images;
-          faction.imageUri = images[0];
           totalImages += images.length;
           console.log(
             `[GitHub Export] Processed ${images.length} images for faction: ${faction.name}`
@@ -365,8 +361,8 @@ export const exportToGitHub = async (): Promise<{
 
     // Update data.json with modified paths
     // Note: This happens AFTER image processing because we need to update
-    // the imageUri/imageUris fields in the dataset to point to the
-    // relative paths in the repository (e.g., "images/characters/id_0.jpg")
+    // the imageUris fields in the dataset to point to the relative paths in
+    // the repository (e.g., "images/characters/id_0.jpg")
     const updatedDataContent = Buffer.from(
       JSON.stringify(sortedDataset, null, 2)
     ).toString('base64');
@@ -653,7 +649,6 @@ export const importFromGitHub = async (): Promise<{
             const localPaths = await downloadImages(character.imageUris);
             if (localPaths.length > 0) {
               character.imageUris = localPaths;
-              character.imageUri = localPaths[0];
               totalImagesDownloaded += localPaths.length;
             } else {
               console.warn(
@@ -664,12 +659,14 @@ export const importFromGitHub = async (): Promise<{
               delete character.imageUris;
             }
           } else if (character.imageUri) {
+            // Legacy single-image field from an older export/repo - download
+            // it and normalize onto imageUris, dropping the deprecated field.
             console.log(
               `[GitHub Import] Processing single image for character: ${character.name}`
             );
             const localPaths = await downloadImages([character.imageUri]);
+            delete character.imageUri;
             if (localPaths.length > 0) {
-              character.imageUri = localPaths[0];
               character.imageUris = localPaths;
               totalImagesDownloaded += localPaths.length;
             } else {
@@ -677,7 +674,6 @@ export const importFromGitHub = async (): Promise<{
                 `[GitHub Import] No image downloaded for character: ${character.name}`
               );
               // Clear image references if download failed
-              delete character.imageUri;
               delete character.imageUris;
             }
           }
@@ -694,7 +690,6 @@ export const importFromGitHub = async (): Promise<{
             const localPaths = await downloadImages(location.imageUris);
             if (localPaths.length > 0) {
               location.imageUris = localPaths;
-              location.imageUri = localPaths[0];
               totalImagesDownloaded += localPaths.length;
             } else {
               console.warn(
@@ -705,12 +700,14 @@ export const importFromGitHub = async (): Promise<{
               delete location.imageUris;
             }
           } else if (location.imageUri) {
+            // Legacy single-image field from an older export/repo - download
+            // it and normalize onto imageUris, dropping the deprecated field.
             console.log(
               `[GitHub Import] Processing single image for location: ${location.name}`
             );
             const localPaths = await downloadImages([location.imageUri]);
+            delete location.imageUri;
             if (localPaths.length > 0) {
-              location.imageUri = localPaths[0];
               location.imageUris = localPaths;
               totalImagesDownloaded += localPaths.length;
             } else {
@@ -718,7 +715,6 @@ export const importFromGitHub = async (): Promise<{
                 `[GitHub Import] No image downloaded for location: ${location.name}`
               );
               // Clear image references if download failed
-              delete location.imageUri;
               delete location.imageUris;
             }
           }
@@ -735,7 +731,6 @@ export const importFromGitHub = async (): Promise<{
             const localPaths = await downloadImages(event.imageUris);
             if (localPaths.length > 0) {
               event.imageUris = localPaths;
-              event.imageUri = localPaths[0];
               totalImagesDownloaded += localPaths.length;
             } else {
               console.warn(
@@ -746,12 +741,14 @@ export const importFromGitHub = async (): Promise<{
               delete event.imageUris;
             }
           } else if (event.imageUri) {
+            // Legacy single-image field from an older export/repo - download
+            // it and normalize onto imageUris, dropping the deprecated field.
             console.log(
               `[GitHub Import] Processing single image for event: ${event.title}`
             );
             const localPaths = await downloadImages([event.imageUri]);
+            delete event.imageUri;
             if (localPaths.length > 0) {
-              event.imageUri = localPaths[0];
               event.imageUris = localPaths;
               totalImagesDownloaded += localPaths.length;
             } else {
@@ -759,7 +756,6 @@ export const importFromGitHub = async (): Promise<{
                 `[GitHub Import] No image downloaded for event: ${event.title}`
               );
               // Clear image references if download failed
-              delete event.imageUri;
               delete event.imageUris;
             }
           }
@@ -776,7 +772,6 @@ export const importFromGitHub = async (): Promise<{
             const localPaths = await downloadImages(faction.imageUris);
             if (localPaths.length > 0) {
               faction.imageUris = localPaths;
-              faction.imageUri = localPaths[0];
               totalImagesDownloaded += localPaths.length;
             } else {
               console.warn(
@@ -787,12 +782,14 @@ export const importFromGitHub = async (): Promise<{
               delete faction.imageUris;
             }
           } else if (faction.imageUri) {
+            // Legacy single-image field from an older export/repo - download
+            // it and normalize onto imageUris, dropping the deprecated field.
             console.log(
               `[GitHub Import] Processing single image for faction: ${faction.name}`
             );
             const localPaths = await downloadImages([faction.imageUri]);
+            delete faction.imageUri;
             if (localPaths.length > 0) {
-              faction.imageUri = localPaths[0];
               faction.imageUris = localPaths;
               totalImagesDownloaded += localPaths.length;
             } else {
@@ -800,7 +797,6 @@ export const importFromGitHub = async (): Promise<{
                 `[GitHub Import] No image downloaded for faction: ${faction.name}`
               );
               // Clear image references if download failed
-              delete faction.imageUri;
               delete faction.imageUris;
             }
           }

--- a/tst/helpers/storage.ts
+++ b/tst/helpers/storage.ts
@@ -22,6 +22,7 @@ export function primeStorageDefaults(): void {
   storage.loadQuests.mockResolvedValue([]);
   storage.getFactionDescription.mockResolvedValue('');
   storage.migrateFactionDescriptions.mockResolvedValue(undefined);
+  storage.migrateImageUris.mockResolvedValue(undefined);
   storage.getLocation.mockResolvedValue(null);
   storage.getAllStoredFactions.mockResolvedValue([]);
 }

--- a/tst/utils/characterStorage.test.ts
+++ b/tst/utils/characterStorage.test.ts
@@ -1803,6 +1803,179 @@ describe('characterStorage', () => {
       });
     });
 
+    describe('migrateImageUris', () => {
+      it('backfills a legacy imageUri into imageUris and strips it, for every entity type', async () => {
+        const character = {
+          id: 'char-1',
+          name: 'Test',
+          species: 'Human',
+          perkIds: [],
+          distinctionIds: [],
+          factions: [],
+          relationships: [],
+          present: false,
+          retired: false,
+          imageUri: 'legacy-character.jpg',
+          createdAt: mockDate,
+          updatedAt: mockDate,
+        };
+        const faction = {
+          name: 'Brotherhood',
+          description: '',
+          imageUri: 'legacy-faction.jpg',
+          createdAt: mockDate,
+          updatedAt: mockDate,
+        };
+        const location = {
+          id: 'loc-1',
+          name: 'Test Location',
+          description: '',
+          imageUri: 'legacy-location.jpg',
+          createdAt: mockDate,
+          updatedAt: mockDate,
+        };
+        const event = {
+          id: 'event-1',
+          title: 'Test Event',
+          date: '2025-01-01',
+          imageUri: 'legacy-event.jpg',
+          createdAt: mockDate,
+          updatedAt: mockDate,
+        };
+        const quest = {
+          id: 'quest-1',
+          name: 'Test Quest',
+          status: QuestStatus.NotStarted,
+          imageUri: 'legacy-quest.jpg',
+          createdAt: mockDate,
+          updatedAt: mockDate,
+        };
+
+        (SafeAsyncStorageJSONParser.getItem as jest.Mock)
+          .mockResolvedValueOnce({
+            characters: [character],
+            version: '1.0',
+            lastUpdated: mockDate,
+          })
+          .mockResolvedValueOnce({
+            factions: [faction],
+            version: '1.0',
+            lastUpdated: mockDate,
+          })
+          .mockResolvedValueOnce({
+            locations: [location],
+            version: '1.0',
+            lastUpdated: mockDate,
+          })
+          .mockResolvedValueOnce({
+            events: [event],
+            version: '1.0',
+            lastUpdated: mockDate,
+          })
+          .mockResolvedValueOnce({
+            quests: [quest],
+            version: '1.0',
+            lastUpdated: mockDate,
+          });
+
+        await CharacterStorage.migrateImageUris();
+
+        const setItemMock = SafeAsyncStorageJSONParser.setItem as jest.Mock;
+
+        const savedCharacters = setItemMock.mock.calls.find(
+          c => c[0] === 'gameCharacterManager'
+        )?.[1];
+        expect(savedCharacters.characters[0].imageUris).toEqual([
+          'legacy-character.jpg',
+        ]);
+        expect(savedCharacters.characters[0].imageUri).toBeUndefined();
+
+        const savedFactions = setItemMock.mock.calls.find(
+          c => c[0] === 'gameCharacterManager_factions'
+        )?.[1];
+        expect(savedFactions.factions[0].imageUris).toEqual([
+          'legacy-faction.jpg',
+        ]);
+        expect(savedFactions.factions[0].imageUri).toBeUndefined();
+
+        const savedLocations = setItemMock.mock.calls.find(
+          c => c[0] === 'gameCharacterManager_locations'
+        )?.[1];
+        expect(savedLocations.locations[0].imageUris).toEqual([
+          'legacy-location.jpg',
+        ]);
+        expect(savedLocations.locations[0].imageUri).toBeUndefined();
+
+        const savedEvents = setItemMock.mock.calls.find(
+          c => c[0] === 'gameCharacterManager_events'
+        )?.[1];
+        expect(savedEvents.events[0].imageUris).toEqual(['legacy-event.jpg']);
+        expect(savedEvents.events[0].imageUri).toBeUndefined();
+
+        const savedQuests = setItemMock.mock.calls.find(
+          c => c[0] === 'gameCharacterManager_quests'
+        )?.[1];
+        expect(savedQuests.quests[0].imageUris).toEqual(['legacy-quest.jpg']);
+        expect(savedQuests.quests[0].imageUri).toBeUndefined();
+      });
+
+      it('does not write to storage when no records have a legacy imageUri', async () => {
+        (SafeAsyncStorageJSONParser.getItem as jest.Mock)
+          .mockResolvedValueOnce({
+            characters: [
+              { id: 'char-1', name: 'Test', imageUris: ['already-multi.jpg'] },
+            ],
+            version: '1.0',
+          })
+          .mockResolvedValueOnce({ factions: [], version: '1.0' })
+          .mockResolvedValueOnce({ locations: [], version: '1.0' })
+          .mockResolvedValueOnce({ events: [], version: '1.0' })
+          .mockResolvedValueOnce({ quests: [], version: '1.0' });
+
+        await CharacterStorage.migrateImageUris();
+
+        expect(SafeAsyncStorageJSONParser.setItem).not.toHaveBeenCalled();
+      });
+
+      it('preserves an existing imageUris array rather than overwriting it with the legacy value', async () => {
+        (SafeAsyncStorageJSONParser.getItem as jest.Mock)
+          .mockResolvedValueOnce({
+            characters: [
+              {
+                id: 'char-1',
+                name: 'Test',
+                imageUri: 'legacy.jpg',
+                imageUris: ['already-multi.jpg'],
+              },
+            ],
+            version: '1.0',
+          })
+          .mockResolvedValueOnce({ factions: [], version: '1.0' })
+          .mockResolvedValueOnce({ locations: [], version: '1.0' })
+          .mockResolvedValueOnce({ events: [], version: '1.0' })
+          .mockResolvedValueOnce({ quests: [], version: '1.0' });
+
+        await CharacterStorage.migrateImageUris();
+
+        const saved = (
+          SafeAsyncStorageJSONParser.setItem as jest.Mock
+        ).mock.calls.find(c => c[0] === 'gameCharacterManager')?.[1];
+        expect(saved.characters[0].imageUris).toEqual(['already-multi.jpg']);
+        expect(saved.characters[0].imageUri).toBeUndefined();
+      });
+
+      it('is a no-op (idempotent) when storage is empty for every key', async () => {
+        (SafeAsyncStorageJSONParser.getItem as jest.Mock).mockResolvedValue(
+          null
+        );
+
+        await expect(
+          CharacterStorage.migrateImageUris()
+        ).resolves.toBeUndefined();
+        expect(SafeAsyncStorageJSONParser.setItem).not.toHaveBeenCalled();
+      });
+    });
+
     describe('Location Management Advanced', () => {
       it('should return null when creating location with duplicate name', async () => {
         (SafeAsyncStorageJSONParser.getItem as jest.Mock).mockResolvedValue({
@@ -2201,7 +2374,6 @@ describe('characterStorage', () => {
           name: '',
           species: 'Human',
           notes: '',
-          imageUri: '',
           perkIds: [],
           distinctionIds: [],
           factions: [],
@@ -2217,7 +2389,6 @@ describe('characterStorage', () => {
           name: 'Imported Name',
           species: 'Human',
           notes: 'Imported notes',
-          imageUri: 'http://example.com/image.png',
           perkIds: [],
           distinctionIds: [],
           factions: [],
@@ -2251,7 +2422,6 @@ describe('characterStorage', () => {
         expect(result.conflicts).toHaveLength(0);
         expect(result.merged[0].name).toBe('Imported Name');
         expect(result.merged[0].notes).toBe('Imported notes');
-        expect(result.merged[0].imageUri).toBe('http://example.com/image.png');
       });
 
       it('should merge and update relationships', async () => {

--- a/tst/utils/exportImport.test.ts
+++ b/tst/utils/exportImport.test.ts
@@ -91,7 +91,7 @@ describe('exportImport JSON round trip', () => {
       );
     });
 
-    it('strips imageUri fields from characters before importing', async () => {
+    it('strips a legacy imageUri from characters before importing (without images)', async () => {
       mockPickedFile('backup.json');
       const dataset = {
         characters: [
@@ -120,7 +120,11 @@ describe('exportImport JSON round trip', () => {
       const saved = (
         SafeAsyncStorageJSONParser.setItem as jest.Mock
       ).mock.calls.find(c => c[0] === 'gameCharacterManager')?.[1];
+      // Plain-JSON import explicitly skips images, so the deprecated
+      // imageUri is dropped rather than backfilled into imageUris - there
+      // is no accompanying image asset to carry forward.
       expect(saved.characters[0].imageUri).toBeUndefined();
+      expect(saved.characters[0].imageUris).toBeUndefined();
     });
 
     it('returns false without touching storage when the user cancels the picker', async () => {


### PR DESCRIPTION
## Summary

Closes #117.

- Removes the deprecated `imageUri` field from `GameCharacter`, `GameLocation`, `GameEvent`, `GameQuest` (`src/models/types.ts`), and `StoredFaction` (`src/utils/characterStorage.ts`) now that `imageUris[]` is the only supported shape.
- All character/faction/location/event forms and detail/list screens now read and write `imageUris` exclusively — the old "keep `imageUri` for backward compatibility (first image)" write-backs are gone.
- Adds a one-time `migrateImageUris()` migration (mirrors the existing `migrateFactionDescriptions` pattern, wrapped per-key in `runExclusive`) that backfills any persisted legacy `imageUri` into `imageUris` and strips the field. It runs on `CharacterListScreen`'s initial load, the app's entry route.
- `loadCharacters`/`loadFactions`/`loadLocations`/`loadEvents`/`loadQuests` also normalize in-memory on every read, so the UI never sees the deprecated field even before the persisted migration has run.
- The GitHub sync boundary (`gitIntegration.ts`) and JSON/ZIP import-export (`exportImport.ts`, plus `characterStorage.ts`'s `importDataset`/`mergeDatasets`/`mergeDatasetWithConflictResolution`) now tolerate a legacy `imageUri` **on read** (backfilling it into `imageUris`) but never write it back out on export/push — closing the drift where one path wrote `imageUri` while another read `imageUris`.
- The plain-JSON "without images" import path intentionally drops a legacy `imageUri` rather than backfilling it (there's no image asset to carry forward, and backfilling would silently re-embed a stale `data:`/`file://` reference the user explicitly chose to skip).

## Test plan

- [x] `npm run check-all` (type-check + lint + format:check + test) is green — 418 tests passing, 0 lint errors (pre-existing warnings only).
- [x] New `migrateImageUris` tests in `tst/utils/characterStorage.test.ts` cover: backfill + strip across all five entity types, no-op when nothing needs migrating, preserving an existing `imageUris` array instead of overwriting it, and idempotency on empty storage.
- [x] Updated `tst/utils/characterStorage.test.ts`'s merge-conflict test (previously asserted a scalar `imageUri` merge, which no longer applies now that images are arrays) and `tst/utils/exportImport.test.ts`'s "strips imageUri" test to reflect the actual normalize/strip behavior.
- [x] `grep -rn "imageUri\b" src/` returns no hits outside the migration helper's own declaration and the read-tolerant/strip logic in the three boundary files (`characterStorage.ts`, `exportImport.ts`, `gitIntegration.ts`).

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017QyiKhMxTSH6PaxW1mwqs3)_