### PR TITLE
Add tests for factionStats/influenceAnalysis, discord screens, and LocationMapScreen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,8 +121,8 @@ Path aliases (tsconfig + babel-plugin-module-resolver): `@/*` → `src/*`, plus
   just bare `expo`), since `expo-file-system` and `@octokit/rest` ship ESM
   and would otherwise fail to parse the moment coverage collection touches
   them.
-- Real baseline as of this writing: **~26% statements / ~26% functions**
-  (was ~21%; before that it was previously reported as ~75%, which only
+- Real baseline as of this writing: **~54% statements / ~51% functions**
+  (was ~26%; before that it was previously reported as ~75%, which only
   looked healthy because most of `src/screens` and several `src/utils`
   modules were invisible to the report — see the config details above).
 
@@ -131,11 +131,7 @@ Path aliases (tsconfig + babel-plugin-module-resolver): `@/*` → `src/*`, plus
 Ranked by value if you're looking for where to add tests next (highest
 blast-radius / lowest-effort first):
 
-1. **`src/components/screens/BaseDetailScreen.tsx`** (~7%) and
-   **`BaseFormScreen.tsx`** (~17%) — the generic scaffolds nearly every
-   detail/form screen is built on; tests here have the highest leverage per
-   line written.
-2. **`src/utils/exportImport.ts`** (~11% covered) — the plain-JSON path of
+1. **`src/utils/exportImport.ts`** (~11% covered) — the plain-JSON path of
    `importCharacterData`/`mergeCharacterData` is now tested (see
    `tst/utils/exportImport.test.ts`; note `jest.setup.js` mocks
    `expo-file-system/legacy`, the specifier this file actually imports, not
@@ -143,25 +139,41 @@ blast-radius / lowest-effort first):
    `.zip` branches of import/merge — all need `react-native-zip-archive` +
    directory-walking (`makeDirectoryAsync`/`copyAsync`/`getInfoAsync`/
    `readDirectoryAsync`) + `expo-sharing` mocked.
-3. **`src/utils/gitIntegration.ts`** (~900 lines, untested) — GitHub-backed
+2. **`src/utils/gitIntegration.ts`** (~900 lines, untested) — GitHub-backed
    sync; highest blast radius, needs `@octokit` mocking.
-4. ~~`src/utils/discordStorage.ts`~~ — **done.** Was untested and had the
-   same unwrapped read-modify-write bug `characterStorage.ts` had (no
-   `runExclusive`); both the bug and the test gap are fixed
-   (`tst/utils/discordStorage.test.ts` +
-   `tst/utils/discordStorage.concurrency.test.ts`, ~75% covered).
-5. **`src/utils/influenceAnalysis.ts`** (~370 lines) and
-   **`src/utils/factionStats.ts`** (~260 lines) — both pure computation,
-   both untested; easy, high-signal unit tests.
-6. **`src/utils/discordApi.ts`** and **`src/utils/discordCharacterExtraction.ts`**
+3. **`src/utils/discordApi.ts`** and **`src/utils/discordCharacterExtraction.ts`**
    (untested) — parsing/ingesting external Discord data; boundary-parsing
    bugs are likely here.
-7. **Every detail/form screen, and the whole `src/screens/discord/`,
-   `src/screens/events/`, and `src/screens/location/` folders** — entirely
-   untested (0%). Only the `*ListScreen` components have tests
-   (`tst/screens/character/CharacterListScreen.test.tsx`,
-   `tst/screens/faction/FactionListScreen.test.tsx`); use those as the
-   template.
+
+Done since the list above was last written:
+
+- ~~`src/components/screens/BaseDetailScreen.tsx`/`BaseFormScreen.tsx`~~ and
+  every templated character/faction/location/events/quest detail/form/list
+  screen — contract-based tests via `tst/helpers/screenContracts.ts`
+  (`describeListScreenContract`/`describeDetailScreenContract`/
+  `describeFormScreenContract`).
+- ~~`src/utils/discordStorage.ts`~~ — was untested and had the same
+  unwrapped read-modify-write bug `characterStorage.ts` had (no
+  `runExclusive`); both the bug and the test gap are fixed
+  (`tst/utils/discordStorage.test.ts` +
+  `tst/utils/discordStorage.concurrency.test.ts`).
+- ~~`src/utils/influenceAnalysis.ts`~~ and ~~`src/utils/factionStats.ts`~~ —
+  pure computation, now covered by `tst/utils/influenceAnalysis.test.ts` and
+  `tst/utils/factionStats.test.ts`. The one async export,
+  `analyzeFactionInfluence`, does a lazy `await import('@utils/characterStorage')`
+  — Jest's CommonJS transform doesn't lower dynamic `import()` on its own, so
+  `babel.config.js` adds `babel-plugin-dynamic-import-node` under the `test`
+  env to make it work under test (Metro/production builds are unaffected).
+- ~~`src/screens/discord/`~~ (all 6 screens) and ~~`LocationMapScreen.tsx`~~ —
+  bespoke tests (these don't fit the generic list/detail/form contracts) in
+  `tst/screens/discord/*.test.tsx` and
+  `tst/screens/location/LocationMapScreen.test.tsx`. Two reusable additions
+  came out of this: `installFocusEffectOnce()` (`tst/helpers/navigation.ts`)
+  for screens that gate a loading spinner behind `useFocusEffect` (the global
+  mock re-fires on every render, which bounces that gate into a real
+  render-phase update loop), and local per-file mocks for
+  `react-native-reanimated`/`react-native-gesture-handler` for the one screen
+  using shared-value animations and gesture composition.
 
 ## Scope discipline
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -19,5 +19,15 @@ module.exports = function (api) {
       ],
       'react-native-reanimated/plugin',
     ],
+    env: {
+      // Jest runs under CommonJS without --experimental-vm-modules, so the
+      // native `import()` calls left untouched by babel-preset-expo (e.g.
+      // influenceAnalysis.ts's lazy `@utils/characterStorage` import) need
+      // to be lowered to `require()` only for tests; Metro/production
+      // builds are unaffected.
+      test: {
+        plugins: ['babel-plugin-dynamic-import-node'],
+      },
+    },
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^8.46.2",
         "@typescript-eslint/parser": "^8.46.2",
+        "babel-plugin-dynamic-import-node": "^2.3.3",
         "babel-plugin-module-resolver": "^5.0.2",
         "eslint": "^9.38.0",
         "eslint-config-prettier": "^10.1.8",
@@ -6326,6 +6327,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-plugin-dynamic-import-node": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+      "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object.assign": "^4.1.0"
       }
     },
     "node_modules/babel-plugin-istanbul": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^8.46.2",
     "@typescript-eslint/parser": "^8.46.2",
+    "babel-plugin-dynamic-import-node": "^2.3.3",
     "babel-plugin-module-resolver": "^5.0.2",
     "eslint": "^9.38.0",
     "eslint-config-prettier": "^10.1.8",

