### PR TITLE
Add global search screen spanning all five domains

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -18,6 +18,7 @@ import {
   RootStackParamList,
   RootDrawerParamList,
 } from './src/navigation/types';
+import { GlobalSearchScreen } from './src/screens/search/GlobalSearchScreen';
 import { CharacterListScreen } from './src/screens/character/CharacterListScreen';
 import { CharacterDetailScreen } from './src/screens/character/CharacterDetailScreen';
 import { CharacterFormScreen } from './src/screens/character/CharacterFormScreen';
@@ -79,6 +80,15 @@ function CustomDrawerContent(props: DrawerContentComponentProps) {
 
   return (
     <DrawerContentScrollView {...props} style={{ backgroundColor: '#262647' }}>
+      <DrawerItem
+        label="Search"
+        onPress={() => navigation.navigate('GlobalSearch')}
+        focused={isActive('GlobalSearch')}
+        activeTintColor="#6C5CE7"
+        inactiveTintColor="#B8B8CC"
+        activeBackgroundColor="rgba(108, 92, 231, 0.1)"
+        labelStyle={drawerStyles.drawerLabel}
+      />
       <DrawerItem
         label="Characters"
         onPress={() => navigation.navigate('CharacterList')}
@@ -262,6 +272,14 @@ function MainDrawer() {
         },
       }}
     >
+      <Drawer.Screen
+        name="GlobalSearch"
+        component={GlobalSearchScreen}
+        options={{
+          title: 'Search',
+          drawerLabel: 'Search',
+        }}
+      />
       <Drawer.Screen
         name="CharacterList"
         component={CharacterListScreen}

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -6,6 +6,7 @@ import {
 } from '@models/types';
 
 export type RootDrawerParamList = {
+  GlobalSearch: undefined;
   CharacterList: undefined;
   DataManagement: undefined;
   Factions: undefined;

--- a/src/screens/search/GlobalSearchScreen.tsx
+++ b/src/screens/search/GlobalSearchScreen.tsx
@@ -1,0 +1,206 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import {
+  useNavigation,
+  useFocusEffect,
+  CompositeNavigationProp,
+} from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { DrawerNavigationProp } from '@react-navigation/drawer';
+import { RootStackParamList, RootDrawerParamList } from '@/navigation/types';
+import {
+  loadCharacters,
+  loadFactions,
+  loadLocations,
+  loadEvents,
+  loadQuests,
+} from '@utils/characterStorage';
+import {
+  GlobalSearchData,
+  GlobalSearchResult,
+  SearchDomain,
+  SEARCH_DOMAIN_ORDER,
+  MIN_QUERY_LENGTH,
+  searchAllDomains,
+} from '@utils/globalSearch';
+import { commonStyles } from '@/styles/commonStyles';
+import { spacing } from '@/styles/theme';
+import { BaseListScreen } from '@/components';
+
+type NavigationProp = CompositeNavigationProp<
+  DrawerNavigationProp<RootDrawerParamList, 'GlobalSearch'>,
+  StackNavigationProp<RootStackParamList>
+>;
+
+const DOMAIN_LABELS: Record<SearchDomain, string> = {
+  character: 'Characters',
+  faction: 'Factions',
+  location: 'Locations',
+  event: 'Events',
+  quest: 'Quests',
+};
+
+const DOMAIN_BADGES: Record<SearchDomain, string> = {
+  character: 'Character',
+  faction: 'Faction',
+  location: 'Location',
+  event: 'Event',
+  quest: 'Quest',
+};
+
+type SearchRow =
+  | { kind: 'header'; key: string; label: string }
+  | { kind: 'result'; key: string; result: GlobalSearchResult };
+
+const EMPTY_DATA: GlobalSearchData = {
+  characters: [],
+  factions: [],
+  locations: [],
+  events: [],
+  quests: [],
+};
+
+export const GlobalSearchScreen: React.FC = () => {
+  const [data, setData] = useState<GlobalSearchData>(EMPTY_DATA);
+  const [searchQuery, setSearchQuery] = useState<string>('');
+  const navigation = useNavigation<NavigationProp>();
+
+  const loadData = useCallback(async () => {
+    const [characters, factions, locations, events, quests] = await Promise.all(
+      [
+        loadCharacters(),
+        loadFactions(),
+        loadLocations(),
+        loadEvents(),
+        loadQuests(),
+      ]
+    );
+    setData({ characters, factions, locations, events, quests });
+  }, []);
+
+  // Reload all domains whenever the screen comes into focus
+  useFocusEffect(
+    useCallback(() => {
+      loadData();
+    }, [loadData])
+  );
+
+  const rows = useMemo<SearchRow[]>(() => {
+    const results = searchAllDomains(data, searchQuery);
+    const grouped: SearchRow[] = [];
+    for (const domain of SEARCH_DOMAIN_ORDER) {
+      const domainResults = results.filter(result => result.domain === domain);
+      if (domainResults.length === 0) {
+        continue;
+      }
+      grouped.push({
+        kind: 'header',
+        key: `header:${domain}`,
+        label: `${DOMAIN_LABELS[domain]} (${domainResults.length})`,
+      });
+      for (const result of domainResults) {
+        grouped.push({ kind: 'result', key: result.key, result });
+      }
+    }
+    return grouped;
+  }, [data, searchQuery]);
+
+  const handleResultPress = useCallback(
+    (result: GlobalSearchResult) => {
+      switch (result.domain) {
+        case 'character':
+          navigation.navigate('CharacterDetail', {
+            character: result.character,
+          });
+          break;
+        case 'faction':
+          navigation.navigate('FactionDetails', {
+            factionName: result.factionName,
+          });
+          break;
+        case 'location':
+          navigation.navigate('LocationDetails', {
+            locationId: result.locationId,
+          });
+          break;
+        case 'event':
+          navigation.navigate('EventsDetail', { eventId: result.eventId });
+          break;
+        case 'quest':
+          navigation.navigate('QuestsDetail', { questId: result.questId });
+          break;
+      }
+    },
+    [navigation]
+  );
+
+  const renderItem = (row: SearchRow) => {
+    if (row.kind === 'header') {
+      return <Text style={styles.sectionHeader}>{row.label}</Text>;
+    }
+    const { result } = row;
+    return (
+      <TouchableOpacity
+        style={styles.card}
+        onPress={() => handleResultPress(result)}
+      >
+        <View style={styles.cardHeader}>
+          <Text style={styles.title} numberOfLines={1} ellipsizeMode="tail">
+            {result.title}
+          </Text>
+          <View style={styles.badge}>
+            <Text style={styles.badgeText}>{DOMAIN_BADGES[result.domain]}</Text>
+          </View>
+        </View>
+        {result.subtitle ? (
+          <Text style={styles.subtitle} numberOfLines={2} ellipsizeMode="tail">
+            {result.subtitle}
+          </Text>
+        ) : null}
+      </TouchableOpacity>
+    );
+  };
+
+  const isIdle = searchQuery.trim().length < MIN_QUERY_LENGTH;
+
+  return (
+    <BaseListScreen
+      data={rows}
+      renderItem={renderItem}
+      keyExtractor={row => row.key}
+      searchQuery={searchQuery}
+      onSearchChange={setSearchQuery}
+      searchPlaceholder="Search all domains..."
+      emptyStateTitle={isIdle ? 'Search everything' : 'No results'}
+      emptyStateSubtitle={
+        isIdle
+          ? 'Find characters, factions, locations, events, and quests'
+          : 'Try a different search term'
+      }
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  sectionHeader: {
+    ...commonStyles.text.h3,
+    marginTop: spacing.base,
+    marginBottom: spacing.xs,
+  },
+  card: commonStyles.card.base,
+  cardHeader: commonStyles.card.header,
+  title: {
+    ...commonStyles.text.h3,
+    flex: 1,
+  },
+  badge: {
+    ...commonStyles.badge.base,
+    ...commonStyles.badge.small,
+    ...commonStyles.badge.tag,
+  },
+  badgeText: commonStyles.badge.text,
+  subtitle: {
+    ...commonStyles.text.caption,
+    marginTop: spacing.sm,
+  },
+});

--- a/src/utils/globalSearch.ts
+++ b/src/utils/globalSearch.ts
@@ -1,0 +1,286 @@
+/**
+ * Pure cross-domain search over the five entity types (characters, factions,
+ * locations, events, quests). Takes already-loaded arrays so it stays free of
+ * storage/side effects; callers load data via the `characterStorage` loaders.
+ *
+ * Matching mirrors the per-screen list filters: case-insensitive substring on
+ * the trimmed query. Within each domain, matches on the primary field
+ * (name/title) rank before matches on secondary fields (descriptions, notes,
+ * etc.), alphabetically within each tier, capped per domain.
+ */
+
+import {
+  GameCharacter,
+  GameEvent,
+  GameLocation,
+  GameQuest,
+} from '@models/types';
+import type { StoredFaction } from './characterStorage';
+
+export type SearchDomain =
+  | 'character'
+  | 'faction'
+  | 'location'
+  | 'event'
+  | 'quest';
+
+interface BaseSearchResult {
+  /** Stable list key, e.g. `character:<id>`, `faction:<name>`. */
+  key: string;
+  /** Primary display text (name/title). */
+  title: string;
+  /** Context line: the matched secondary field, or default context. */
+  subtitle?: string;
+  /** True when the query matched the primary field (used for ranking). */
+  primaryMatch: boolean;
+}
+
+export interface CharacterSearchResult extends BaseSearchResult {
+  domain: 'character';
+  /** Full object — the CharacterDetail route takes the whole character. */
+  character: GameCharacter;
+}
+
+export interface FactionSearchResult extends BaseSearchResult {
+  domain: 'faction';
+  /** Factions have no id; the FactionDetails route keys on name. */
+  factionName: string;
+}
+
+export interface LocationSearchResult extends BaseSearchResult {
+  domain: 'location';
+  locationId: string;
+}
+
+export interface EventSearchResult extends BaseSearchResult {
+  domain: 'event';
+  eventId: string;
+}
+
+export interface QuestSearchResult extends BaseSearchResult {
+  domain: 'quest';
+  questId: string;
+}
+
+export type GlobalSearchResult =
+  | CharacterSearchResult
+  | FactionSearchResult
+  | LocationSearchResult
+  | EventSearchResult
+  | QuestSearchResult;
+
+export interface GlobalSearchData {
+  characters: GameCharacter[];
+  factions: StoredFaction[];
+  locations: GameLocation[];
+  events: GameEvent[];
+  quests: GameQuest[];
+}
+
+export const MIN_QUERY_LENGTH = 2;
+export const MAX_RESULTS_PER_DOMAIN = 20;
+
+export const SEARCH_DOMAIN_ORDER: SearchDomain[] = [
+  'character',
+  'faction',
+  'location',
+  'event',
+  'quest',
+];
+
+interface FieldMatch {
+  primaryMatch: boolean;
+  subtitle?: string;
+}
+
+const includesQuery = (value: string | undefined, query: string): boolean =>
+  value !== undefined && value.toLowerCase().includes(query);
+
+/**
+ * Matches an entity against the query. A primary-field hit keeps the given
+ * default context as the subtitle; otherwise the first matching secondary
+ * field becomes the subtitle so the user can see why the result matched.
+ */
+const matchFields = (
+  primary: string,
+  defaultSubtitle: string | undefined,
+  secondary: (string | undefined)[],
+  query: string
+): FieldMatch | undefined => {
+  if (includesQuery(primary, query)) {
+    return { primaryMatch: true, subtitle: defaultSubtitle };
+  }
+  const matched = secondary.find(field => includesQuery(field, query));
+  if (matched !== undefined) {
+    return { primaryMatch: false, subtitle: matched };
+  }
+  return undefined;
+};
+
+const rankAndCap = <T extends GlobalSearchResult>(results: T[]): T[] =>
+  results
+    .sort((a, b) => {
+      if (a.primaryMatch !== b.primaryMatch) {
+        return a.primaryMatch ? -1 : 1;
+      }
+      return a.title.localeCompare(b.title);
+    })
+    .slice(0, MAX_RESULTS_PER_DOMAIN);
+
+const searchCharacters = (
+  characters: GameCharacter[],
+  query: string
+): CharacterSearchResult[] => {
+  const results: CharacterSearchResult[] = [];
+  for (const character of characters) {
+    const match = matchFields(
+      character.name,
+      character.occupation ?? character.species,
+      [
+        character.occupation,
+        character.species,
+        character.notes,
+        ...(character.factions ?? []).map(faction => faction.name),
+      ],
+      query
+    );
+    if (match) {
+      results.push({
+        domain: 'character',
+        key: `character:${character.id}`,
+        title: character.name,
+        character,
+        ...match,
+      });
+    }
+  }
+  return rankAndCap(results);
+};
+
+const searchFactions = (
+  factions: StoredFaction[],
+  query: string
+): FactionSearchResult[] => {
+  const results: FactionSearchResult[] = [];
+  for (const faction of factions) {
+    const match = matchFields(
+      faction.name,
+      faction.description || undefined,
+      [faction.description],
+      query
+    );
+    if (match) {
+      results.push({
+        domain: 'faction',
+        key: `faction:${faction.name}`,
+        title: faction.name,
+        factionName: faction.name,
+        ...match,
+      });
+    }
+  }
+  return rankAndCap(results);
+};
+
+const searchLocations = (
+  locations: GameLocation[],
+  query: string
+): LocationSearchResult[] => {
+  const results: LocationSearchResult[] = [];
+  for (const location of locations) {
+    const match = matchFields(
+      location.name,
+      location.description || undefined,
+      [location.description],
+      query
+    );
+    if (match) {
+      results.push({
+        domain: 'location',
+        key: `location:${location.id}`,
+        title: location.name,
+        locationId: location.id,
+        ...match,
+      });
+    }
+  }
+  return rankAndCap(results);
+};
+
+const searchEvents = (
+  events: GameEvent[],
+  query: string
+): EventSearchResult[] => {
+  const results: EventSearchResult[] = [];
+  for (const event of events) {
+    const match = matchFields(
+      event.title,
+      event.description ?? event.date,
+      [event.description, event.notes],
+      query
+    );
+    if (match) {
+      results.push({
+        domain: 'event',
+        key: `event:${event.id}`,
+        title: event.title,
+        eventId: event.id,
+        ...match,
+      });
+    }
+  }
+  return rankAndCap(results);
+};
+
+const searchQuests = (
+  quests: GameQuest[],
+  query: string
+): QuestSearchResult[] => {
+  const results: QuestSearchResult[] = [];
+  for (const quest of quests) {
+    const match = matchFields(
+      quest.name,
+      quest.details,
+      [
+        quest.details,
+        quest.notes,
+        quest.junktownOffice,
+        ...(quest.factionNames ?? []),
+      ],
+      query
+    );
+    if (match) {
+      results.push({
+        domain: 'quest',
+        key: `quest:${quest.id}`,
+        title: quest.name,
+        questId: quest.id,
+        ...match,
+      });
+    }
+  }
+  return rankAndCap(results);
+};
+
+/**
+ * Searches all five domains. Returns results grouped in
+ * `SEARCH_DOMAIN_ORDER`, each group ranked (primary-field matches first,
+ * alphabetical within each tier) and capped at `MAX_RESULTS_PER_DOMAIN`.
+ * Queries shorter than `MIN_QUERY_LENGTH` after trimming return no results.
+ */
+export const searchAllDomains = (
+  data: GlobalSearchData,
+  query: string
+): GlobalSearchResult[] => {
+  const normalized = query.trim().toLowerCase();
+  if (normalized.length < MIN_QUERY_LENGTH) {
+    return [];
+  }
+  return [
+    ...searchCharacters(data.characters, normalized),
+    ...searchFactions(data.factions, normalized),
+    ...searchLocations(data.locations, normalized),
+    ...searchEvents(data.events, normalized),
+    ...searchQuests(data.quests, normalized),
+  ];
+};

--- a/tst/screens/search/GlobalSearchScreen.test.tsx
+++ b/tst/screens/search/GlobalSearchScreen.test.tsx
@@ -1,0 +1,183 @@
+import React from 'react';
+import { render, waitFor, fireEvent } from '@testing-library/react-native';
+import { GlobalSearchScreen } from '@screens/search/GlobalSearchScreen';
+import { getStorageMock, primeStorageDefaults } from '../../helpers/storage';
+import {
+  installNavigationMock,
+  installFocusEffectOnce,
+  resetNavigationMocks,
+  NavMock,
+} from '../../helpers/navigation';
+import {
+  makeCharacter,
+  makeStoredFaction,
+  makeLocation,
+  makeEvent,
+  makeQuest,
+} from '../../helpers/factories';
+
+jest.mock('@utils/characterStorage');
+
+const storage = getStorageMock();
+
+const SEARCH_PLACEHOLDER = 'Search all domains...';
+
+describe('GlobalSearchScreen', () => {
+  let nav: NavMock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    primeStorageDefaults();
+    nav = installNavigationMock();
+    installFocusEffectOnce();
+  });
+
+  afterEach(() => {
+    resetNavigationMocks();
+  });
+
+  const primePopulated = () => {
+    storage.loadCharacters.mockResolvedValue([
+      makeCharacter({ id: 'c1', name: 'Rusty Nail', occupation: 'Mechanic' }),
+    ]);
+    storage.loadFactions.mockResolvedValue([
+      makeStoredFaction({ name: 'Rust Barons' }),
+    ]);
+    storage.loadLocations.mockResolvedValue([
+      makeLocation({ id: 'l1', name: 'Rust Yard' }),
+    ]);
+    storage.loadEvents.mockResolvedValue([
+      makeEvent({ id: 'e1', title: 'Rust Storm' }),
+    ]);
+    storage.loadQuests.mockResolvedValue([
+      makeQuest({ id: 'q1', name: 'Clear the Rust' }),
+    ]);
+  };
+
+  it('shows the idle state and calls all five loaders on mount', async () => {
+    const { getByText, getByPlaceholderText } = render(<GlobalSearchScreen />);
+
+    await waitFor(() => {
+      expect(storage.loadCharacters).toHaveBeenCalled();
+      expect(storage.loadFactions).toHaveBeenCalled();
+      expect(storage.loadLocations).toHaveBeenCalled();
+      expect(storage.loadEvents).toHaveBeenCalled();
+      expect(storage.loadQuests).toHaveBeenCalled();
+    });
+    expect(getByText('Search everything')).toBeTruthy();
+    expect(getByPlaceholderText(SEARCH_PLACEHOLDER)).toBeTruthy();
+  });
+
+  it('shows grouped results across domains when a query is entered', async () => {
+    primePopulated();
+
+    const { getByText, getByPlaceholderText } = render(<GlobalSearchScreen />);
+
+    await waitFor(() => {
+      expect(storage.loadQuests).toHaveBeenCalled();
+    });
+    fireEvent.changeText(getByPlaceholderText(SEARCH_PLACEHOLDER), 'rust');
+
+    await waitFor(() => {
+      expect(getByText('Characters (1)')).toBeTruthy();
+      expect(getByText('Factions (1)')).toBeTruthy();
+      expect(getByText('Locations (1)')).toBeTruthy();
+      expect(getByText('Events (1)')).toBeTruthy();
+      expect(getByText('Quests (1)')).toBeTruthy();
+      expect(getByText('Rusty Nail')).toBeTruthy();
+      expect(getByText('Rust Barons')).toBeTruthy();
+      expect(getByText('Rust Yard')).toBeTruthy();
+      expect(getByText('Rust Storm')).toBeTruthy();
+      expect(getByText('Clear the Rust')).toBeTruthy();
+    });
+  });
+
+  it('navigates to the character detail with the full character object', async () => {
+    const character = makeCharacter({ id: 'c1', name: 'Rusty Nail' });
+    storage.loadCharacters.mockResolvedValue([character]);
+
+    const { getByText, getByPlaceholderText } = render(<GlobalSearchScreen />);
+
+    await waitFor(() => {
+      expect(storage.loadCharacters).toHaveBeenCalled();
+    });
+    fireEvent.changeText(getByPlaceholderText(SEARCH_PLACEHOLDER), 'rusty');
+
+    await waitFor(() => {
+      expect(getByText('Rusty Nail')).toBeTruthy();
+    });
+    fireEvent.press(getByText('Rusty Nail'));
+
+    expect(nav.navigate).toHaveBeenCalledWith('CharacterDetail', {
+      character,
+    });
+  });
+
+  it('navigates to the faction detail keyed by faction name', async () => {
+    storage.loadFactions.mockResolvedValue([
+      makeStoredFaction({ name: 'Rust Barons' }),
+    ]);
+
+    const { getByText, getByPlaceholderText } = render(<GlobalSearchScreen />);
+
+    await waitFor(() => {
+      expect(storage.loadFactions).toHaveBeenCalled();
+    });
+    fireEvent.changeText(getByPlaceholderText(SEARCH_PLACEHOLDER), 'barons');
+
+    await waitFor(() => {
+      expect(getByText('Rust Barons')).toBeTruthy();
+    });
+    fireEvent.press(getByText('Rust Barons'));
+
+    expect(nav.navigate).toHaveBeenCalledWith('FactionDetails', {
+      factionName: 'Rust Barons',
+    });
+  });
+
+  it('navigates to location, event, and quest details by id', async () => {
+    primePopulated();
+
+    const { getByText, getByPlaceholderText } = render(<GlobalSearchScreen />);
+
+    await waitFor(() => {
+      expect(storage.loadQuests).toHaveBeenCalled();
+    });
+    fireEvent.changeText(getByPlaceholderText(SEARCH_PLACEHOLDER), 'rust');
+
+    await waitFor(() => {
+      expect(getByText('Rust Yard')).toBeTruthy();
+    });
+    fireEvent.press(getByText('Rust Yard'));
+    fireEvent.press(getByText('Rust Storm'));
+    fireEvent.press(getByText('Clear the Rust'));
+
+    expect(nav.navigate).toHaveBeenCalledWith('LocationDetails', {
+      locationId: 'l1',
+    });
+    expect(nav.navigate).toHaveBeenCalledWith('EventsDetail', {
+      eventId: 'e1',
+    });
+    expect(nav.navigate).toHaveBeenCalledWith('QuestsDetail', {
+      questId: 'q1',
+    });
+  });
+
+  it('shows the no-results state for a query that matches nothing', async () => {
+    primePopulated();
+
+    const { getByText, getByPlaceholderText } = render(<GlobalSearchScreen />);
+
+    await waitFor(() => {
+      expect(storage.loadQuests).toHaveBeenCalled();
+    });
+    fireEvent.changeText(
+      getByPlaceholderText(SEARCH_PLACEHOLDER),
+      'zzz-no-match'
+    );
+
+    await waitFor(() => {
+      expect(getByText('No results')).toBeTruthy();
+    });
+  });
+});