--- a/tst/helpers/factories.ts
+++ b/tst/helpers/factories.ts
@@ -1,4 +1,7 @@
 import {
+  DiscordCharacterAlias,
+  DiscordMessage,
+  DiscordServerConfig,
   GameCharacter,
   GameEvent,
   GameLocation,
@@ -58,6 +61,45 @@ export const makeQuest = (overrides: Partial<GameQuest> = {}): GameQuest => ({
   id: 'quest-1',
   name: 'Test Quest',
   status: QuestStatus.NotStarted,
+  createdAt: TEST_TIMESTAMP,
+  updatedAt: TEST_TIMESTAMP,
+  ...overrides,
+});
+
+export const makeDiscordServerConfig = (
+  overrides: Partial<DiscordServerConfig> = {}
+): DiscordServerConfig => ({
+  id: 'server-config-1',
+  name: 'Test Server',
+  botToken: 'test-bot-token',
+  channelId: 'channel-1',
+  enabled: true,
+  createdAt: TEST_TIMESTAMP,
+  updatedAt: TEST_TIMESTAMP,
+  ...overrides,
+});
+
+export const makeDiscordMessage = (
+  overrides: Partial<DiscordMessage> = {}
+): DiscordMessage => ({
+  id: 'message-1',
+  channelId: 'channel-1',
+  authorId: 'author-1',
+  authorUsername: 'TestUser',
+  content: 'Test message content',
+  timestamp: TEST_TIMESTAMP,
+  createdAt: TEST_TIMESTAMP,
+  ...overrides,
+});
+
+export const makeDiscordCharacterAlias = (
+  overrides: Partial<DiscordCharacterAlias> = {}
+): DiscordCharacterAlias => ({
+  alias: 'Test Alias',
+  characterId: 'character-1',
+  discordUserId: 'author-1',
+  confidence: 1,
+  usageCount: 1,
   createdAt: TEST_TIMESTAMP,
   updatedAt: TEST_TIMESTAMP,
   ...overrides,

--- a/tst/helpers/navigation.ts
+++ b/tst/helpers/navigation.ts
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react';
+import { useEffect, type ReactElement } from 'react';
 
 /**
  * Helpers for controlling the global `@react-navigation/native` mock from
@@ -21,6 +21,7 @@ export interface NavMock {
 interface MockedNavigationModule {
   useNavigation: () => unknown;
   useRoute: () => { params: Record<string, unknown> };
+  useFocusEffect: (callback: () => void) => void;
 }
 
 const getMockModule = (): MockedNavigationModule =>
@@ -28,6 +29,9 @@ const getMockModule = (): MockedNavigationModule =>
 
 let originalUseNavigation: MockedNavigationModule['useNavigation'] | undefined;
 let originalUseRoute: MockedNavigationModule['useRoute'] | undefined;
+let originalUseFocusEffect:
+  | MockedNavigationModule['useFocusEffect']
+  | undefined;
 
 export function installNavigationMock(): NavMock {
   const mockModule = getMockModule();
@@ -54,6 +58,31 @@ export function installRouteParams(params: Record<string, unknown>): void {
   mockModule.useRoute = () => ({ params });
 }
 
+/**
+ * The global `useFocusEffect` mock (`jest.setup.js`) invokes its callback
+ * synchronously on *every* render, unlike the real hook (which only re-fires
+ * on focus). For screens that gate a full-screen loading spinner behind
+ * state set inside that callback, this causes a genuine render-phase update
+ * loop (loading flips true → false → true forever) that trips React's "Too
+ * many re-renders" guard. This installs a version that behaves like a normal
+ * mount effect (runs the callback once, after render, via `useEffect`),
+ * which is enough to test the initial load without the bounce.
+ */
+function useFocusEffectOnceMock(callback: () => void): void {
+  useEffect(() => {
+    callback();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}
+
+export function installFocusEffectOnce(): void {
+  const mockModule = getMockModule();
+  if (!originalUseFocusEffect) {
+    originalUseFocusEffect = mockModule.useFocusEffect;
+  }
+  mockModule.useFocusEffect = useFocusEffectOnceMock;
+}
+
 export function resetNavigationMocks(): void {
   const mockModule = getMockModule();
   if (originalUseNavigation) {
@@ -61,6 +90,9 @@ export function resetNavigationMocks(): void {
   }
   if (originalUseRoute) {
     mockModule.useRoute = originalUseRoute;
+  }
+  if (originalUseFocusEffect) {
+    mockModule.useFocusEffect = originalUseFocusEffect;
   }
 }
 

--- a/tst/screens/discord/DiscordCharacterMappingScreen.test.tsx
+++ b/tst/screens/discord/DiscordCharacterMappingScreen.test.tsx
@@ -1,0 +1,180 @@
+import React from 'react';
+import { render, waitFor, fireEvent } from '@testing-library/react-native';
+import { DiscordCharacterMappingScreen } from '@screens/discord/DiscordCharacterMappingScreen';
+import * as discordStorage from '@utils/discordStorage';
+import * as characterStorage from '@utils/characterStorage';
+import * as discordCharacterExtraction from '@utils/discordCharacterExtraction';
+import {
+  installFocusEffectOnce,
+  resetNavigationMocks,
+} from '../../helpers/navigation';
+import { spyOnAlert, pressAlertButton } from '../../helpers/alertAndPlatform';
+import {
+  makeCharacter,
+  makeDiscordMessage,
+  makeDiscordCharacterAlias,
+} from '../../helpers/factories';
+
+jest.mock('@utils/discordStorage');
+jest.mock('@utils/characterStorage');
+jest.mock('@utils/discordCharacterExtraction');
+
+const storage = jest.mocked(discordStorage);
+const charStorage = jest.mocked(characterStorage);
+const extraction = jest.mocked(discordCharacterExtraction);
+
+const primeDefaults = () => {
+  storage.getDiscordMessages.mockResolvedValue([]);
+  charStorage.loadCharacters.mockResolvedValue([]);
+  storage.getDiscordCharacterAliases.mockResolvedValue([]);
+};
+
+describe('DiscordCharacterMappingScreen', () => {
+  let alertSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    primeDefaults();
+    installFocusEffectOnce();
+    alertSpy = spyOnAlert();
+  });
+
+  afterEach(() => {
+    resetNavigationMocks();
+    jest.restoreAllMocks();
+  });
+
+  it('shows an empty state when there are no unmapped messages', async () => {
+    const { getByText } = render(<DiscordCharacterMappingScreen />);
+
+    await waitFor(() => {
+      expect(getByText('No unmapped character names found.')).toBeTruthy();
+    });
+  });
+
+  it('groups unmapped messages by extracted name', async () => {
+    storage.getDiscordMessages.mockResolvedValue([
+      makeDiscordMessage({
+        id: 'message-1',
+        extractedCharacterName: 'Boone',
+        authorUsername: 'Player1',
+        content: '>[Boone] says hello',
+      }),
+      makeDiscordMessage({
+        id: 'message-2',
+        extractedCharacterName: 'Boone',
+        authorUsername: 'Player1',
+        content: '>[Boone] says hi again',
+      }),
+    ]);
+
+    const { getByText } = render(<DiscordCharacterMappingScreen />);
+
+    await waitFor(() => {
+      expect(getByText('"Boone"')).toBeTruthy();
+      expect(getByText('Needs Mapping (1)')).toBeTruthy();
+    });
+  });
+
+  it('excludes messages that already have a characterId', async () => {
+    storage.getDiscordMessages.mockResolvedValue([
+      makeDiscordMessage({
+        id: 'message-1',
+        extractedCharacterName: 'Boone',
+        characterId: 'character-1',
+      }),
+    ]);
+
+    const { getByText } = render(<DiscordCharacterMappingScreen />);
+
+    await waitFor(() => {
+      expect(getByText('No unmapped character names found.')).toBeTruthy();
+    });
+  });
+
+  it('saves selected mappings and confirms the alias', async () => {
+    storage.getDiscordMessages.mockResolvedValue([
+      makeDiscordMessage({
+        id: 'message-1',
+        authorId: 'author-1',
+        extractedCharacterName: 'Boone',
+      }),
+    ]);
+    charStorage.loadCharacters.mockResolvedValue([
+      makeCharacter({ id: 'character-1', name: 'Boone' }),
+    ]);
+    storage.saveDiscordMessages.mockResolvedValue(undefined);
+    extraction.confirmCharacterMapping.mockResolvedValue(undefined);
+
+    const { getByText, UNSAFE_getByType } = render(
+      <DiscordCharacterMappingScreen />
+    );
+
+    await waitFor(() => {
+      expect(getByText('"Boone"')).toBeTruthy();
+    });
+
+    const { Picker } = jest.requireActual('@react-native-picker/picker');
+    fireEvent(UNSAFE_getByType(Picker), 'valueChange', 'character-1');
+
+    await waitFor(() => {
+      expect(getByText('Save 1 Mapping')).toBeTruthy();
+    });
+    fireEvent.press(getByText('Save 1 Mapping'));
+
+    await waitFor(() => {
+      expect(storage.saveDiscordMessages).toHaveBeenCalledWith([
+        expect.objectContaining({
+          id: 'message-1',
+          characterId: 'character-1',
+        }),
+      ]);
+      expect(extraction.confirmCharacterMapping).toHaveBeenCalledWith(
+        'Boone',
+        'character-1',
+        'author-1'
+      );
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Success',
+        'Character mappings saved successfully',
+        expect.any(Array)
+      );
+    });
+  });
+
+  it('switches to the existing mappings view and deletes an alias after confirmation', async () => {
+    storage.getDiscordCharacterAliases.mockResolvedValue([
+      makeDiscordCharacterAlias({
+        alias: 'Boone',
+        characterId: 'character-1',
+        discordUserId: 'discord-user-1',
+      }),
+    ]);
+    charStorage.loadCharacters.mockResolvedValue([
+      makeCharacter({ id: 'character-1', name: 'Boone Character' }),
+    ]);
+    storage.saveDiscordCharacterAliases.mockResolvedValue(undefined);
+
+    const { getByText } = render(<DiscordCharacterMappingScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Existing Mappings (1)')).toBeTruthy();
+    });
+    fireEvent.press(getByText('Existing Mappings (1)'));
+
+    await waitFor(() => {
+      expect(getByText('"Boone"')).toBeTruthy();
+      expect(getByText('Boone Character')).toBeTruthy();
+    });
+    fireEvent.press(getByText('🗑️'));
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalled();
+    });
+    await pressAlertButton(alertSpy, 'Delete');
+
+    await waitFor(() => {
+      expect(storage.saveDiscordCharacterAliases).toHaveBeenCalledWith([]);
+    });
+  });
+});

--- a/tst/screens/discord/DiscordConfigScreen.test.tsx
+++ b/tst/screens/discord/DiscordConfigScreen.test.tsx
@@ -1,0 +1,226 @@
+import React from 'react';
+import { render, waitFor, fireEvent } from '@testing-library/react-native';
+import { DiscordConfigScreen } from '@screens/discord/DiscordConfigScreen';
+import * as discordStorage from '@utils/discordStorage';
+import * as discordApi from '@utils/discordApi';
+import { resetNavigationMocks } from '../../helpers/navigation';
+import { spyOnAlert, pressAlertButton } from '../../helpers/alertAndPlatform';
+
+jest.mock('@utils/discordStorage');
+jest.mock('@utils/discordApi');
+
+const storage = jest.mocked(discordStorage);
+const api = jest.mocked(discordApi);
+
+const primeDefaults = () => {
+  storage.getDiscordConfig.mockResolvedValue({
+    enabled: false,
+    autoSync: true,
+    serverConfigs: [],
+  });
+};
+
+describe('DiscordConfigScreen', () => {
+  let alertSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    primeDefaults();
+    alertSpy = spyOnAlert();
+  });
+
+  afterEach(() => {
+    resetNavigationMocks();
+    jest.restoreAllMocks();
+  });
+
+  it('loads and displays the existing config', async () => {
+    storage.getDiscordConfig.mockResolvedValue({
+      botToken: 'existing-token',
+      guildId: 'guild-1',
+      channelId: 'channel-1',
+      enabled: true,
+      autoSync: false,
+      lastSync: '2026-01-01T00:00:00.000Z',
+      serverConfigs: [],
+    });
+
+    const { getByDisplayValue, getByText } = render(<DiscordConfigScreen />);
+
+    await waitFor(() => {
+      expect(getByDisplayValue('guild-1')).toBeTruthy();
+      expect(getByDisplayValue('channel-1')).toBeTruthy();
+      expect(getByText('Enabled')).toBeTruthy();
+    });
+  });
+
+  it('shows an error when testing without a token or channel', async () => {
+    const { getByText } = render(<DiscordConfigScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Test Connection')).toBeTruthy();
+    });
+    fireEvent.press(getByText('Test Connection'));
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Error',
+        'Please enter bot token and channel ID',
+        expect.any(Array)
+      );
+    });
+    expect(api.testDiscordConnection).not.toHaveBeenCalled();
+  });
+
+  it('saves the config then tests the connection', async () => {
+    storage.saveDiscordConfig.mockResolvedValue(undefined);
+    api.testDiscordConnection.mockResolvedValue({ success: true });
+
+    const { getByText, getByPlaceholderText } = render(<DiscordConfigScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Test Connection')).toBeTruthy();
+    });
+    fireEvent.changeText(
+      getByPlaceholderText('Enter Discord bot token'),
+      'a-token'
+    );
+    fireEvent.changeText(
+      getByPlaceholderText('Enter Discord channel ID'),
+      'a-channel'
+    );
+    fireEvent.press(getByText('Test Connection'));
+
+    await waitFor(() => {
+      expect(storage.saveDiscordConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          botToken: 'a-token',
+          channelId: 'a-channel',
+        })
+      );
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Success',
+        'Connection test successful!',
+        expect.any(Array)
+      );
+    });
+  });
+
+  it('reports connection failure with the returned error', async () => {
+    api.testDiscordConnection.mockResolvedValue({
+      success: false,
+      error: 'Bad token',
+    });
+
+    const { getByText, getByPlaceholderText } = render(<DiscordConfigScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Test Connection')).toBeTruthy();
+    });
+    fireEvent.changeText(
+      getByPlaceholderText('Enter Discord bot token'),
+      'a-token'
+    );
+    fireEvent.changeText(
+      getByPlaceholderText('Enter Discord channel ID'),
+      'a-channel'
+    );
+    fireEvent.press(getByText('Test Connection'));
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Connection Failed',
+        'Bad token',
+        expect.any(Array)
+      );
+    });
+  });
+
+  it('syncs messages and reports the result', async () => {
+    api.syncDiscordMessages.mockResolvedValue({
+      newMessages: 3,
+      totalMessages: 10,
+      servers: 1,
+    });
+
+    const { getByText, getByPlaceholderText } = render(<DiscordConfigScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Sync Messages Now')).toBeTruthy();
+    });
+    fireEvent.changeText(
+      getByPlaceholderText('Enter Discord bot token'),
+      'a-token'
+    );
+    fireEvent.changeText(
+      getByPlaceholderText('Enter Discord channel ID'),
+      'a-channel'
+    );
+    fireEvent.press(getByText('Sync Messages Now'));
+
+    await waitFor(() => {
+      expect(api.syncDiscordMessages).toHaveBeenCalled();
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Sync Complete',
+        expect.stringContaining('Synced 3 new messages'),
+        expect.any(Array)
+      );
+    });
+  });
+
+  it('clears messages after confirmation', async () => {
+    storage.clearDiscordMessages.mockResolvedValue(undefined);
+
+    const { getByText } = render(<DiscordConfigScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Clear All Messages')).toBeTruthy();
+    });
+    fireEvent.press(getByText('Clear All Messages'));
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalled();
+    });
+    await pressAlertButton(alertSpy, 'Clear Messages');
+
+    await waitFor(() => {
+      expect(storage.clearDiscordMessages).toHaveBeenCalled();
+    });
+  });
+
+  it('does not clear messages when the confirmation is cancelled', async () => {
+    const { getByText } = render(<DiscordConfigScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Clear All Messages')).toBeTruthy();
+    });
+    fireEvent.press(getByText('Clear All Messages'));
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalled();
+    });
+    await pressAlertButton(alertSpy, 'Cancel');
+
+    expect(storage.clearDiscordMessages).not.toHaveBeenCalled();
+  });
+
+  it('saves the configuration from the Save button', async () => {
+    storage.saveDiscordConfig.mockResolvedValue(undefined);
+
+    const { getByText } = render(<DiscordConfigScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Save Configuration')).toBeTruthy();
+    });
+    fireEvent.press(getByText('Save Configuration'));
+
+    await waitFor(() => {
+      expect(storage.saveDiscordConfig).toHaveBeenCalled();
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Success',
+        'Discord configuration saved successfully',
+        expect.any(Array)
+      );
+    });
+  });
+});

--- a/tst/screens/discord/DiscordMessageContextScreen.test.tsx
+++ b/tst/screens/discord/DiscordMessageContextScreen.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+import { DiscordMessageContextScreen } from '@screens/discord/DiscordMessageContextScreen';
+import * as discordStorage from '@utils/discordStorage';
+import {
+  installRouteParams,
+  resetNavigationMocks,
+} from '../../helpers/navigation';
+import { makeDiscordMessage } from '../../helpers/factories';
+
+jest.mock('@utils/discordStorage');
+
+const storage = jest.mocked(discordStorage);
+
+describe('DiscordMessageContextScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    resetNavigationMocks();
+  });
+
+  it('renders an empty state when there are no messages', async () => {
+    installRouteParams({ messageId: 'message-1' });
+    storage.getDiscordMessages.mockResolvedValue([]);
+
+    const { getByText } = render(<DiscordMessageContextScreen />);
+
+    await waitFor(() => {
+      expect(getByText('No messages found')).toBeTruthy();
+    });
+  });
+
+  it('filters to messages from the same server config as the target message', async () => {
+    installRouteParams({ messageId: 'message-1' });
+    storage.getDiscordMessages.mockResolvedValue([
+      makeDiscordMessage({
+        id: 'message-1',
+        serverConfigId: 'server-1',
+        authorUsername: 'Alice',
+        content: 'Hello there',
+        timestamp: '2026-01-01T00:00:00.000Z',
+      }),
+      makeDiscordMessage({
+        id: 'message-2',
+        serverConfigId: 'server-1',
+        authorUsername: 'Bob',
+        content: 'Same server',
+        timestamp: '2026-01-01T00:01:00.000Z',
+      }),
+      makeDiscordMessage({
+        id: 'message-3',
+        serverConfigId: 'server-2',
+        authorUsername: 'Carl',
+        content: 'Different server',
+        timestamp: '2026-01-01T00:02:00.000Z',
+      }),
+    ]);
+
+    const { getByText, queryByText } = render(<DiscordMessageContextScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Hello there')).toBeTruthy();
+      expect(getByText('Same server')).toBeTruthy();
+    });
+    expect(queryByText('Different server')).toBeNull();
+  });
+
+  it('falls back to filtering by channelId for legacy messages without serverConfigId', async () => {
+    installRouteParams({ messageId: 'message-1' });
+    storage.getDiscordMessages.mockResolvedValue([
+      makeDiscordMessage({
+        id: 'message-1',
+        channelId: 'channel-1',
+        content: 'Legacy target',
+      }),
+      makeDiscordMessage({
+        id: 'message-2',
+        channelId: 'channel-1',
+        content: 'Same legacy channel',
+      }),
+      makeDiscordMessage({
+        id: 'message-3',
+        channelId: 'channel-2',
+        content: 'Other channel',
+      }),
+    ]);
+
+    const { getByText, queryByText } = render(<DiscordMessageContextScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Legacy target')).toBeTruthy();
+      expect(getByText('Same legacy channel')).toBeTruthy();
+    });
+    expect(queryByText('Other channel')).toBeNull();
+  });
+
+  it('sorts messages oldest first', async () => {
+    installRouteParams({ messageId: 'message-1' });
+    storage.getDiscordMessages.mockResolvedValue([
+      makeDiscordMessage({
+        id: 'message-1',
+        serverConfigId: 'server-1',
+        authorUsername: 'Newer',
+        content: 'Newer message',
+        timestamp: '2026-01-01T00:05:00.000Z',
+      }),
+      makeDiscordMessage({
+        id: 'message-2',
+        serverConfigId: 'server-1',
+        authorUsername: 'Older',
+        content: 'Older message',
+        timestamp: '2026-01-01T00:00:00.000Z',
+      }),
+    ]);
+
+    const { getByText } = render(<DiscordMessageContextScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Older message')).toBeTruthy();
+      expect(getByText('Newer message')).toBeTruthy();
+    });
+  });
+
+  it('shows an image indicator when a message has attached images', async () => {
+    installRouteParams({ messageId: 'message-1' });
+    storage.getDiscordMessages.mockResolvedValue([
+      makeDiscordMessage({
+        id: 'message-1',
+        content: 'Look at this',
+        imageUris: ['file://one.jpg', 'file://two.jpg'],
+      }),
+    ]);
+
+    const { getByText } = render(<DiscordMessageContextScreen />);
+
+    await waitFor(() => {
+      expect(getByText('📷 2 images')).toBeTruthy();
+    });
+  });
+});