--- a/tst/utils/globalSearch.test.ts
+++ b/tst/utils/globalSearch.test.ts
@@ -1,0 +1,251 @@
+import { RelationshipStanding } from '@models/types';
+import {
+  GlobalSearchData,
+  MAX_RESULTS_PER_DOMAIN,
+  searchAllDomains,
+} from '@utils/globalSearch';
+import {
+  makeCharacter,
+  makeStoredFaction,
+  makeLocation,
+  makeEvent,
+  makeQuest,
+} from '../helpers/factories';
+
+const makeData = (
+  overrides: Partial<GlobalSearchData> = {}
+): GlobalSearchData => ({
+  characters: [],
+  factions: [],
+  locations: [],
+  events: [],
+  quests: [],
+  ...overrides,
+});
+
+describe('globalSearch', () => {
+  describe('searchAllDomains', () => {
+    it('returns no results for an empty query', () => {
+      const data = makeData({
+        characters: [makeCharacter({ name: 'Rusty' })],
+      });
+
+      expect(searchAllDomains(data, '')).toEqual([]);
+    });
+
+    it('returns no results for a query below the minimum length', () => {
+      const data = makeData({
+        characters: [makeCharacter({ name: 'Rusty' })],
+      });
+
+      expect(searchAllDomains(data, 'r')).toEqual([]);
+      expect(searchAllDomains(data, '  r  ')).toEqual([]);
+    });
+
+    it('matches case-insensitively on each domain primary field', () => {
+      const data = makeData({
+        characters: [makeCharacter({ id: 'c1', name: 'Rusty Nail' })],
+        factions: [makeStoredFaction({ name: 'Rust Barons' })],
+        locations: [makeLocation({ id: 'l1', name: 'Rust Yard' })],
+        events: [makeEvent({ id: 'e1', title: 'Rust Storm' })],
+        quests: [makeQuest({ id: 'q1', name: 'Clear the Rust' })],
+      });
+
+      const results = searchAllDomains(data, 'RUST');
+
+      expect(results.map(result => result.domain)).toEqual([
+        'character',
+        'faction',
+        'location',
+        'event',
+        'quest',
+      ]);
+      expect(results.map(result => result.title)).toEqual([
+        'Rusty Nail',
+        'Rust Barons',
+        'Rust Yard',
+        'Rust Storm',
+        'Clear the Rust',
+      ]);
+    });
+
+    it('matches secondary fields and surfaces them as the subtitle', () => {
+      const data = makeData({
+        characters: [
+          makeCharacter({
+            id: 'c1',
+            name: 'Vera',
+            factions: [
+              {
+                name: 'Scrap Collective',
+                standing: RelationshipStanding.Neutral,
+              },
+            ],
+          }),
+        ],
+        events: [
+          makeEvent({ id: 'e1', title: 'Town Meeting', notes: 'scrap tax' }),
+        ],
+        quests: [
+          makeQuest({
+            id: 'q1',
+            name: 'Delivery Run',
+            junktownOffice: 'Scrap Office',
+          }),
+        ],
+      });
+
+      const results = searchAllDomains(data, 'scrap');
+
+      expect(results).toHaveLength(3);
+      const [character, event, quest] = results;
+      expect(character).toMatchObject({
+        domain: 'character',
+        title: 'Vera',
+        subtitle: 'Scrap Collective',
+        primaryMatch: false,
+      });
+      expect(event).toMatchObject({
+        domain: 'event',
+        title: 'Town Meeting',
+        subtitle: 'scrap tax',
+      });
+      expect(quest).toMatchObject({
+        domain: 'quest',
+        title: 'Delivery Run',
+        subtitle: 'Scrap Office',
+      });
+    });
+
+    it('ranks primary-field matches before secondary-field matches', () => {
+      const data = makeData({
+        locations: [
+          makeLocation({
+            id: 'l1',
+            name: 'Water Tower',
+            description: 'Old landmark',
+          }),
+          makeLocation({
+            id: 'l2',
+            name: 'Arena',
+            description: 'Has a water fountain',
+          }),
+        ],
+      });
+
+      const results = searchAllDomains(data, 'water');
+
+      expect(results.map(result => result.title)).toEqual([
+        'Water Tower',
+        'Arena',
+      ]);
+      expect(results.map(result => result.primaryMatch)).toEqual([true, false]);
+    });
+
+    it('sorts alphabetically within a ranking tier', () => {
+      const data = makeData({
+        characters: [
+          makeCharacter({ id: 'c1', name: 'Zeke the Rat' }),
+          makeCharacter({ id: 'c2', name: 'Abel the Rat' }),
+        ],
+      });
+
+      const results = searchAllDomains(data, 'rat');
+
+      expect(results.map(result => result.title)).toEqual([
+        'Abel the Rat',
+        'Zeke the Rat',
+      ]);
+    });
+
+    it('caps results per domain', () => {
+      const characters = Array.from(
+        { length: MAX_RESULTS_PER_DOMAIN + 5 },
+        (_, index) =>
+          makeCharacter({ id: `c${index}`, name: `Raider ${index}` })
+      );
+      const data = makeData({
+        characters,
+        factions: [makeStoredFaction({ name: 'Raider Coalition' })],
+      });
+
+      const results = searchAllDomains(data, 'raider');
+
+      expect(
+        results.filter(result => result.domain === 'character')
+      ).toHaveLength(MAX_RESULTS_PER_DOMAIN);
+      expect(
+        results.filter(result => result.domain === 'faction')
+      ).toHaveLength(1);
+    });
+
+    it('builds stable keys and navigation payloads per domain', () => {
+      const character = makeCharacter({ id: 'c1', name: 'Mira' });
+      const data = makeData({
+        characters: [character],
+        factions: [makeStoredFaction({ name: 'Miracle Workers' })],
+        locations: [makeLocation({ id: 'l1', name: 'Mirage Bar' })],
+        events: [makeEvent({ id: 'e1', title: 'Mira Day' })],
+        quests: [makeQuest({ id: 'q1', name: 'Find Mira' })],
+      });
+
+      const results = searchAllDomains(data, 'mira');
+
+      expect(results).toEqual([
+        expect.objectContaining({
+          domain: 'character',
+          key: 'character:c1',
+          character,
+        }),
+        expect.objectContaining({
+          domain: 'faction',
+          key: 'faction:Miracle Workers',
+          factionName: 'Miracle Workers',
+        }),
+        expect.objectContaining({
+          domain: 'location',
+          key: 'location:l1',
+          locationId: 'l1',
+        }),
+        expect.objectContaining({
+          domain: 'event',
+          key: 'event:e1',
+          eventId: 'e1',
+        }),
+        expect.objectContaining({
+          domain: 'quest',
+          key: 'quest:q1',
+          questId: 'q1',
+        }),
+      ]);
+    });
+
+    it('includes retired characters', () => {
+      const data = makeData({
+        characters: [
+          makeCharacter({ id: 'c1', name: 'Old Pete', retired: true }),
+        ],
+      });
+
+      const results = searchAllDomains(data, 'pete');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].title).toBe('Old Pete');
+    });
+
+    it('does not mutate the input arrays while ranking', () => {
+      const characters = [
+        makeCharacter({ id: 'c1', name: 'Zeke' }),
+        makeCharacter({ id: 'c2', name: 'Abel' }),
+      ];
+      const data = makeData({ characters });
+
+      searchAllDomains(data, 'ze');
+
+      expect(characters.map(character => character.name)).toEqual([
+        'Zeke',
+        'Abel',
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
Closes #120

## What

Adds a single **Search** entry point (new drawer item, listed first) that searches characters, factions, locations, events, and quests at once and deep-links each typed result into its existing detail screen.

## How

- **`src/utils/globalSearch.ts`** (new): pure `searchAllDomains(data, query)` over pre-loaded arrays — no storage access, so it's trivially unit-testable. Matching is case-insensitive substring on the trimmed query (consistent with the five per-screen list filters). Within each domain, primary-field matches (`name`/`title`) rank before secondary-field matches (descriptions, notes, faction names, `junktownOffice`), alphabetical within each tier, capped at 20 per domain. Queries shorter than 2 characters return nothing. Results are a discriminated union that carries exactly what each detail route needs: the full `GameCharacter` for `CharacterDetail`, `factionName` for `FactionDetails` (factions have no id), and entity ids for locations/events/quests.
- **`src/screens/search/GlobalSearchScreen.tsx`** (new): built on `BaseListScreen`, loads all five domains in parallel via the existing `characterStorage` loaders on focus, groups results under per-domain header rows ("Characters (3)"), and shows distinct idle vs. no-results empty states. Row tap does an exhaustive switch on the result domain to navigate.
- **Navigation**: `GlobalSearch: undefined` added to `RootDrawerParamList`; drawer item + `Drawer.Screen` registered first in `App.tsx` following the existing hand-written drawer pattern. `initialRouteName` stays `CharacterList`; no stack changes.

## Notes / scope decisions

- **Retired characters are included** in results — this is a lookup tool, not a roster. Easy one-line change if you'd rather exclude them.
- The five existing list screens keep their inline filters (they carry per-screen semantics like present/retired toggles and status pickers). Migrating them onto the shared util is a possible follow-up.
- No changes to `BaseListScreen`, no new dependencies.

## Tests

- `tst/utils/globalSearch.test.ts`: min-query gate, case-insensitive matching per domain's primary field, secondary-field matches surfaced as subtitles, primary-before-secondary ranking, per-domain cap, stable keys and nav payloads, retired inclusion, input non-mutation.
- `tst/screens/search/GlobalSearchScreen.test.tsx`: idle state + all five loaders called on mount, grouped results after typing, per-domain navigation (character with full object, faction by name, location/event/quest by id), no-results state.
- `npm run check-all` green: type-check, lint, format, 52 suites / 498 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JfVG1qNnXWyqwSYyrcAkhf

---
_Generated by [Claude Code](https://claude.ai/code/session_01JfVG1qNnXWyqwSYyrcAkhf)_