--- a/tst/screens/discord/DiscordMessagesScreen.test.tsx
+++ b/tst/screens/discord/DiscordMessagesScreen.test.tsx
@@ -1,0 +1,214 @@
+import React from 'react';
+import { render, waitFor, fireEvent } from '@testing-library/react-native';
+import { Picker } from '@react-native-picker/picker';
+import { DiscordMessagesScreen } from '@screens/discord/DiscordMessagesScreen';
+import * as discordStorage from '@utils/discordStorage';
+import * as characterStorage from '@utils/characterStorage';
+import * as discordCharacterExtraction from '@utils/discordCharacterExtraction';
+import {
+  installFocusEffectOnce,
+  resetNavigationMocks,
+} from '../../helpers/navigation';
+import { spyOnAlert, pressAlertButton } from '../../helpers/alertAndPlatform';
+import {
+  makeCharacter,
+  makeDiscordMessage,
+  makeDiscordServerConfig,
+} from '../../helpers/factories';
+
+jest.mock('@utils/discordStorage');
+jest.mock('@utils/characterStorage');
+jest.mock('@utils/discordCharacterExtraction');
+
+const storage = jest.mocked(discordStorage);
+const charStorage = jest.mocked(characterStorage);
+const extraction = jest.mocked(discordCharacterExtraction);
+
+const primeDefaults = () => {
+  storage.getDiscordMessages.mockResolvedValue([]);
+  charStorage.loadCharacters.mockResolvedValue([]);
+  storage.getDiscordServerConfigs.mockResolvedValue([]);
+};
+
+describe('DiscordMessagesScreen', () => {
+  let alertSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    primeDefaults();
+    installFocusEffectOnce();
+    alertSpy = spyOnAlert();
+  });
+
+  afterEach(() => {
+    resetNavigationMocks();
+    jest.restoreAllMocks();
+  });
+
+  it('shows an empty state when there are no messages', async () => {
+    const { getByText } = render(<DiscordMessagesScreen />);
+
+    await waitFor(() => {
+      expect(getByText('No  messages found')).toBeTruthy();
+    });
+  });
+
+  it('renders a card for each loaded message with its tag status', async () => {
+    storage.getDiscordMessages.mockResolvedValue([
+      makeDiscordMessage({
+        id: 'message-1',
+        authorUsername: 'Alice',
+        content: 'Untagged message',
+      }),
+      makeDiscordMessage({
+        id: 'message-2',
+        authorUsername: 'Bob',
+        content: 'Tagged message',
+        characterId: 'character-1',
+      }),
+    ]);
+    charStorage.loadCharacters.mockResolvedValue([
+      makeCharacter({ id: 'character-1', name: 'Boone' }),
+    ]);
+
+    const { getByText } = render(<DiscordMessagesScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Untagged message')).toBeTruthy();
+      expect(getByText('Tagged message')).toBeTruthy();
+      expect(getByText('UNTAGGED')).toBeTruthy();
+      expect(getByText('Boone')).toBeTruthy();
+    });
+  });
+
+  it('filters messages by tagged/untagged/ignored', async () => {
+    storage.getDiscordMessages.mockResolvedValue([
+      makeDiscordMessage({ id: 'message-1', content: 'Untagged one' }),
+      makeDiscordMessage({
+        id: 'message-2',
+        content: 'Tagged one',
+        characterId: 'character-1',
+      }),
+      makeDiscordMessage({
+        id: 'message-3',
+        content: 'Ignored one',
+        ignored: true,
+      }),
+    ]);
+    charStorage.loadCharacters.mockResolvedValue([
+      makeCharacter({ id: 'character-1', name: 'Boone' }),
+    ]);
+
+    const { getByText, queryByText } = render(<DiscordMessagesScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Untagged one')).toBeTruthy();
+      expect(getByText('Tagged one')).toBeTruthy();
+    });
+    expect(queryByText('Ignored one')).toBeNull();
+
+    fireEvent.press(getByText('Untagged (1)'));
+    await waitFor(() => {
+      expect(getByText('Untagged one')).toBeTruthy();
+    });
+    expect(queryByText('Tagged one')).toBeNull();
+
+    fireEvent.press(getByText('Ignored (1)'));
+    await waitFor(() => {
+      expect(getByText('Ignored one')).toBeTruthy();
+    });
+    expect(queryByText('Untagged one')).toBeNull();
+  });
+
+  it('ignores a message after confirmation', async () => {
+    storage.getDiscordMessages.mockResolvedValue([
+      makeDiscordMessage({ id: 'message-1', content: 'To be ignored' }),
+    ]);
+    storage.saveDiscordMessages.mockResolvedValue(undefined);
+
+    const { getByText } = render(<DiscordMessagesScreen />);
+
+    await waitFor(() => {
+      expect(getByText('✕ Ignore')).toBeTruthy();
+    });
+    fireEvent.press(getByText('✕ Ignore'), { stopPropagation: () => {} });
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalled();
+    });
+    await pressAlertButton(alertSpy, 'Ignore');
+
+    await waitFor(() => {
+      expect(storage.saveDiscordMessages).toHaveBeenCalledWith([
+        expect.objectContaining({ id: 'message-1', ignored: true }),
+      ]);
+    });
+  });
+
+  it('shows the server/channel filter picker when server configs exist', async () => {
+    storage.getDiscordServerConfigs.mockResolvedValue([
+      makeDiscordServerConfig({ id: 'server-1', name: 'Main Server' }),
+    ]);
+
+    const { getByText } = render(<DiscordMessagesScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Server/Channel:')).toBeTruthy();
+    });
+  });
+
+  it('opens the mapping modal and saves a character mapping', async () => {
+    storage.getDiscordMessages.mockResolvedValue([
+      makeDiscordMessage({
+        id: 'message-1',
+        authorId: 'author-1',
+        authorUsername: 'Alice',
+        content: 'Please tag me',
+        extractedCharacterName: 'Boone',
+      }),
+    ]);
+    charStorage.loadCharacters.mockResolvedValue([
+      makeCharacter({ id: 'character-1', name: 'Boone' }),
+    ]);
+    storage.saveDiscordMessages.mockResolvedValue(undefined);
+    extraction.confirmCharacterMapping.mockResolvedValue(undefined);
+    storage.applyAliasToMessages.mockResolvedValue(1);
+
+    const { getByText, UNSAFE_getAllByType } = render(
+      <DiscordMessagesScreen />
+    );
+
+    await waitFor(() => {
+      expect(getByText('Please tag me')).toBeTruthy();
+    });
+    fireEvent.press(getByText('Please tag me'));
+
+    await waitFor(() => {
+      expect(getByText('Link Message to Character')).toBeTruthy();
+    });
+
+    const pickers = UNSAFE_getAllByType(Picker);
+    fireEvent(pickers[pickers.length - 1], 'valueChange', 'character-1');
+
+    fireEvent.press(getByText('Save'));
+
+    await waitFor(() => {
+      expect(storage.saveDiscordMessages).toHaveBeenCalledWith([
+        expect.objectContaining({
+          id: 'message-1',
+          characterId: 'character-1',
+        }),
+      ]);
+      expect(extraction.confirmCharacterMapping).toHaveBeenCalledWith(
+        'Boone',
+        'character-1',
+        'author-1'
+      );
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Success',
+        expect.any(String),
+        expect.any(Array)
+      );
+    });
+  });
+});

--- a/tst/screens/discord/DiscordServerFormScreen.test.tsx
+++ b/tst/screens/discord/DiscordServerFormScreen.test.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import {
+  render,
+  waitFor,
+  fireEvent,
+  type RenderResult,
+} from '@testing-library/react-native';
+import { DiscordServerFormScreen } from '@screens/discord/DiscordServerFormScreen';
+import * as discordStorage from '@utils/discordStorage';
+import * as discordApi from '@utils/discordApi';
+import {
+  installNavigationMock,
+  installRouteParams,
+  resetNavigationMocks,
+} from '../../helpers/navigation';
+import { spyOnAlert, pressAlertButton } from '../../helpers/alertAndPlatform';
+import { makeDiscordServerConfig } from '../../helpers/factories';
+
+jest.mock('@utils/discordStorage');
+jest.mock('@utils/discordApi');
+
+const storage = jest.mocked(discordStorage);
+const api = jest.mocked(discordApi);
+
+const fillRequiredFields = (
+  getByPlaceholderText: RenderResult['getByPlaceholderText']
+) => {
+  fireEvent.changeText(
+    getByPlaceholderText('e.g., Main RP Server - IC Chat'),
+    'Main RP Server'
+  );
+  fireEvent.changeText(
+    getByPlaceholderText('Enter Discord bot token'),
+    'bot-token-123'
+  );
+  fireEvent.changeText(
+    getByPlaceholderText('Enter Discord channel ID'),
+    'channel-123'
+  );
+};
+
+describe('DiscordServerFormScreen', () => {
+  let alertSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    installNavigationMock();
+    installRouteParams({});
+    alertSpy = spyOnAlert();
+  });
+
+  afterEach(() => {
+    resetNavigationMocks();
+    jest.restoreAllMocks();
+  });
+
+  it('shows the create action when adding a new server', async () => {
+    const { getByText } = render(<DiscordServerFormScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Add Server Configuration')).toBeTruthy();
+      expect(getByText('Save Configuration')).toBeTruthy();
+    });
+  });
+
+  it('shows a validation error instead of saving an incomplete form', async () => {
+    const { getByText } = render(<DiscordServerFormScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Save Configuration')).toBeTruthy();
+    });
+    fireEvent.press(getByText('Save Configuration'));
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Error',
+        'Please enter a name for this configuration',
+        expect.any(Array)
+      );
+    });
+    expect(storage.addDiscordServerConfig).not.toHaveBeenCalled();
+  });
+
+  it('adds a new server configuration and navigates back on success', async () => {
+    storage.addDiscordServerConfig.mockResolvedValue(makeDiscordServerConfig());
+    const nav = installNavigationMock();
+
+    const { getByText, getByPlaceholderText } = render(
+      <DiscordServerFormScreen />
+    );
+
+    await waitFor(() => {
+      expect(getByText('Save Configuration')).toBeTruthy();
+    });
+    fillRequiredFields(getByPlaceholderText);
+    fireEvent.press(getByText('Save Configuration'));
+
+    await waitFor(() => {
+      expect(storage.addDiscordServerConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Main RP Server',
+          botToken: 'bot-token-123',
+          channelId: 'channel-123',
+        })
+      );
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Success',
+        'Server configuration added successfully',
+        expect.any(Array)
+      );
+    });
+    await pressAlertButton(alertSpy, 'OK');
+
+    expect(nav.goBack).toHaveBeenCalled();
+  });
+
+  it('prefills existing data and updates instead of creating', async () => {
+    installRouteParams({ serverConfigId: 'server-99' });
+    storage.getDiscordServerConfig.mockResolvedValue(
+      makeDiscordServerConfig({
+        id: 'server-99',
+        name: 'Existing Server',
+        botToken: 'existing-token',
+        channelId: 'existing-channel',
+      })
+    );
+    storage.updateDiscordServerConfig.mockResolvedValue(
+      makeDiscordServerConfig({ id: 'server-99' })
+    );
+    const nav = installNavigationMock();
+
+    const { getByText, getByDisplayValue } = render(
+      <DiscordServerFormScreen />
+    );
+
+    await waitFor(() => {
+      expect(getByDisplayValue('Existing Server')).toBeTruthy();
+      expect(getByText('Update Configuration')).toBeTruthy();
+    });
+    fireEvent.press(getByText('Update Configuration'));
+
+    await waitFor(() => {
+      expect(storage.updateDiscordServerConfig).toHaveBeenCalledWith(
+        'server-99',
+        expect.objectContaining({ name: 'Existing Server' })
+      );
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Success',
+        'Server configuration updated successfully',
+        expect.any(Array)
+      );
+    });
+    expect(storage.addDiscordServerConfig).not.toHaveBeenCalled();
+
+    await pressAlertButton(alertSpy, 'OK');
+    expect(nav.goBack).toHaveBeenCalled();
+  });
+
+  it('tests the connection using the entered token and channel', async () => {
+    api.verifyDiscordToken.mockResolvedValue(true);
+    api.verifyChannelAccess.mockResolvedValue(true);
+    installRouteParams({ serverConfigId: 'server-99' });
+    storage.getDiscordServerConfig.mockResolvedValue(
+      makeDiscordServerConfig({ id: 'server-99' })
+    );
+
+    const { getByText } = render(<DiscordServerFormScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Test Connection')).toBeTruthy();
+    });
+    fireEvent.press(getByText('Test Connection'));
+
+    await waitFor(() => {
+      expect(api.verifyDiscordToken).toHaveBeenCalled();
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Success',
+        'Connection test successful!',
+        expect.any(Array)
+      );
+    });
+  });
+
+  it('navigates back when Cancel is pressed', async () => {
+    const nav = installNavigationMock();
+    const { getByText } = render(<DiscordServerFormScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Cancel')).toBeTruthy();
+    });
+    fireEvent.press(getByText('Cancel'));
+
+    expect(nav.goBack).toHaveBeenCalled();
+  });
+});

--- a/tst/screens/discord/DiscordServerListScreen.test.tsx
+++ b/tst/screens/discord/DiscordServerListScreen.test.tsx
@@ -1,0 +1,198 @@
+import React from 'react';
+import { Switch } from 'react-native';
+import { render, waitFor, fireEvent, act } from '@testing-library/react-native';
+import { DiscordServerListScreen } from '@screens/discord/DiscordServerListScreen';
+import * as discordStorage from '@utils/discordStorage';
+import * as discordApi from '@utils/discordApi';
+import {
+  installNavigationMock,
+  installFocusEffectOnce,
+  resetNavigationMocks,
+} from '../../helpers/navigation';
+import { spyOnAlert, pressAlertButton } from '../../helpers/alertAndPlatform';
+import { makeDiscordServerConfig } from '../../helpers/factories';
+
+jest.mock('@utils/discordStorage');
+jest.mock('@utils/discordApi');
+
+const storage = jest.mocked(discordStorage);
+const api = jest.mocked(discordApi);
+
+const primeDefaults = () => {
+  storage.getDiscordServerConfigs.mockResolvedValue([]);
+  storage.getDiscordConfig.mockResolvedValue({
+    enabled: false,
+    autoSync: true,
+    serverConfigs: [],
+  });
+};
+
+describe('DiscordServerListScreen', () => {
+  let alertSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    primeDefaults();
+    installFocusEffectOnce();
+    alertSpy = spyOnAlert();
+  });
+
+  afterEach(() => {
+    resetNavigationMocks();
+    jest.restoreAllMocks();
+  });
+
+  it('renders the empty state when there are no server configs', async () => {
+    const { getByText } = render(<DiscordServerListScreen />);
+
+    await waitFor(() => {
+      expect(getByText('No server configurations yet')).toBeTruthy();
+    });
+  });
+
+  it('loads server configs and global config on mount', async () => {
+    render(<DiscordServerListScreen />);
+
+    await waitFor(() => {
+      expect(storage.getDiscordServerConfigs).toHaveBeenCalled();
+      expect(storage.getDiscordConfig).toHaveBeenCalled();
+    });
+  });
+
+  it('renders a server card for each configured server', async () => {
+    storage.getDiscordServerConfigs.mockResolvedValue([
+      makeDiscordServerConfig({ name: 'Main RP Server', channelId: 'chan-1' }),
+    ]);
+
+    const { getByText } = render(<DiscordServerListScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Main RP Server')).toBeTruthy();
+      expect(getByText('chan-1')).toBeTruthy();
+    });
+  });
+
+  it('navigates to the form screen to add a new server', async () => {
+    const nav = installNavigationMock();
+    const { getByText } = render(<DiscordServerListScreen />);
+
+    await waitFor(() => {
+      expect(getByText('+ Add Server/Channel')).toBeTruthy();
+    });
+    fireEvent.press(getByText('+ Add Server/Channel'));
+
+    expect(nav.navigate).toHaveBeenCalledWith('DiscordServerForm', {});
+  });
+
+  it('navigates to the form screen to edit an existing server', async () => {
+    const nav = installNavigationMock();
+    storage.getDiscordServerConfigs.mockResolvedValue([
+      makeDiscordServerConfig({ id: 'server-99', name: 'Main RP Server' }),
+    ]);
+
+    const { getByText } = render(<DiscordServerListScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Edit')).toBeTruthy();
+    });
+    fireEvent.press(getByText('Edit'));
+
+    expect(nav.navigate).toHaveBeenCalledWith('DiscordServerForm', {
+      serverConfigId: 'server-99',
+    });
+  });
+
+  it('tests the connection for a server and shows the result', async () => {
+    storage.getDiscordServerConfigs.mockResolvedValue([
+      makeDiscordServerConfig({ name: 'Main RP Server' }),
+    ]);
+    api.testDiscordConnection.mockResolvedValue({ success: true });
+
+    const { getByText } = render(<DiscordServerListScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Test')).toBeTruthy();
+    });
+    await act(async () => {
+      fireEvent.press(getByText('Test'));
+    });
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Success',
+        expect.stringContaining('Main RP Server'),
+        expect.any(Array)
+      );
+    });
+  });
+
+  it('deletes a server configuration after confirmation', async () => {
+    storage.getDiscordServerConfigs.mockResolvedValue([
+      makeDiscordServerConfig({ id: 'server-99', name: 'Main RP Server' }),
+    ]);
+    storage.removeDiscordServerConfig.mockResolvedValue(undefined);
+
+    const { getByText } = render(<DiscordServerListScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Delete')).toBeTruthy();
+    });
+    fireEvent.press(getByText('Delete'));
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalled();
+    });
+    await pressAlertButton(alertSpy, 'Delete');
+
+    await waitFor(() => {
+      expect(storage.removeDiscordServerConfig).toHaveBeenCalledWith(
+        'server-99'
+      );
+    });
+  });
+
+  it('does not delete when the confirmation is cancelled', async () => {
+    storage.getDiscordServerConfigs.mockResolvedValue([
+      makeDiscordServerConfig({ id: 'server-99', name: 'Main RP Server' }),
+    ]);
+
+    const { getByText } = render(<DiscordServerListScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Delete')).toBeTruthy();
+    });
+    fireEvent.press(getByText('Delete'));
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalled();
+    });
+    await pressAlertButton(alertSpy, 'Cancel');
+
+    expect(storage.removeDiscordServerConfig).not.toHaveBeenCalled();
+  });
+
+  it('toggles global Discord integration and persists it', async () => {
+    storage.getDiscordConfig.mockResolvedValue({
+      enabled: false,
+      autoSync: true,
+      serverConfigs: [],
+    });
+    storage.saveDiscordConfig.mockResolvedValue(undefined);
+
+    const { getByText, UNSAFE_getAllByType } = render(
+      <DiscordServerListScreen />
+    );
+
+    await waitFor(() => {
+      expect(getByText('Discord Integration')).toBeTruthy();
+    });
+    const [globalSwitch] = UNSAFE_getAllByType(Switch);
+    fireEvent(globalSwitch, 'valueChange', true);
+
+    await waitFor(() => {
+      expect(storage.saveDiscordConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ enabled: true })
+      );
+    });
+  });
+});

--- a/tst/screens/location/LocationMapScreen.test.tsx
+++ b/tst/screens/location/LocationMapScreen.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Image } from 'react-native';
+import { render, waitFor } from '@testing-library/react-native';
+import { LocationMapScreen } from '@screens/location/LocationMapScreen';
+
+/**
+ * The global `react-native-reanimated` and `react-native-gesture-handler`
+ * mocks (jest.setup.js) only cover what the templated list/detail/form
+ * screens need. LocationMapScreen is the sole user of shared-value
+ * animations and gesture composition, so it needs its own local mocks —
+ * simple passthroughs are enough to exercise the mount/resize behavior
+ * without a real gesture/animation engine.
+ */
+jest.mock('react-native-reanimated', () => ({
+  __esModule: true,
+  default: {
+    View: 'Animated.View',
+    Image: 'Animated.Image',
+    createAnimatedComponent: (component: unknown) => component,
+  },
+  useSharedValue: (initial: number) => ({ value: initial }),
+  useAnimatedStyle: (factory: () => unknown) => factory(),
+  withTiming: (value: number) => value,
+}));
+
+const chainable = () => {
+  const gesture: Record<string, jest.Mock> = {};
+  ['onUpdate', 'onEnd', 'numberOfTaps'].forEach(method => {
+    gesture[method] = jest.fn(() => gesture);
+  });
+  return gesture;
+};
+
+jest.mock('react-native-gesture-handler', () => ({
+  GestureDetector: ({ children }: { children: React.ReactNode }) => children,
+  Gesture: {
+    Pinch: () => chainable(),
+    Pan: () => chainable(),
+    Tap: () => chainable(),
+    Simultaneous: (...gestures: unknown[]) => gestures,
+  },
+}));
+
+describe('LocationMapScreen', () => {
+  it('shows a loading state before the map asset size resolves', () => {
+    jest.spyOn(Image, 'resolveAssetSource').mockReturnValue(undefined as any);
+
+    const { getByText } = render(<LocationMapScreen />);
+
+    expect(getByText('Loading map...')).toBeTruthy();
+  });
+
+  it('renders the map image once the asset size resolves', async () => {
+    jest.spyOn(Image, 'resolveAssetSource').mockReturnValue({
+      width: 1000,
+      height: 500,
+      uri: 'mock-map-uri',
+      scale: 1,
+    });
+
+    const { queryByText, UNSAFE_getByType } = render(<LocationMapScreen />);
+
+    await waitFor(() => {
+      expect(queryByText('Loading map...')).toBeNull();
+    });
+    expect(UNSAFE_getByType('Animated.Image' as never)).toBeTruthy();
+  });
+});

--- a/tst/utils/factionStats.test.ts
+++ b/tst/utils/factionStats.test.ts
@@ -1,0 +1,302 @@
+import {
+  calculateFactionStats,
+  calculateCombinedFactionStats,
+  getAllFactionStats,
+} from '@/utils/factionStats';
+import { GameCharacter, RelationshipStanding } from '@/models/types';
+import { FactionRelationship } from '@/utils/characterStorage';
+import { makeCharacter } from '../helpers/factories';
+
+describe('factionStats', () => {
+  describe('calculateFactionStats', () => {
+    it('returns empty stats when the faction has no members', () => {
+      const stats = calculateFactionStats('Brotherhood', []);
+
+      expect(stats).toEqual({
+        factionName: 'Brotherhood',
+        totalMembers: 0,
+        presentMembers: 0,
+        perkTagCounts: {},
+        topPerkTags: [],
+        commonPerks: [],
+        commonDistinctions: [],
+        speciesDistribution: {},
+        relationships: [],
+        alliedFactions: [],
+        enemyFactions: [],
+      });
+    });
+
+    it('only counts Ally/Friend standings as members, ignoring Neutral/Hostile/Enemy', () => {
+      const characters: GameCharacter[] = [
+        makeCharacter({
+          id: '1',
+          name: 'Ally Member',
+          factions: [
+            { name: 'Brotherhood', standing: RelationshipStanding.Ally },
+          ],
+        }),
+        makeCharacter({
+          id: '2',
+          name: 'Friend Member',
+          factions: [
+            { name: 'Brotherhood', standing: RelationshipStanding.Friend },
+          ],
+        }),
+        makeCharacter({
+          id: '3',
+          name: 'Enemy Non-member',
+          factions: [
+            { name: 'Brotherhood', standing: RelationshipStanding.Enemy },
+          ],
+        }),
+        makeCharacter({
+          id: '4',
+          name: 'Unrelated',
+          factions: [{ name: 'Raiders', standing: RelationshipStanding.Ally }],
+        }),
+      ];
+
+      const stats = calculateFactionStats('Brotherhood', characters);
+
+      expect(stats.totalMembers).toBe(2);
+    });
+
+    it('counts present members separately from total members', () => {
+      const characters: GameCharacter[] = [
+        makeCharacter({
+          id: '1',
+          name: 'Present',
+          present: true,
+          factions: [
+            { name: 'Brotherhood', standing: RelationshipStanding.Ally },
+          ],
+        }),
+        makeCharacter({
+          id: '2',
+          name: 'Absent',
+          present: false,
+          factions: [
+            { name: 'Brotherhood', standing: RelationshipStanding.Ally },
+          ],
+        }),
+      ];
+
+      const stats = calculateFactionStats('Brotherhood', characters);
+
+      expect(stats.totalMembers).toBe(2);
+      expect(stats.presentMembers).toBe(1);
+    });
+
+    it('aggregates perk tag counts, top perk tags, common perks, and species distribution', () => {
+      const characters: GameCharacter[] = [
+        makeCharacter({
+          id: '1',
+          name: 'Member A',
+          species: 'Human',
+          perkIds: ['agility_1'],
+          factions: [
+            { name: 'Brotherhood', standing: RelationshipStanding.Ally },
+          ],
+        }),
+        makeCharacter({
+          id: '2',
+          name: 'Member B',
+          species: 'Human',
+          perkIds: ['agility_1', 'agility_2'],
+          factions: [
+            { name: 'Brotherhood', standing: RelationshipStanding.Friend },
+          ],
+        }),
+        makeCharacter({
+          id: '3',
+          name: 'Member C',
+          species: 'Mutant',
+          perkIds: [],
+          factions: [
+            { name: 'Brotherhood', standing: RelationshipStanding.Ally },
+          ],
+        }),
+      ];
+
+      const stats = calculateFactionStats('Brotherhood', characters);
+
+      expect(stats.perkTagCounts.Agility).toBe(3);
+      expect(stats.topPerkTags[0]).toEqual({
+        tag: 'Agility',
+        count: 3,
+        percentage: 100,
+      });
+      expect(stats.commonPerks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'Agile Strikes',
+            count: 2,
+            percentage: (2 / 3) * 100,
+          }),
+        ])
+      );
+      expect(stats.speciesDistribution).toEqual({ Human: 2, Mutant: 1 });
+    });
+
+    it('falls back to Unknown Perk/Distinction names for unrecognized ids', () => {
+      const characters: GameCharacter[] = [
+        makeCharacter({
+          id: '1',
+          name: 'Member A',
+          perkIds: ['not-a-real-perk'],
+          distinctionIds: ['not-a-real-distinction'],
+          factions: [
+            { name: 'Brotherhood', standing: RelationshipStanding.Ally },
+          ],
+        }),
+      ];
+
+      const stats = calculateFactionStats('Brotherhood', characters);
+
+      expect(stats.commonPerks[0].name).toBe('Unknown Perk');
+      expect(stats.commonDistinctions[0].name).toBe('Unknown Distinction');
+    });
+
+    it('classifies faction relationships into allied and enemy factions', () => {
+      const relationships: FactionRelationship[] = [
+        { factionName: 'Raiders', relationshipType: RelationshipStanding.Ally },
+        {
+          factionName: 'Scavengers',
+          relationshipType: RelationshipStanding.Friend,
+        },
+        {
+          factionName: 'Vault Dwellers',
+          relationshipType: RelationshipStanding.Enemy,
+        },
+        {
+          factionName: 'Ghouls',
+          relationshipType: RelationshipStanding.Hostile,
+        },
+        {
+          factionName: 'Traders',
+          relationshipType: RelationshipStanding.Neutral,
+        },
+      ];
+      const characters: GameCharacter[] = [
+        makeCharacter({
+          id: '1',
+          name: 'Member A',
+          factions: [
+            { name: 'Brotherhood', standing: RelationshipStanding.Ally },
+          ],
+        }),
+      ];
+
+      const stats = calculateFactionStats(
+        'Brotherhood',
+        characters,
+        relationships
+      );
+
+      expect(stats.alliedFactions).toEqual(['Raiders', 'Scavengers']);
+      expect(stats.enemyFactions).toEqual(['Vault Dwellers', 'Ghouls']);
+      expect(stats.relationships).toBe(relationships);
+    });
+  });
+
+  describe('calculateCombinedFactionStats', () => {
+    it('combines member counts and perk tags with allied factions', () => {
+      const characters: GameCharacter[] = [
+        makeCharacter({
+          id: '1',
+          name: 'Brotherhood Member',
+          perkIds: ['agility_1'],
+          factions: [
+            { name: 'Brotherhood', standing: RelationshipStanding.Ally },
+          ],
+        }),
+        makeCharacter({
+          id: '2',
+          name: 'Ally Member',
+          perkIds: ['agility_1'],
+          factions: [
+            { name: 'Scavengers', standing: RelationshipStanding.Ally },
+          ],
+        }),
+      ];
+      const relationshipsMap = new Map<string, FactionRelationship[]>([
+        [
+          'Brotherhood',
+          [
+            {
+              factionName: 'Scavengers',
+              relationshipType: RelationshipStanding.Ally,
+            },
+          ],
+        ],
+        ['Scavengers', []],
+      ]);
+
+      const combined = calculateCombinedFactionStats(
+        'Brotherhood',
+        characters,
+        relationshipsMap
+      );
+
+      expect(combined.directMembers).toBe(1);
+      expect(combined.alliedFactions).toEqual(['Scavengers']);
+      expect(combined.combinedMembers).toBe(2);
+      expect(combined.combinedPerkTags.Agility).toBe(2);
+      expect(combined.strengthMultiplier).toBe(2);
+    });
+
+    it('defaults strengthMultiplier to 1 when the faction has no direct members', () => {
+      const relationshipsMap = new Map<string, FactionRelationship[]>();
+
+      const combined = calculateCombinedFactionStats(
+        'Empty Faction',
+        [],
+        relationshipsMap
+      );
+
+      expect(combined.directMembers).toBe(0);
+      expect(combined.combinedMembers).toBe(0);
+      expect(combined.strengthMultiplier).toBe(1);
+    });
+
+    it('treats an unknown faction relationships key as an empty relationship list', () => {
+      const combined = calculateCombinedFactionStats(
+        'Unknown Faction',
+        [],
+        new Map()
+      );
+
+      expect(combined.alliedFactions).toEqual([]);
+      expect(combined.combinedMembers).toBe(0);
+    });
+  });
+
+  describe('getAllFactionStats', () => {
+    it('returns stats for every faction present in the relationships map', () => {
+      const characters: GameCharacter[] = [
+        makeCharacter({
+          id: '1',
+          name: 'Member A',
+          factions: [
+            { name: 'Brotherhood', standing: RelationshipStanding.Ally },
+          ],
+        }),
+      ];
+      const relationshipsMap = new Map<string, FactionRelationship[]>([
+        ['Brotherhood', []],
+        ['Raiders', []],
+      ]);
+
+      const stats = getAllFactionStats(characters, relationshipsMap);
+
+      expect(stats.map(s => s.factionName)).toEqual(['Brotherhood', 'Raiders']);
+      expect(stats[0].totalMembers).toBe(1);
+      expect(stats[1].totalMembers).toBe(0);
+    });
+
+    it('returns an empty array when the relationships map is empty', () => {
+      expect(getAllFactionStats([], new Map())).toEqual([]);
+    });
+  });
+});

--- a/tst/utils/influenceAnalysis.test.ts
+++ b/tst/utils/influenceAnalysis.test.ts
@@ -1,0 +1,455 @@
+import {
+  calculateCharacterInfluence,
+  getTopInfluencers,
+  analyzeFactionInfluence,
+  buildRelationshipNetwork,
+  findFactionConnections,
+  findMutualRelationships,
+  findKeyConnectors,
+  findPowerCenters,
+} from '@/utils/influenceAnalysis';
+import { GameCharacter, RelationshipStanding } from '@/models/types';
+import { makeCharacter, makeStoredFaction } from '../helpers/factories';
+import { getStorageMock, primeStorageDefaults } from '../helpers/storage';
+
+jest.mock('@utils/characterStorage');
+
+describe('influenceAnalysis', () => {
+  describe('calculateCharacterInfluence', () => {
+    it('scores positive relationships, negative relationships, and factions', () => {
+      const character = makeCharacter({
+        id: '1',
+        name: 'Alice',
+        factions: [
+          { name: 'Brotherhood', standing: RelationshipStanding.Ally },
+        ],
+        relationships: [
+          { characterName: 'Bob', relationshipType: RelationshipStanding.Ally },
+          {
+            characterName: 'Carl',
+            relationshipType: RelationshipStanding.Enemy,
+          },
+        ],
+      });
+
+      const influence = calculateCharacterInfluence(character, [character]);
+
+      // 1 positive * 3 - 1 negative * 2 + 1 faction * 5 = 6
+      expect(influence.influenceScore).toBe(6);
+      expect(influence.relationshipCount).toBe(2);
+      expect(influence.positiveRelationships).toBe(1);
+      expect(influence.negativeRelationships).toBe(1);
+      expect(influence.factionCount).toBe(1);
+      expect(influence.factions).toEqual(['Brotherhood']);
+    });
+
+    it('collects connections from both outgoing relationships and reverse references', () => {
+      const alice = makeCharacter({
+        id: '1',
+        name: 'Alice',
+        relationships: [
+          { characterName: 'Bob', relationshipType: RelationshipStanding.Ally },
+        ],
+      });
+      const bob = makeCharacter({
+        id: '2',
+        name: 'Bob',
+        relationships: [],
+      });
+      const carl = makeCharacter({
+        id: '3',
+        name: 'Carl',
+        relationships: [
+          {
+            characterName: 'Alice',
+            relationshipType: RelationshipStanding.Friend,
+          },
+        ],
+      });
+
+      const influence = calculateCharacterInfluence(alice, [alice, bob, carl]);
+
+      expect(influence.connections.sort()).toEqual(['Bob', 'Carl']);
+    });
+
+    it('handles characters with no relationships or factions', () => {
+      const character = makeCharacter({ relationships: [], factions: [] });
+
+      const influence = calculateCharacterInfluence(character, [character]);
+
+      expect(influence.influenceScore).toBe(0);
+      expect(influence.connections).toEqual([]);
+    });
+  });
+
+  describe('getTopInfluencers', () => {
+    it('filters out characters with zero or negative influence and sorts descending', () => {
+      const influential = makeCharacter({
+        id: '1',
+        name: 'Influential',
+        factions: [
+          { name: 'Brotherhood', standing: RelationshipStanding.Ally },
+        ],
+      });
+      const neutral = makeCharacter({ id: '2', name: 'Neutral' });
+      const negative = makeCharacter({
+        id: '3',
+        name: 'Negative',
+        relationships: [
+          {
+            characterName: 'Influential',
+            relationshipType: RelationshipStanding.Enemy,
+          },
+        ],
+      });
+
+      const top = getTopInfluencers([influential, neutral, negative]);
+
+      expect(top.map(inf => inf.character.name)).toEqual(['Influential']);
+    });
+
+    it('respects the limit parameter', () => {
+      const characters: GameCharacter[] = Array.from({ length: 15 }, (_, i) =>
+        makeCharacter({
+          id: `${i}`,
+          name: `Char ${i}`,
+          factions: [
+            { name: 'Brotherhood', standing: RelationshipStanding.Ally },
+          ],
+        })
+      );
+
+      expect(getTopInfluencers(characters, 3)).toHaveLength(3);
+      expect(getTopInfluencers(characters)).toHaveLength(10);
+    });
+  });
+
+  describe('analyzeFactionInfluence', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      primeStorageDefaults();
+    });
+
+    it('groups characters by faction and computes total/average influence', async () => {
+      const storage = getStorageMock();
+      storage.loadFactions.mockResolvedValue([]);
+
+      const alice = makeCharacter({
+        id: '1',
+        name: 'Alice',
+        factions: [
+          { name: 'Brotherhood', standing: RelationshipStanding.Ally },
+        ],
+        relationships: [
+          { characterName: 'Bob', relationshipType: RelationshipStanding.Ally },
+        ],
+      });
+      const bob = makeCharacter({
+        id: '2',
+        name: 'Bob',
+        factions: [
+          { name: 'Brotherhood', standing: RelationshipStanding.Friend },
+        ],
+      });
+
+      const result = await analyzeFactionInfluence([alice, bob]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('Brotherhood');
+      expect(result[0].memberCount).toBe(2);
+      expect(result[0].averageInfluence).toBe(
+        result[0].totalInfluence / result[0].memberCount
+      );
+    });
+
+    it('excludes retired factions from the analysis', async () => {
+      const storage = getStorageMock();
+      storage.loadFactions.mockResolvedValue([
+        makeStoredFaction({ name: 'Retired Faction', retired: true }),
+      ]);
+
+      const alice = makeCharacter({
+        id: '1',
+        name: 'Alice',
+        factions: [
+          { name: 'Retired Faction', standing: RelationshipStanding.Ally },
+        ],
+      });
+
+      const result = await analyzeFactionInfluence([alice]);
+
+      expect(result).toEqual([]);
+    });
+
+    it('identifies allied and enemy factions from member faction standings', async () => {
+      const storage = getStorageMock();
+      storage.loadFactions.mockResolvedValue([]);
+
+      const alice = makeCharacter({
+        id: '1',
+        name: 'Alice',
+        factions: [
+          { name: 'Brotherhood', standing: RelationshipStanding.Ally },
+          { name: 'Raiders', standing: RelationshipStanding.Enemy },
+          { name: 'Scavengers', standing: RelationshipStanding.Ally },
+        ],
+      });
+
+      const result = await analyzeFactionInfluence([alice]);
+
+      const brotherhood = result.find(f => f.name === 'Brotherhood');
+      expect(brotherhood?.allies).toEqual(['Scavengers']);
+      expect(brotherhood?.enemies).toEqual(['Raiders']);
+    });
+  });
+
+  describe('buildRelationshipNetwork', () => {
+    it('buckets related characters by relationship standing', () => {
+      const alice = makeCharacter({
+        id: '1',
+        name: 'Alice',
+        relationships: [
+          { characterName: 'Bob', relationshipType: RelationshipStanding.Ally },
+          {
+            characterName: 'Carl',
+            relationshipType: RelationshipStanding.Friend,
+          },
+          {
+            characterName: 'Dana',
+            relationshipType: RelationshipStanding.Neutral,
+          },
+          {
+            characterName: 'Eve',
+            relationshipType: RelationshipStanding.Hostile,
+          },
+          {
+            characterName: 'Frank',
+            relationshipType: RelationshipStanding.Enemy,
+          },
+          {
+            characterName: 'Unknown Person',
+            relationshipType: RelationshipStanding.Ally,
+          },
+        ],
+      });
+      const others = ['Bob', 'Carl', 'Dana', 'Eve', 'Frank'].map(name =>
+        makeCharacter({ id: name, name })
+      );
+
+      const network = buildRelationshipNetwork(alice, [alice, ...others]);
+
+      expect(network.allies.map(c => c.name)).toEqual(['Bob']);
+      expect(network.friends.map(c => c.name)).toEqual(['Carl']);
+      expect(network.neutral.map(c => c.name)).toEqual(['Dana']);
+      expect(network.hostile.map(c => c.name)).toEqual(['Eve']);
+      expect(network.enemies.map(c => c.name)).toEqual(['Frank']);
+    });
+  });
+
+  describe('findFactionConnections', () => {
+    it('maps each of a character faction to its other members, excluding the character itself', () => {
+      const alice = makeCharacter({
+        id: '1',
+        name: 'Alice',
+        factions: [
+          { name: 'Brotherhood', standing: RelationshipStanding.Ally },
+        ],
+      });
+      const bob = makeCharacter({
+        id: '2',
+        name: 'Bob',
+        factions: [
+          { name: 'Brotherhood', standing: RelationshipStanding.Friend },
+        ],
+      });
+      const carl = makeCharacter({ id: '3', name: 'Carl', factions: [] });
+
+      const connections = findFactionConnections(alice, [alice, bob, carl]);
+
+      expect(connections.get('Brotherhood')?.map(c => c.name)).toEqual(['Bob']);
+      expect(connections.size).toBe(1);
+    });
+
+    it('omits factions with no other members', () => {
+      const alice = makeCharacter({
+        id: '1',
+        name: 'Alice',
+        factions: [
+          { name: 'Solo Faction', standing: RelationshipStanding.Ally },
+        ],
+      });
+
+      const connections = findFactionConnections(alice, [alice]);
+
+      expect(connections.size).toBe(0);
+    });
+  });
+
+  describe('findMutualRelationships', () => {
+    it('finds pairs of characters who reference each other, without duplicates', () => {
+      const alice = makeCharacter({
+        id: '1',
+        name: 'Alice',
+        relationships: [
+          { characterName: 'Bob', relationshipType: RelationshipStanding.Ally },
+        ],
+      });
+      const bob = makeCharacter({
+        id: '2',
+        name: 'Bob',
+        relationships: [
+          {
+            characterName: 'Alice',
+            relationshipType: RelationshipStanding.Friend,
+          },
+        ],
+      });
+      const carl = makeCharacter({
+        id: '3',
+        name: 'Carl',
+        relationships: [
+          {
+            characterName: 'Alice',
+            relationshipType: RelationshipStanding.Neutral,
+          },
+        ],
+      });
+
+      const mutuals = findMutualRelationships([alice, bob, carl]);
+
+      expect(mutuals).toHaveLength(1);
+      expect(mutuals[0].character1.name).toBe('Alice');
+      expect(mutuals[0].character2.name).toBe('Bob');
+      expect(mutuals[0].relationship1).toBe(RelationshipStanding.Ally);
+      expect(mutuals[0].relationship2).toBe(RelationshipStanding.Friend);
+    });
+
+    it('returns an empty array when no relationships are mutual', () => {
+      const alice = makeCharacter({
+        id: '1',
+        name: 'Alice',
+        relationships: [
+          { characterName: 'Bob', relationshipType: RelationshipStanding.Ally },
+        ],
+      });
+      const bob = makeCharacter({ id: '2', name: 'Bob', relationships: [] });
+
+      expect(findMutualRelationships([alice, bob])).toEqual([]);
+    });
+  });
+
+  describe('findKeyConnectors', () => {
+    it('only includes characters with more than one faction and more than two relationships', () => {
+      const qualifies = makeCharacter({
+        id: '1',
+        name: 'Connector',
+        factions: [
+          { name: 'A', standing: RelationshipStanding.Ally },
+          { name: 'B', standing: RelationshipStanding.Ally },
+        ],
+        relationships: [
+          { characterName: 'X', relationshipType: RelationshipStanding.Ally },
+          { characterName: 'Y', relationshipType: RelationshipStanding.Ally },
+          { characterName: 'Z', relationshipType: RelationshipStanding.Ally },
+        ],
+      });
+      const singleFaction = makeCharacter({
+        id: '2',
+        name: 'Single Faction',
+        factions: [{ name: 'A', standing: RelationshipStanding.Ally }],
+        relationships: [
+          { characterName: 'X', relationshipType: RelationshipStanding.Ally },
+          { characterName: 'Y', relationshipType: RelationshipStanding.Ally },
+          { characterName: 'Z', relationshipType: RelationshipStanding.Ally },
+        ],
+      });
+      const fewRelationships = makeCharacter({
+        id: '3',
+        name: 'Few Relationships',
+        factions: [
+          { name: 'A', standing: RelationshipStanding.Ally },
+          { name: 'B', standing: RelationshipStanding.Ally },
+        ],
+        relationships: [
+          { characterName: 'X', relationshipType: RelationshipStanding.Ally },
+        ],
+      });
+
+      const connectors = findKeyConnectors([
+        qualifies,
+        singleFaction,
+        fewRelationships,
+      ]);
+
+      expect(connectors.map(c => c.character.name)).toEqual(['Connector']);
+    });
+
+    it('respects the limit parameter', () => {
+      const characters = Array.from({ length: 10 }, (_, i) =>
+        makeCharacter({
+          id: `${i}`,
+          name: `Char ${i}`,
+          factions: [
+            { name: 'A', standing: RelationshipStanding.Ally },
+            { name: 'B', standing: RelationshipStanding.Ally },
+          ],
+          relationships: [
+            {
+              characterName: 'X',
+              relationshipType: RelationshipStanding.Ally,
+            },
+            {
+              characterName: 'Y',
+              relationshipType: RelationshipStanding.Ally,
+            },
+            {
+              characterName: 'Z',
+              relationshipType: RelationshipStanding.Ally,
+            },
+          ],
+        })
+      );
+
+      expect(findKeyConnectors(characters, 2)).toHaveLength(2);
+    });
+  });
+
+  describe('findPowerCenters', () => {
+    it('boosts score for allies who are themselves influential and filters below the threshold', () => {
+      const influentialAlly = makeCharacter({
+        id: '1',
+        name: 'Influential Ally',
+        factions: [
+          { name: 'A', standing: RelationshipStanding.Ally },
+          { name: 'B', standing: RelationshipStanding.Ally },
+          { name: 'C', standing: RelationshipStanding.Ally },
+        ],
+      });
+      const powerCenter = makeCharacter({
+        id: '2',
+        name: 'Power Center',
+        factions: [
+          { name: 'A', standing: RelationshipStanding.Ally },
+          { name: 'B', standing: RelationshipStanding.Ally },
+          { name: 'C', standing: RelationshipStanding.Ally },
+        ],
+        relationships: [
+          {
+            characterName: 'Influential Ally',
+            relationshipType: RelationshipStanding.Ally,
+          },
+        ],
+      });
+      const weakCharacter = makeCharacter({ id: '3', name: 'Weak' });
+
+      const centers = findPowerCenters([
+        influentialAlly,
+        powerCenter,
+        weakCharacter,
+      ]);
+
+      expect(centers.map(c => c.character.name)).toContain('Power Center');
+      expect(centers.map(c => c.character.name)).not.toContain('Weak');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes part of #119 (test-coverage tracking issue). Research at the start of this PR found two of the issue's checkboxes were already done by prior PRs (#113/#114): `BaseDetailScreen.tsx`/`BaseFormScreen.tsx` and every templated character/faction/location/events/quest detail/form/list screen already have contract-based tests, so `AGENTS.md`'s coverage-gap notes were stale on that point.

This PR closes the remaining checkboxes that reuse existing test infrastructure without introducing new mocking machinery in the same change:

- `src/utils/factionStats.ts` and `src/utils/influenceAnalysis.ts` — pure computation, previously untested. `analyzeFactionInfluence`'s lazy `await import('@utils/characterStorage')` doesn't work under Jest's CommonJS transform by default, so `babel.config.js` now adds `babel-plugin-dynamic-import-node` under the `test` env only (Metro/production builds are unaffected).
- All 6 screens in `src/screens/discord/` (previously 0% covered) — bespoke tests since these don't fit the generic list/detail/form contracts (switches, filters, modals, pickers). Added `installFocusEffectOnce()` to `tst/helpers/navigation.ts`: the global `useFocusEffect` test mock re-fires its callback on every render, which trips React's "too many re-renders" guard on screens that gate a loading spinner behind it — this makes it behave like a normal mount effect instead.
- `src/screens/location/LocationMapScreen.tsx` (the one location screen still missing a test) — needed local per-file mocks for `react-native-reanimated` (`useSharedValue`/`useAnimatedStyle`/`withTiming`) and `react-native-gesture-handler` (`GestureDetector`/`Gesture`), since it's the only screen using shared-value animations and gesture composition.
- Updated `AGENTS.md`'s "Test coverage gaps" section to remove the stale claims and record what's now closed.

**Out of scope for this PR** (left as open follow-up, per the issue's "splittable per checkbox" note): `exportImport.ts`'s `.zip` branches/`exportCharacterData`, and `gitIntegration.ts` (needs an `@octokit/rest` mock built from scratch) — both sizable enough to warrant their own PR.

Coverage moves from ~26% to ~54% statements / ~51% functions (measured via `npm run test:coverage`).

## Test plan
- [x] `npm run check-all` (type-check + lint + format:check + full test suite) passes — 50 suites, 482 tests
- [x] New/changed files have zero lint errors (only pre-existing warnings elsewhere, none in touched files)
- [x] Ran the new Discord and LocationMapScreen suites in isolation to confirm no cross-file mock leakage

---
_Generated by [Claude Code](https://claude.ai/code/session_013GvSocvXnH6ZkkksoRhMWm)_