### PR TITLE
Link events and quests for narrative threads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,21 @@ Path aliases (tsconfig + babel-plugin-module-resolver): `@/*` → `src/*`, plus
   sync, and renaming a faction must update its references on characters and on
   other factions' relationships. See `updateFaction` / `createFaction` in
   `characterStorage.ts` for the pattern.
+- **Quest ↔ event links:** `GameQuest.eventIds` and `GameEvent.questIds` are
+  mirrored back-references, kept in sync by `addQuest`/`updateQuest`/
+  `deleteQuest`/`addEvent`/`updateEvent`/`deleteEvent` in `characterStorage.ts`
+  (see the "Quest <-> Event bidirectional link sync" section). Each side is a
+  separate storage key, so a sync locks `EVENT_STORAGE_KEY` and
+  `QUEST_STORAGE_KEY` **sequentially, never nested** — nesting a
+  `runExclusive` call for a key inside a `runExclusive` call for the _other_
+  key is fine (they're different keys), but never call `runExclusive` for the
+  same key you're already inside, or it deadlocks. A partial update that omits
+  `eventIds`/`questIds` must leave existing links alone, not clear them —
+  mutators must gate the sync on `updates.eventIds !== undefined` /
+  `updates.questIds !== undefined`. `reconcileQuestEventLinks()` backfills and
+  prunes both sides for data written before the back-reference existed; call
+  it (idempotently) from a list screen's load path, same as
+  `migrateFactionDescriptions`.
 - **Screens:** list/form/detail screens are built on the generics in
   `src/components/screens/`. Follow the existing feature folders rather than
   hand-rolling new layouts, and keep the dark theme from `styles/theme.ts`.

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -120,6 +120,7 @@ export interface GameEvent {
   locationId?: string; // Reference to GameLocation.id
   characterIds?: string[]; // References to GameCharacter.id
   factionNames?: string[]; // Faction names involved in the event
+  questIds?: string[]; // References to GameQuest.id
   notes?: string;
   imageUri?: string; // Deprecated: Use imageUris instead
   imageUris?: string[];

--- a/src/screens/events/EventsDetailScreen.tsx
+++ b/src/screens/events/EventsDetailScreen.tsx
@@ -1,5 +1,12 @@
 import React, { useState, useCallback } from 'react';
-import { View, Text, StyleSheet, Alert, Image } from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Alert,
+  Image,
+  TouchableOpacity,
+} from 'react-native';
 import {
   useNavigation,
   useRoute,
@@ -12,13 +19,22 @@ import {
   loadEvents,
   loadCharacters,
   loadLocations,
+  loadQuests,
   deleteEvent,
 } from '@utils/characterStorage';
-import { GameEvent } from '@models/types';
+import { GameEvent, QuestStatus } from '@models/types';
 import { colors as themeColors } from '@/styles/theme';
 import { BaseDetailScreen, Section, CollapsibleSection } from '@/components';
 import Markdown from 'react-native-markdown-display';
 import { formatEventDate } from '@utils/dateUtils';
+
+const QUEST_STATUS_LABELS: Record<QuestStatus, string> = {
+  [QuestStatus.NotStarted]: 'Not Started',
+  [QuestStatus.Assigned]: 'Assigned',
+  [QuestStatus.InProgress]: 'In Progress',
+  [QuestStatus.Successful]: 'Successful',
+  [QuestStatus.Failure]: 'Failure',
+};
 
 type EventsDetailNavigationProp = StackNavigationProp<
   RootStackParamList,
@@ -27,9 +43,16 @@ type EventsDetailNavigationProp = StackNavigationProp<
 
 type EventsDetailRouteProp = RouteProp<RootStackParamList, 'EventsDetail'>;
 
+interface EventQuestInfo {
+  id: string;
+  name: string;
+  status: QuestStatus;
+}
+
 interface EventWithDetails extends GameEvent {
   locationName?: string;
   characterNames: string[];
+  quests: EventQuestInfo[];
 }
 
 export const EventsDetailScreen: React.FC = () => {
@@ -40,9 +63,12 @@ export const EventsDetailScreen: React.FC = () => {
   const [event, setEvent] = useState<EventWithDetails | null>(null);
 
   const loadEventDetails = useCallback(async () => {
-    const events = await loadEvents();
-    const characters = await loadCharacters();
-    const locations = await loadLocations();
+    const [events, characters, locations, quests] = await Promise.all([
+      loadEvents(),
+      loadCharacters(),
+      loadLocations(),
+      loadQuests(),
+    ]);
 
     const foundEvent = events.find(e => e.id === eventId);
     if (!foundEvent) {
@@ -55,6 +81,7 @@ export const EventsDetailScreen: React.FC = () => {
     // Create lookup maps
     const locationMap = new Map(locations.map(l => [l.id, l.name]));
     const characterMap = new Map(characters.map(c => [c.id, c.name]));
+    const questMap = new Map(quests.map(q => [q.id, q]));
 
     const eventWithDetails: EventWithDetails = {
       ...foundEvent,
@@ -64,6 +91,15 @@ export const EventsDetailScreen: React.FC = () => {
       characterNames:
         foundEvent.characterIds?.map(id => characterMap.get(id) || 'Unknown') ||
         [],
+      quests:
+        foundEvent.questIds
+          ?.map(id => questMap.get(id))
+          .filter((quest): quest is NonNullable<typeof quest> => Boolean(quest))
+          .map(quest => ({
+            id: quest.id,
+            name: quest.name,
+            status: quest.status,
+          })) || [],
     };
 
     setEvent(eventWithDetails);
@@ -183,6 +219,28 @@ export const EventsDetailScreen: React.FC = () => {
                 <Text style={styles.listBullet}>•</Text>
                 <Text style={styles.listText}>{name}</Text>
               </View>
+            ))}
+          </View>
+        </CollapsibleSection>
+      )}
+
+      {/* Quests - Using CollapsibleSection */}
+      {event.quests.length > 0 && (
+        <CollapsibleSection title="Quests">
+          <View style={styles.list}>
+            {event.quests.map(quest => (
+              <TouchableOpacity
+                key={quest.id}
+                style={styles.questRow}
+                onPress={() =>
+                  navigation.navigate('QuestsDetail', { questId: quest.id })
+                }
+              >
+                <Text style={styles.listText}>{quest.name}</Text>
+                <Text style={styles.questStatus}>
+                  {QUEST_STATUS_LABELS[quest.status]}
+                </Text>
+              </TouchableOpacity>
             ))}
           </View>
         </CollapsibleSection>
@@ -320,6 +378,15 @@ const styles = StyleSheet.create({
   overviewValue: {
     flex: 1,
     flexWrap: 'wrap',
+  },
+  questRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  questStatus: {
+    fontSize: 14,
+    color: themeColors.text.muted,
   },
 });
 

--- a/src/screens/events/EventsFormScreen.tsx
+++ b/src/screens/events/EventsFormScreen.tsx
@@ -18,10 +18,16 @@ import {
   loadCharacters,
   loadLocations,
   loadFactions,
+  loadQuests,
 } from '@utils/characterStorage';
 import { colors as themeColors } from '@/styles/theme';
 import { Picker } from '@react-native-picker/picker';
-import { GameCharacter, GameLocation, CertaintyLevel } from '@models/types';
+import {
+  GameCharacter,
+  GameLocation,
+  GameQuest,
+  CertaintyLevel,
+} from '@models/types';
 import { BaseFormScreen } from '@/components';
 
 type EventsFormNavigationProp = StackNavigationProp<
@@ -39,6 +45,7 @@ interface EventFormData {
   locationId: string;
   characterIds: string[];
   factionNames: string[];
+  questIds: string[];
   notes: string;
   imageUri?: string;
   imageUris?: string[];
@@ -65,6 +72,7 @@ export const EventsFormScreen: React.FC = () => {
     locationId: '',
     characterIds: [],
     factionNames: [],
+    questIds: [],
     notes: '',
     imageUri: undefined,
     imageUris: [],
@@ -76,12 +84,18 @@ export const EventsFormScreen: React.FC = () => {
   const [characters, setCharacters] = useState<GameCharacter[]>([]);
   const [locations, setLocations] = useState<GameLocation[]>([]);
   const [factions, setFactions] = useState<string[]>([]);
+  const [quests, setQuests] = useState<GameQuest[]>([]);
 
-  // Load characters, locations, and factions
+  // Load characters, locations, factions, and quests
   useEffect(() => {
     const loadData = async () => {
-      const [loadedCharacters, loadedLocations, loadedFactions] =
-        await Promise.all([loadCharacters(), loadLocations(), loadFactions()]);
+      const [loadedCharacters, loadedLocations, loadedFactions, loadedQuests] =
+        await Promise.all([
+          loadCharacters(),
+          loadLocations(),
+          loadFactions(),
+          loadQuests(),
+        ]);
       setCharacters(
         loadedCharacters.sort((a, b) => a.name.localeCompare(b.name))
       );
@@ -95,6 +109,7 @@ export const EventsFormScreen: React.FC = () => {
           .map(f => f.name)
           .sort()
       );
+      setQuests(loadedQuests.sort((a, b) => a.name.localeCompare(b.name)));
     };
     loadData();
   }, []);
@@ -110,6 +125,7 @@ export const EventsFormScreen: React.FC = () => {
         locationId: event.locationId || '',
         characterIds: event.characterIds || [],
         factionNames: event.factionNames || [],
+        questIds: event.questIds || [],
         notes: event.notes || '',
         imageUri: event.imageUri,
         imageUris: event.imageUris || (event.imageUri ? [event.imageUri] : []),
@@ -189,6 +205,22 @@ export const EventsFormScreen: React.FC = () => {
     setFormData({
       ...formData,
       factionNames: formData.factionNames.filter(f => f !== faction),
+    });
+  };
+
+  const addQuest = (questId: string) => {
+    if (questId && !formData.questIds.includes(questId)) {
+      setFormData({
+        ...formData,
+        questIds: [...formData.questIds, questId],
+      });
+    }
+  };
+
+  const removeQuest = (questId: string) => {
+    setFormData({
+      ...formData,
+      questIds: formData.questIds.filter(id => id !== questId),
     });
   };
 
@@ -400,6 +432,45 @@ export const EventsFormScreen: React.FC = () => {
               </TouchableOpacity>
             </View>
           ))}
+        </View>
+      </View>
+
+      {/* Quests */}
+      <View style={styles.section}>
+        <Text style={styles.label}>Related Quests</Text>
+        <View style={styles.pickerContainer}>
+          <Picker
+            selectedValue=""
+            onValueChange={addQuest}
+            style={styles.picker}
+            dropdownIconColor={themeColors.text.secondary}
+          >
+            <Picker.Item label="Select quest to add..." value="" />
+            {quests
+              .filter(q => !formData.questIds.includes(q.id))
+              .map(quest => (
+                <Picker.Item
+                  key={quest.id}
+                  label={quest.name}
+                  value={quest.id}
+                />
+              ))}
+          </Picker>
+        </View>
+        <View style={styles.selectedList}>
+          {formData.questIds.map(questId => {
+            const quest = quests.find(q => q.id === questId);
+            return (
+              <View key={questId} style={styles.selectedChip}>
+                <Text style={styles.selectedChipText}>
+                  {quest?.name ?? 'Unknown'}
+                </Text>
+                <TouchableOpacity onPress={() => removeQuest(questId)}>
+                  <Text style={styles.removeButton}>×</Text>
+                </TouchableOpacity>
+              </View>
+            );
+          })}
         </View>
       </View>
 

--- a/src/screens/events/EventsListScreen.tsx
+++ b/src/screens/events/EventsListScreen.tsx
@@ -6,6 +6,7 @@ import {
   loadCharacters,
   loadLocations,
   loadFactions,
+  reconcileQuestEventLinks,
 } from '@utils/characterStorage';
 import {
   useNavigation,
@@ -47,6 +48,9 @@ export const EventsTimelineScreen: React.FC = () => {
   const navigation = useNavigation<EventsNavigationProp>();
 
   const loadData = useCallback(async () => {
+    // Backfill/prune quest<->event back-references (idempotent operation)
+    await reconcileQuestEventLinks();
+
     const eventsData = await loadEvents();
     const charactersData = await loadCharacters();
     const locationsData = await loadLocations();

--- a/src/screens/quest/QuestDetailScreen.tsx
+++ b/src/screens/quest/QuestDetailScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { View, Text, StyleSheet, Alert } from 'react-native';
+import { View, Text, StyleSheet, Alert, TouchableOpacity } from 'react-native';
 import {
   useNavigation,
   useRoute,
@@ -15,11 +15,21 @@ import {
   loadEvents,
   deleteQuest,
 } from '@utils/characterStorage';
-import { GameQuest, QuestStatus } from '@models/types';
+import {
+  GameQuest,
+  GameEvent,
+  GameCharacter,
+  QuestStatus,
+} from '@models/types';
 import { colors as themeColors } from '@/styles/theme';
 import { commonStyles } from '@/styles/commonStyles';
 import { BaseDetailScreen, Section, CollapsibleSection } from '@/components';
-import { formatEventDate } from '@utils/dateUtils';
+import { formatEventDate, formatEventDateShort } from '@utils/dateUtils';
+import {
+  buildQuestTimeline,
+  buildQuestParticipants,
+  QuestParticipant,
+} from '@utils/questNarrative';
 
 type QuestsDetailNavigationProp = StackNavigationProp<
   RootStackParamList,
@@ -44,10 +54,16 @@ const STATUS_COLORS: Record<QuestStatus, string> = {
   [QuestStatus.Failure]: themeColors.accent.danger,
 };
 
+interface QuestTimelineItem {
+  event: GameEvent;
+  locationName?: string;
+  dateLabel: string;
+}
+
 interface QuestWithDetails extends GameQuest {
   locationName?: string;
-  characterNames: string[];
-  eventTitles: string[];
+  timeline: QuestTimelineItem[];
+  participants: QuestParticipant[];
 }
 
 export const QuestDetailScreen: React.FC = () => {
@@ -56,9 +72,10 @@ export const QuestDetailScreen: React.FC = () => {
   const { questId } = route.params;
 
   const [quest, setQuest] = useState<QuestWithDetails | null>(null);
+  const [characters, setCharacters] = useState<GameCharacter[]>([]);
 
   const loadQuestDetails = useCallback(async () => {
-    const [quests, characters, locations, events] = await Promise.all([
+    const [quests, charactersData, locations, events] = await Promise.all([
       loadQuests(),
       loadCharacters(),
       loadLocations(),
@@ -74,22 +91,39 @@ export const QuestDetailScreen: React.FC = () => {
     }
 
     const locationMap = new Map(locations.map(l => [l.id, l.name]));
-    const characterMap = new Map(characters.map(c => [c.id, c.name]));
-    const eventMap = new Map(events.map(e => [e.id, e.title]));
+
+    const timeline: QuestTimelineItem[] = buildQuestTimeline(
+      foundQuest,
+      events
+    ).map(event => {
+      let dateLabel = 'Undated';
+      if (event.date) {
+        try {
+          dateLabel = formatEventDateShort(event.date, event.time);
+        } catch {
+          dateLabel = 'Undated';
+        }
+      }
+
+      return {
+        event,
+        locationName: event.locationId
+          ? locationMap.get(event.locationId)
+          : undefined,
+        dateLabel,
+      };
+    });
 
     const questWithDetails: QuestWithDetails = {
       ...foundQuest,
       locationName: foundQuest.locationId
         ? locationMap.get(foundQuest.locationId)
         : undefined,
-      characterNames:
-        foundQuest.assignedCharacterIds?.map(
-          id => characterMap.get(id) || 'Unknown'
-        ) || [],
-      eventTitles:
-        foundQuest.eventIds?.map(id => eventMap.get(id) || 'Unknown') || [],
+      timeline,
+      participants: buildQuestParticipants(foundQuest, events, charactersData),
     };
 
+    setCharacters(charactersData);
     setQuest(questWithDetails);
   }, [questId, navigation]);
 
@@ -181,17 +215,36 @@ export const QuestDetailScreen: React.FC = () => {
         )}
       </Section>
 
-      {/* Assigned Team */}
-      <CollapsibleSection
-        title={`Assigned Team (${quest.characterNames.length})`}
-      >
-        {quest.characterNames.length > 0 ? (
-          <View style={styles.chipList}>
-            {quest.characterNames.map((name, index) => (
-              <View key={index} style={styles.chip}>
-                <Text style={styles.chipText}>{name}</Text>
-              </View>
-            ))}
+      {/* Participants */}
+      <CollapsibleSection title={`Participants (${quest.participants.length})`}>
+        {quest.participants.length > 0 ? (
+          <View style={styles.participantsList}>
+            {quest.participants.map(participant => {
+              const character = characters.find(
+                c => c.id === participant.characterId
+              );
+              const roleLabel =
+                participant.assigned && participant.eventCount > 0
+                  ? 'Assigned · In events'
+                  : participant.assigned
+                    ? 'Assigned'
+                    : 'In events';
+
+              return (
+                <TouchableOpacity
+                  key={participant.characterId}
+                  style={styles.participantRow}
+                  disabled={!character}
+                  onPress={() =>
+                    character &&
+                    navigation.navigate('CharacterDetail', { character })
+                  }
+                >
+                  <Text style={styles.participantName}>{participant.name}</Text>
+                  <Text style={styles.participantMeta}>{roleLabel}</Text>
+                </TouchableOpacity>
+              );
+            })}
           </View>
         ) : (
           <Text style={styles.emptyText}>No characters assigned yet</Text>
@@ -311,17 +364,29 @@ export const QuestDetailScreen: React.FC = () => {
         </CollapsibleSection>
       )}
 
-      {/* Related Events */}
-      {quest.eventTitles.length > 0 && (
+      {/* Quest Timeline */}
+      {quest.timeline.length > 0 && (
         <CollapsibleSection
-          title={`Related Events (${quest.eventTitles.length})`}
+          title={`Quest Timeline (${quest.timeline.length})`}
           defaultCollapsed
         >
-          <View style={styles.chipList}>
-            {quest.eventTitles.map((title, index) => (
-              <View key={index} style={styles.chip}>
-                <Text style={styles.chipText}>{title}</Text>
-              </View>
+          <View style={styles.timelineList}>
+            {quest.timeline.map(item => (
+              <TouchableOpacity
+                key={item.event.id}
+                style={styles.timelineRow}
+                onPress={() =>
+                  navigation.navigate('EventsDetail', {
+                    eventId: item.event.id,
+                  })
+                }
+              >
+                <Text style={styles.timelineDate}>{item.dateLabel}</Text>
+                <Text style={styles.timelineTitle}>{item.event.title}</Text>
+                {item.locationName && (
+                  <Text style={styles.timelineMeta}>{item.locationName}</Text>
+                )}
+              </TouchableOpacity>
             ))}
           </View>
         </CollapsibleSection>
@@ -442,4 +507,43 @@ const styles = StyleSheet.create({
     borderColor: themeColors.accent.success,
   },
   materialProgressText: commonStyles.badge.text,
+  participantsList: {
+    gap: 8,
+  },
+  participantRow: {
+    ...commonStyles.card.base,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 12,
+  },
+  participantName: {
+    ...commonStyles.text.body,
+    fontWeight: '600',
+  },
+  participantMeta: {
+    ...commonStyles.text.caption,
+    color: themeColors.text.muted,
+  },
+  timelineList: {
+    gap: 8,
+  },
+  timelineRow: {
+    ...commonStyles.card.base,
+    paddingVertical: 12,
+  },
+  timelineDate: {
+    ...commonStyles.text.caption,
+    color: themeColors.text.muted,
+    marginBottom: 4,
+  },
+  timelineTitle: {
+    ...commonStyles.text.body,
+    fontWeight: '600',
+  },
+  timelineMeta: {
+    ...commonStyles.text.caption,
+    color: themeColors.text.muted,
+    marginTop: 2,
+  },
 });

--- a/src/screens/quest/QuestListScreen.tsx
+++ b/src/screens/quest/QuestListScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import { View, StyleSheet, TouchableOpacity, Text } from 'react-native';
 import { GameQuest, QuestStatus } from '@models/types';
-import { loadQuests } from '@utils/characterStorage';
+import { loadQuests, reconcileQuestEventLinks } from '@utils/characterStorage';
 import {
   useNavigation,
   useFocusEffect,
@@ -54,6 +54,9 @@ export const QuestListScreen: React.FC = () => {
   const navigation = useNavigation<QuestListNavigationProp>();
 
   const loadData = useCallback(async () => {
+    // Backfill/prune quest<->event back-references (idempotent operation)
+    await reconcileQuestEventLinks();
+
     const questsData = await loadQuests();
     setQuests([...questsData].sort((a, b) => a.name.localeCompare(b.name)));
   }, []);

--- a/src/utils/characterStorage.ts
+++ b/src/utils/characterStorage.ts
@@ -1313,29 +1313,38 @@ export const createEvent = async (
 
 export const addEvent = async (
   event: Omit<GameEvent, 'id' | 'createdAt' | 'updatedAt'>
-): Promise<GameEvent> =>
-  runExclusive(EVENT_STORAGE_KEY, async () => {
+): Promise<GameEvent> => {
+  const newEvent = await runExclusive(EVENT_STORAGE_KEY, async () => {
     const events = await loadEvents();
-    const newEvent: GameEvent = {
+    const created: GameEvent = {
       ...event,
       id: uuidv4(),
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     };
 
-    await saveEvents([...events, newEvent]);
-    return newEvent;
+    await saveEvents([...events, created]);
+    return created;
   });
+
+  if (newEvent.questIds && newEvent.questIds.length > 0) {
+    await syncQuestBackrefsForEvent(newEvent.id, newEvent.questIds, []);
+  }
+
+  return newEvent;
+};
 
 export const updateEvent = async (
   id: string,
   updates: Partial<GameEvent>
-): Promise<GameEvent | null> =>
-  runExclusive(EVENT_STORAGE_KEY, async () => {
+): Promise<GameEvent | null> => {
+  const result = await runExclusive(EVENT_STORAGE_KEY, async () => {
     const events = await loadEvents();
     const index = events.findIndex(e => e.id === id);
 
     if (index === -1) return null;
+
+    const previousQuestIds = events[index].questIds || [];
 
     const updatedEvent: GameEvent = {
       ...events[index],
@@ -1345,11 +1354,27 @@ export const updateEvent = async (
 
     events[index] = updatedEvent;
     await saveEvents(events);
-    return updatedEvent;
+    return { updatedEvent, previousQuestIds };
   });
 
-export const deleteEvent = async (id: string): Promise<boolean> =>
-  runExclusive(EVENT_STORAGE_KEY, async () => {
+  if (!result) return null;
+
+  const { updatedEvent, previousQuestIds } = result;
+
+  if (updates.questIds !== undefined) {
+    const nextQuestIds = updatedEvent.questIds || [];
+    const added = nextQuestIds.filter(qid => !previousQuestIds.includes(qid));
+    const removed = previousQuestIds.filter(qid => !nextQuestIds.includes(qid));
+    if (added.length > 0 || removed.length > 0) {
+      await syncQuestBackrefsForEvent(id, added, removed);
+    }
+  }
+
+  return updatedEvent;
+};
+
+export const deleteEvent = async (id: string): Promise<boolean> => {
+  const deleted = await runExclusive(EVENT_STORAGE_KEY, async () => {
     const events = await loadEvents();
     const filtered = events.filter(e => e.id !== id);
 
@@ -1358,6 +1383,13 @@ export const deleteEvent = async (id: string): Promise<boolean> =>
     await saveEvents(filtered);
     return true;
   });
+
+  if (deleted) {
+    await removeEventFromAllQuests(id);
+  }
+
+  return deleted;
+};
 
 // ============================================
 // Quest Storage Functions
@@ -1388,29 +1420,38 @@ export const createQuest = async (
 
 export const addQuest = async (
   quest: Omit<GameQuest, 'id' | 'createdAt' | 'updatedAt'>
-): Promise<GameQuest> =>
-  runExclusive(QUEST_STORAGE_KEY, async () => {
+): Promise<GameQuest> => {
+  const newQuest = await runExclusive(QUEST_STORAGE_KEY, async () => {
     const quests = await loadQuests();
-    const newQuest: GameQuest = {
+    const created: GameQuest = {
       ...quest,
       id: uuidv4(),
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     };
 
-    await saveQuests([...quests, newQuest]);
-    return newQuest;
+    await saveQuests([...quests, created]);
+    return created;
   });
+
+  if (newQuest.eventIds && newQuest.eventIds.length > 0) {
+    await syncEventBackrefsForQuest(newQuest.id, newQuest.eventIds, []);
+  }
+
+  return newQuest;
+};
 
 export const updateQuest = async (
   id: string,
   updates: Partial<GameQuest>
-): Promise<GameQuest | null> =>
-  runExclusive(QUEST_STORAGE_KEY, async () => {
+): Promise<GameQuest | null> => {
+  const result = await runExclusive(QUEST_STORAGE_KEY, async () => {
     const quests = await loadQuests();
     const index = quests.findIndex(q => q.id === id);
 
     if (index === -1) return null;
+
+    const previousEventIds = quests[index].eventIds || [];
 
     const updatedQuest: GameQuest = {
       ...quests[index],
@@ -1420,11 +1461,27 @@ export const updateQuest = async (
 
     quests[index] = updatedQuest;
     await saveQuests(quests);
-    return updatedQuest;
+    return { updatedQuest, previousEventIds };
   });
 
-export const deleteQuest = async (id: string): Promise<boolean> =>
-  runExclusive(QUEST_STORAGE_KEY, async () => {
+  if (!result) return null;
+
+  const { updatedQuest, previousEventIds } = result;
+
+  if (updates.eventIds !== undefined) {
+    const nextEventIds = updatedQuest.eventIds || [];
+    const added = nextEventIds.filter(eid => !previousEventIds.includes(eid));
+    const removed = previousEventIds.filter(eid => !nextEventIds.includes(eid));
+    if (added.length > 0 || removed.length > 0) {
+      await syncEventBackrefsForQuest(id, added, removed);
+    }
+  }
+
+  return updatedQuest;
+};
+
+export const deleteQuest = async (id: string): Promise<boolean> => {
+  const deleted = await runExclusive(QUEST_STORAGE_KEY, async () => {
     const quests = await loadQuests();
     const filtered = quests.filter(q => q.id !== id);
 
@@ -1433,3 +1490,213 @@ export const deleteQuest = async (id: string): Promise<boolean> =>
     await saveQuests(filtered);
     return true;
   });
+
+  if (deleted) {
+    await removeQuestFromAllEvents(id);
+  }
+
+  return deleted;
+};
+
+// ============================================
+// Quest <-> Event bidirectional link sync
+// ============================================
+//
+// GameQuest.eventIds and GameEvent.questIds are kept as mirrored
+// back-references (same pattern as the bidirectional faction relationships
+// above). Each side is its own storage key, so a sync always locks
+// EVENT_STORAGE_KEY and QUEST_STORAGE_KEY sequentially -- never nested --
+// to avoid deadlocking runExclusive on the same key twice.
+
+/** Adds/removes `questId` on the named events' `questIds`. No-ops (and skips
+ * the write entirely) when there is nothing to change. */
+const syncEventBackrefsForQuest = async (
+  questId: string,
+  addToEventIds: string[],
+  removeFromEventIds: string[]
+): Promise<void> => {
+  if (addToEventIds.length === 0 && removeFromEventIds.length === 0) return;
+
+  await runExclusive(EVENT_STORAGE_KEY, async () => {
+    const events = await loadEvents();
+    const now = new Date().toISOString();
+    let changed = false;
+
+    const updated = events.map(event => {
+      const currentQuestIds = event.questIds || [];
+      const shouldAdd =
+        addToEventIds.includes(event.id) && !currentQuestIds.includes(questId);
+      const shouldRemove =
+        removeFromEventIds.includes(event.id) &&
+        currentQuestIds.includes(questId);
+
+      if (!shouldAdd && !shouldRemove) return event;
+
+      changed = true;
+      const questIds = shouldAdd
+        ? [...currentQuestIds, questId]
+        : currentQuestIds.filter(id => id !== questId);
+
+      return { ...event, questIds, updatedAt: now };
+    });
+
+    if (changed) await saveEvents(updated);
+  });
+};
+
+/** Adds/removes `eventId` on the named quests' `eventIds`. Mirror of
+ * `syncEventBackrefsForQuest`. */
+const syncQuestBackrefsForEvent = async (
+  eventId: string,
+  addToQuestIds: string[],
+  removeFromQuestIds: string[]
+): Promise<void> => {
+  if (addToQuestIds.length === 0 && removeFromQuestIds.length === 0) return;
+
+  await runExclusive(QUEST_STORAGE_KEY, async () => {
+    const quests = await loadQuests();
+    const now = new Date().toISOString();
+    let changed = false;
+
+    const updated = quests.map(quest => {
+      const currentEventIds = quest.eventIds || [];
+      const shouldAdd =
+        addToQuestIds.includes(quest.id) && !currentEventIds.includes(eventId);
+      const shouldRemove =
+        removeFromQuestIds.includes(quest.id) &&
+        currentEventIds.includes(eventId);
+
+      if (!shouldAdd && !shouldRemove) return quest;
+
+      changed = true;
+      const eventIds = shouldAdd
+        ? [...currentEventIds, eventId]
+        : currentEventIds.filter(id => id !== eventId);
+
+      return { ...quest, eventIds, updatedAt: now };
+    });
+
+    if (changed) await saveQuests(updated);
+  });
+};
+
+/** Removes `questId` from every event's `questIds`, regardless of what the
+ * quest's own `eventIds` currently records. Used on quest delete so stale
+ * back-references can't survive drift. */
+const removeQuestFromAllEvents = async (questId: string): Promise<void> => {
+  await runExclusive(EVENT_STORAGE_KEY, async () => {
+    const events = await loadEvents();
+    const now = new Date().toISOString();
+    let changed = false;
+
+    const updated = events.map(event => {
+      if (!event.questIds?.includes(questId)) return event;
+      changed = true;
+      return {
+        ...event,
+        questIds: event.questIds.filter(id => id !== questId),
+        updatedAt: now,
+      };
+    });
+
+    if (changed) await saveEvents(updated);
+  });
+};
+
+/** Removes `eventId` from every quest's `eventIds`. Mirror of
+ * `removeQuestFromAllEvents`. */
+const removeEventFromAllQuests = async (eventId: string): Promise<void> => {
+  await runExclusive(QUEST_STORAGE_KEY, async () => {
+    const quests = await loadQuests();
+    const now = new Date().toISOString();
+    let changed = false;
+
+    const updated = quests.map(quest => {
+      if (!quest.eventIds?.includes(eventId)) return quest;
+      changed = true;
+      return {
+        ...quest,
+        eventIds: quest.eventIds.filter(id => id !== eventId),
+        updatedAt: now,
+      };
+    });
+
+    if (changed) await saveQuests(updated);
+  });
+};
+
+/**
+ * Backfills and prunes the quest<->event back-references so existing data
+ * (e.g. quests with `eventIds` from before `GameEvent.questIds` existed)
+ * ends up consistent on both sides. Safe to call repeatedly; a side is only
+ * written when it actually changes. Mirrors `migrateFactionDescriptions`.
+ */
+export const reconcileQuestEventLinks = async (): Promise<void> => {
+  const [quests, events] = await Promise.all([loadQuests(), loadEvents()]);
+
+  const eventIdSet = new Set(events.map(e => e.id));
+  const questIdSet = new Set(quests.map(q => q.id));
+
+  // Union of both directions: a link recorded on either side counts.
+  const eventIdsByQuest = new Map<string, Set<string>>();
+  const questIdsByEvent = new Map<string, Set<string>>();
+
+  quests.forEach(quest => {
+    const validEventIds = (quest.eventIds || []).filter(id =>
+      eventIdSet.has(id)
+    );
+    eventIdsByQuest.set(quest.id, new Set(validEventIds));
+  });
+  events.forEach(event => {
+    const validQuestIds = (event.questIds || []).filter(id =>
+      questIdSet.has(id)
+    );
+    questIdsByEvent.set(event.id, new Set(validQuestIds));
+
+    validQuestIds.forEach(questId => {
+      eventIdsByQuest.get(questId)?.add(event.id);
+    });
+  });
+  quests.forEach(quest => {
+    (eventIdsByQuest.get(quest.id) || new Set()).forEach(eventId => {
+      questIdsByEvent.get(eventId)?.add(quest.id);
+    });
+  });
+
+  const now = new Date().toISOString();
+
+  let questsChanged = false;
+  const reconciledQuests = quests.map(quest => {
+    const reconciled = Array.from(eventIdsByQuest.get(quest.id) || []);
+    const original = quest.eventIds || [];
+    if (
+      reconciled.length === original.length &&
+      reconciled.every(id => original.includes(id))
+    ) {
+      return quest;
+    }
+    questsChanged = true;
+    return { ...quest, eventIds: reconciled, updatedAt: now };
+  });
+
+  let eventsChanged = false;
+  const reconciledEvents = events.map(event => {
+    const reconciled = Array.from(questIdsByEvent.get(event.id) || []);
+    const original = event.questIds || [];
+    if (
+      reconciled.length === original.length &&
+      reconciled.every(id => original.includes(id))
+    ) {
+      return event;
+    }
+    eventsChanged = true;
+    return { ...event, questIds: reconciled, updatedAt: now };
+  });
+
+  if (questsChanged) {
+    await runExclusive(QUEST_STORAGE_KEY, () => saveQuests(reconciledQuests));
+  }
+  if (eventsChanged) {
+    await runExclusive(EVENT_STORAGE_KEY, () => saveEvents(reconciledEvents));
+  }
+};

--- a/src/utils/questNarrative.ts
+++ b/src/utils/questNarrative.ts
@@ -1,0 +1,104 @@
+/**
+ * Pure computation for the quest <-> event narrative thread (see
+ * `GameQuest.eventIds` / `GameEvent.questIds` in `@models/types`, kept in
+ * sync by `characterStorage.ts`). Screens should call these rather than
+ * re-deriving timeline order or participant rosters themselves.
+ */
+import { GameQuest, GameEvent, GameCharacter } from '@models/types';
+import { parseDateString } from './dateUtils';
+
+export interface QuestParticipant {
+  characterId: string;
+  name: string;
+  /** True if the character is on `quest.assignedCharacterIds`. */
+  assigned: boolean;
+  /** Number of the quest's linked events this character appears in. */
+  eventCount: number;
+}
+
+/** Parses `event.date` (YYYY-MM-DD), returning null for a missing or
+ * malformed date rather than throwing -- callers sort those last. */
+const parseEventDate = (event: GameEvent): Date | null => {
+  if (!event.date) return null;
+  try {
+    return parseDateString(event.date);
+  } catch {
+    return null;
+  }
+};
+
+/** Parses an optional `HH:MM` time string to minutes-since-midnight,
+ * defaulting to 0 (start of day) when missing or malformed. */
+const parseTimeMinutes = (time?: string): number => {
+  const match = time ? /^(\d{1,2}):(\d{2})$/.exec(time) : null;
+  if (!match) return 0;
+
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  return Number.isNaN(hours) || Number.isNaN(minutes)
+    ? 0
+    : hours * 60 + minutes;
+};
+
+/**
+ * Resolves `quest.eventIds` against the event list and returns them sorted
+ * ascending by date, then time. Dangling ids (pointing at a deleted event)
+ * are dropped; events with a missing/unparseable date sort last.
+ */
+export const buildQuestTimeline = (
+  quest: GameQuest,
+  events: GameEvent[]
+): GameEvent[] => {
+  const eventMap = new Map(events.map(event => [event.id, event]));
+  const linkedEvents = (quest.eventIds || [])
+    .map(id => eventMap.get(id))
+    .filter((event): event is GameEvent => Boolean(event));
+
+  return [...linkedEvents].sort((a, b) => {
+    const dateA = parseEventDate(a);
+    const dateB = parseEventDate(b);
+
+    if (!dateA && !dateB) return 0;
+    if (!dateA) return 1;
+    if (!dateB) return -1;
+
+    const dateDiff = dateA.getTime() - dateB.getTime();
+    if (dateDiff !== 0) return dateDiff;
+
+    return parseTimeMinutes(a.time) - parseTimeMinutes(b.time);
+  });
+};
+
+/**
+ * Builds the quest's combined participant roster: the union of
+ * `quest.assignedCharacterIds` and every character appearing in the quest's
+ * linked events, sorted by name. Each entry is tagged so the UI can
+ * distinguish "assigned to the quest", "appears in its events", or both.
+ */
+export const buildQuestParticipants = (
+  quest: GameQuest,
+  events: GameEvent[],
+  characters: GameCharacter[]
+): QuestParticipant[] => {
+  const characterMap = new Map(characters.map(c => [c.id, c]));
+  const linkedEvents = buildQuestTimeline(quest, events);
+
+  const eventCounts = new Map<string, number>();
+  linkedEvents.forEach(event => {
+    event.characterIds?.forEach(id => {
+      eventCounts.set(id, (eventCounts.get(id) || 0) + 1);
+    });
+  });
+
+  const assignedIds = new Set(quest.assignedCharacterIds || []);
+  const allIds = new Set<string>([...assignedIds, ...eventCounts.keys()]);
+
+  const participants: QuestParticipant[] = Array.from(allIds).map(id => ({
+    characterId: id,
+    name: characterMap.get(id)?.name ?? 'Unknown',
+    assigned: assignedIds.has(id),
+    eventCount: eventCounts.get(id) ?? 0,
+  }));
+
+  return participants.sort((a, b) => a.name.localeCompare(b.name));
+};

--- a/tst/screens/events/EventsDetailScreen.test.tsx
+++ b/tst/screens/events/EventsDetailScreen.test.tsx
@@ -1,9 +1,16 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, waitFor, fireEvent } from '@testing-library/react-native';
 import { EventsDetailScreen } from '@screens/events/EventsDetailScreen';
 import { describeDetailScreenContract } from '../../helpers/screenContracts';
-import { getStorageMock } from '../../helpers/storage';
-import { makeEvent } from '../../helpers/factories';
+import { getStorageMock, primeStorageDefaults } from '../../helpers/storage';
+import { makeEvent, makeQuest } from '../../helpers/factories';
+import { QuestStatus } from '@models/types';
+import {
+  installNavigationMock,
+  installRouteParams,
+  resetNavigationMocks,
+  NavMock,
+} from '../../helpers/navigation';
 
 jest.mock('@utils/characterStorage');
 
@@ -22,7 +29,7 @@ describeDetailScreenContract({
   edit: {
     expectedScreen: 'EventsForm',
     expectedParams: {
-      event: { ...event, characterNames: [] },
+      event: { ...event, characterNames: [], quests: [] },
     },
   },
   del: {
@@ -31,4 +38,48 @@ describeDetailScreenContract({
       storage.deleteEvent.mockResolvedValue(true);
     },
   },
+});
+
+describe('EventsDetailScreen — narrative thread', () => {
+  let nav: NavMock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    primeStorageDefaults();
+    nav = installNavigationMock();
+    installRouteParams({ eventId: EVENT_ID });
+  });
+
+  afterEach(() => {
+    resetNavigationMocks();
+  });
+
+  it('lists the quests the event belongs to and navigates to one on tap', async () => {
+    const quest = makeQuest({
+      id: 'quest-1',
+      name: 'Recover the Cargo',
+      status: QuestStatus.InProgress,
+    });
+    const linkedEvent = makeEvent({
+      id: EVENT_ID,
+      title: 'The Great Fire',
+      questIds: [quest.id],
+    });
+
+    storage.loadEvents.mockResolvedValue([linkedEvent]);
+    storage.loadQuests.mockResolvedValue([quest]);
+
+    const { getByText } = render(<EventsDetailScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Recover the Cargo')).toBeTruthy();
+    });
+    expect(getByText('In Progress')).toBeTruthy();
+
+    fireEvent.press(getByText('Recover the Cargo'));
+
+    expect(nav.navigate).toHaveBeenCalledWith('QuestsDetail', {
+      questId: quest.id,
+    });
+  });
 });

--- a/tst/screens/events/EventsFormScreen.test.tsx
+++ b/tst/screens/events/EventsFormScreen.test.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, waitFor, fireEvent } from '@testing-library/react-native';
+import { Picker } from '@react-native-picker/picker';
 import { EventsFormScreen } from '@screens/events/EventsFormScreen';
 import { describeFormScreenContract } from '../../helpers/screenContracts';
-import { getStorageMock } from '../../helpers/storage';
-import { makeEvent } from '../../helpers/factories';
+import { getStorageMock, primeStorageDefaults } from '../../helpers/storage';
+import { makeEvent, makeQuest } from '../../helpers/factories';
+import {
+  installNavigationMock,
+  installRouteParams,
+  resetNavigationMocks,
+} from '../../helpers/navigation';
 
 jest.mock('@utils/characterStorage');
 
@@ -29,4 +35,66 @@ describeFormScreenContract({
     },
     prefilledValue: 'Old Gathering',
   },
+});
+
+describe('EventsFormScreen — quest links', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    primeStorageDefaults();
+    installNavigationMock();
+    installRouteParams({});
+  });
+
+  afterEach(() => {
+    resetNavigationMocks();
+  });
+
+  it('includes a selected quest in the create payload', async () => {
+    const quest = makeQuest({ id: 'quest-1', name: 'Retrieve the Cargo' });
+    storage.loadQuests.mockResolvedValue([quest]);
+    storage.createEvent.mockResolvedValue(makeEvent());
+
+    const { getByPlaceholderText, getByText, UNSAFE_getAllByType } = render(
+      <EventsFormScreen />
+    );
+
+    await waitFor(() => {
+      expect(getByText('Related Quests')).toBeTruthy();
+    });
+
+    fireEvent.changeText(getByPlaceholderText('Event title'), 'The Wedding');
+
+    const pickers = UNSAFE_getAllByType(Picker);
+    fireEvent(pickers[pickers.length - 1], 'valueChange', quest.id);
+
+    await waitFor(() => {
+      expect(getByText('Retrieve the Cargo')).toBeTruthy();
+    });
+
+    fireEvent.press(getByText('Create Event'));
+
+    await waitFor(() => {
+      expect(storage.createEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ questIds: [quest.id] })
+      );
+    });
+  });
+
+  it('prefills existing quest links when editing an event', async () => {
+    const quest = makeQuest({ id: 'quest-1', name: 'Retrieve the Cargo' });
+    const eventWithQuest = makeEvent({
+      id: 'event-2',
+      title: 'The Ambush',
+      questIds: [quest.id],
+    });
+    storage.loadQuests.mockResolvedValue([quest]);
+    storage.updateEvent.mockResolvedValue(eventWithQuest);
+    installRouteParams({ event: eventWithQuest });
+
+    const { getByText } = render(<EventsFormScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Retrieve the Cargo')).toBeTruthy();
+    });
+  });
 });

--- a/tst/screens/quest/QuestDetailScreen.test.tsx
+++ b/tst/screens/quest/QuestDetailScreen.test.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, waitFor, fireEvent } from '@testing-library/react-native';
 import { QuestDetailScreen } from '@screens/quest/QuestDetailScreen';
 import { describeDetailScreenContract } from '../../helpers/screenContracts';
-import { getStorageMock } from '../../helpers/storage';
-import { makeQuest } from '../../helpers/factories';
+import { getStorageMock, primeStorageDefaults } from '../../helpers/storage';
+import { makeQuest, makeEvent, makeCharacter } from '../../helpers/factories';
+import {
+  installNavigationMock,
+  installRouteParams,
+  resetNavigationMocks,
+  NavMock,
+} from '../../helpers/navigation';
 
 jest.mock('@utils/characterStorage');
 
@@ -27,7 +33,7 @@ describeDetailScreenContract({
   edit: {
     expectedScreen: 'QuestsForm',
     expectedParams: {
-      quest: { ...quest, characterNames: [], eventTitles: [] },
+      quest: { ...quest, timeline: [], participants: [] },
     },
   },
   del: {
@@ -36,4 +42,97 @@ describeDetailScreenContract({
       storage.deleteQuest.mockResolvedValue(true);
     },
   },
+});
+
+describe('QuestDetailScreen — narrative thread', () => {
+  let nav: NavMock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    primeStorageDefaults();
+    nav = installNavigationMock();
+    installRouteParams({ questId: QUEST_ID });
+  });
+
+  afterEach(() => {
+    resetNavigationMocks();
+  });
+
+  it('shows the quest timeline in date order and navigates to the event on tap', async () => {
+    const laterEvent = makeEvent({
+      id: 'event-later',
+      title: 'Second Skirmish',
+      date: '2026-02-01',
+    });
+    const earlierEvent = makeEvent({
+      id: 'event-earlier',
+      title: 'First Contact',
+      date: '2026-01-01',
+    });
+    const narrativeQuest = makeQuest({
+      id: QUEST_ID,
+      name: 'Recover the Cargo',
+      eventIds: [laterEvent.id, earlierEvent.id],
+    });
+
+    storage.loadQuests.mockResolvedValue([narrativeQuest]);
+    storage.loadEvents.mockResolvedValue([laterEvent, earlierEvent]);
+
+    const { getByText, getAllByText } = render(<QuestDetailScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Quest Timeline (2)')).toBeTruthy();
+    });
+
+    fireEvent.press(getByText('Quest Timeline (2)'));
+
+    const titles = getAllByText(/First Contact|Second Skirmish/);
+    expect(titles[0].props.children).toBe('First Contact');
+    expect(titles[1].props.children).toBe('Second Skirmish');
+
+    fireEvent.press(getByText('First Contact'));
+
+    expect(nav.navigate).toHaveBeenCalledWith('EventsDetail', {
+      eventId: earlierEvent.id,
+    });
+  });
+
+  it('tags participants as assigned, in-events, or both and navigates to the character on tap', async () => {
+    const assignedOnly = makeCharacter({
+      id: 'char-assigned',
+      name: 'Assigned Only',
+    });
+    const eventOnly = makeCharacter({ id: 'char-event', name: 'Event Only' });
+    const both = makeCharacter({ id: 'char-both', name: 'Both Roles' });
+
+    const event = makeEvent({
+      id: 'event-1',
+      characterIds: [eventOnly.id, both.id],
+    });
+    const narrativeQuest = makeQuest({
+      id: QUEST_ID,
+      assignedCharacterIds: [assignedOnly.id, both.id],
+      eventIds: [event.id],
+    });
+
+    storage.loadQuests.mockResolvedValue([narrativeQuest]);
+    storage.loadEvents.mockResolvedValue([event]);
+    storage.loadCharacters.mockResolvedValue([assignedOnly, eventOnly, both]);
+
+    const { getByText } = render(<QuestDetailScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Participants (3)')).toBeTruthy();
+    });
+
+    expect(getByText('Assigned Only')).toBeTruthy();
+    expect(getByText('Event Only')).toBeTruthy();
+    expect(getByText('Both Roles')).toBeTruthy();
+
+    fireEvent.press(getByText('Both Roles'));
+
+    expect(nav.navigate).toHaveBeenCalledWith('CharacterDetail', {
+      character: both,
+    });
+  });
 });

--- a/tst/utils/questEventLinks.concurrency.test.ts
+++ b/tst/utils/questEventLinks.concurrency.test.ts
@@ -1,0 +1,180 @@
+import {
+  updateQuest,
+  updateEvent,
+  deleteQuest,
+} from '@/utils/characterStorage';
+import { SafeAsyncStorageJSONParser } from '@/utils/safeAsyncStorageJSONParser';
+import { GameEvent, GameQuest, QuestStatus } from '@/models/types';
+
+jest.mock('@/utils/safeAsyncStorageJSONParser');
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'mock-uuid-1234'),
+}));
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Stateful in-memory backing store with an artificial async gap on
+ * read/write, shared across both storage keys the quest<->event sync
+ * touches. The gap forces interleaving: without per-key serialization,
+ * concurrent read-modify-writes on the same key would read the same
+ * starting snapshot and clobber each other. Mirrors
+ * `characterStorage.concurrency.test.ts` / `quest.concurrency.test.ts`.
+ */
+const installStatefulStore = (initial: Record<string, unknown>) => {
+  const store: Record<string, unknown> = clone(initial);
+
+  (SafeAsyncStorageJSONParser.getItem as jest.Mock).mockImplementation(
+    async (key: string) => {
+      await delay(1);
+      return key in store ? clone(store[key]) : null;
+    }
+  );
+  (SafeAsyncStorageJSONParser.setItem as jest.Mock).mockImplementation(
+    async (key: string, value: unknown) => {
+      await delay(1);
+      store[key] = clone(value);
+      return true;
+    }
+  );
+
+  return store;
+};
+
+const TS = '2025-01-01T00:00:00.000Z';
+
+const makeEvent = (overrides: Partial<GameEvent> = {}): GameEvent => ({
+  id: 'event-a',
+  title: 'Event A',
+  date: '2025-01-01',
+  createdAt: TS,
+  updatedAt: TS,
+  ...overrides,
+});
+
+const makeQuest = (overrides: Partial<GameQuest> = {}): GameQuest => ({
+  id: 'quest-a',
+  name: 'Quest A',
+  status: QuestStatus.NotStarted,
+  createdAt: TS,
+  updatedAt: TS,
+  ...overrides,
+});
+
+type EventStore = { events: GameEvent[] };
+type QuestStore = { quests: GameQuest[] };
+
+describe('quest <-> event link sync concurrency', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('keeps every back-reference when several quests link overlapping events concurrently', async () => {
+    const eventA = makeEvent({ id: 'event-a' });
+    const eventB = makeEvent({ id: 'event-b' });
+    const questX = makeQuest({ id: 'quest-x' });
+    const questY = makeQuest({ id: 'quest-y' });
+    const questZ = makeQuest({ id: 'quest-z' });
+
+    const store = installStatefulStore({
+      gameCharacterManager_events: {
+        events: [eventA, eventB],
+        version: '1.0',
+        lastUpdated: TS,
+      },
+      gameCharacterManager_quests: {
+        quests: [questX, questY, questZ],
+        version: '1.0',
+        lastUpdated: TS,
+      },
+    });
+
+    // Three quests all link event-a concurrently (and quest-z also links
+    // event-b). Each updateQuest call does its own event-side sync, so
+    // without serialization on EVENT_STORAGE_KEY the writes would clobber
+    // one another and drop back-references.
+    await Promise.all([
+      updateQuest('quest-x', { eventIds: ['event-a'] }),
+      updateQuest('quest-y', { eventIds: ['event-a'] }),
+      updateQuest('quest-z', { eventIds: ['event-a', 'event-b'] }),
+    ]);
+
+    const events = (store.gameCharacterManager_events as EventStore).events;
+    const eventAQuestIds = events.find(e => e.id === 'event-a')?.questIds;
+    const eventBQuestIds = events.find(e => e.id === 'event-b')?.questIds;
+
+    expect(eventAQuestIds?.slice().sort()).toEqual([
+      'quest-x',
+      'quest-y',
+      'quest-z',
+    ]);
+    expect(eventBQuestIds).toEqual(['quest-z']);
+  });
+
+  it('completes interleaved quest-side and event-side updates without deadlocking, both sides ending consistent', async () => {
+    const event = makeEvent({ id: 'event-a' });
+    const quest = makeQuest({ id: 'quest-a' });
+
+    const store = installStatefulStore({
+      gameCharacterManager_events: {
+        events: [event],
+        version: '1.0',
+        lastUpdated: TS,
+      },
+      gameCharacterManager_quests: {
+        quests: [quest],
+        version: '1.0',
+        lastUpdated: TS,
+      },
+    });
+
+    // updateQuest locks QUEST_STORAGE_KEY then EVENT_STORAGE_KEY; updateEvent
+    // locks EVENT_STORAGE_KEY then QUEST_STORAGE_KEY. Firing both at once
+    // would hang (jest's test timeout would fail it) if either ever nested a
+    // lock on a key it already held instead of releasing before acquiring
+    // the other; resolving proves the sequential (never-nested) locking
+    // holds, and the assertions below prove neither sync clobbered the
+    // other's write.
+    await Promise.all([
+      updateQuest('quest-a', { eventIds: ['event-a'] }),
+      updateEvent('event-a', { questIds: ['quest-a'] }),
+    ]);
+
+    const events = (store.gameCharacterManager_events as EventStore).events;
+    const quests = (store.gameCharacterManager_quests as QuestStore).quests;
+    expect(events.find(e => e.id === 'event-a')?.questIds).toEqual(['quest-a']);
+    expect(quests.find(q => q.id === 'quest-a')?.eventIds).toEqual(['event-a']);
+  });
+
+  it('deleting a quest concurrently with an unrelated event update leaves both consistent', async () => {
+    const eventA = makeEvent({ id: 'event-a', questIds: ['quest-a'] });
+    const eventB = makeEvent({ id: 'event-b' });
+    const quest = makeQuest({ id: 'quest-a', eventIds: ['event-a'] });
+
+    const store = installStatefulStore({
+      gameCharacterManager_events: {
+        events: [eventA, eventB],
+        version: '1.0',
+        lastUpdated: TS,
+      },
+      gameCharacterManager_quests: {
+        quests: [quest],
+        version: '1.0',
+        lastUpdated: TS,
+      },
+    });
+
+    await Promise.all([
+      deleteQuest('quest-a'),
+      updateEvent('event-b', { description: 'Updated concurrently' }),
+    ]);
+
+    const events = (store.gameCharacterManager_events as EventStore).events;
+    expect(events.find(e => e.id === 'event-a')?.questIds).toEqual([]);
+    expect(events.find(e => e.id === 'event-b')?.description).toBe(
+      'Updated concurrently'
+    );
+  });
+});

--- a/tst/utils/questEventLinks.test.ts
+++ b/tst/utils/questEventLinks.test.ts
@@ -1,0 +1,316 @@
+import {
+  addQuest,
+  updateQuest,
+  deleteQuest,
+  addEvent,
+  updateEvent,
+  deleteEvent,
+  reconcileQuestEventLinks,
+} from '@/utils/characterStorage';
+import { SafeAsyncStorageJSONParser } from '@/utils/safeAsyncStorageJSONParser';
+import { GameEvent, GameQuest, QuestStatus } from '@/models/types';
+
+jest.mock('@/utils/safeAsyncStorageJSONParser');
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'mock-uuid-1234'),
+}));
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
+
+/**
+ * Install a stateful in-memory backing store for SafeAsyncStorageJSONParser,
+ * shared across both the `gameCharacterManager_quests` and
+ * `gameCharacterManager_events` keys these sync helpers touch. Mirrors the
+ * pattern in `characterStorage.concurrency.test.ts` / `quest.concurrency.test.ts`
+ * (no artificial delay needed here since these tests aren't proving
+ * interleaving, just end-to-end sync behavior).
+ */
+const installStatefulStore = (initial: Record<string, unknown>) => {
+  const store: Record<string, unknown> = clone(initial);
+
+  (SafeAsyncStorageJSONParser.getItem as jest.Mock).mockImplementation(
+    async (key: string) => (key in store ? clone(store[key]) : null)
+  );
+  (SafeAsyncStorageJSONParser.setItem as jest.Mock).mockImplementation(
+    async (key: string, value: unknown) => {
+      store[key] = clone(value);
+      return true;
+    }
+  );
+
+  return store;
+};
+
+const TS = '2025-01-01T00:00:00.000Z';
+
+const makeEvent = (overrides: Partial<GameEvent> = {}): GameEvent => ({
+  id: 'event-a',
+  title: 'Event A',
+  date: '2025-01-01',
+  createdAt: TS,
+  updatedAt: TS,
+  ...overrides,
+});
+
+const makeQuest = (overrides: Partial<GameQuest> = {}): GameQuest => ({
+  id: 'quest-a',
+  name: 'Quest A',
+  status: QuestStatus.NotStarted,
+  createdAt: TS,
+  updatedAt: TS,
+  ...overrides,
+});
+
+type EventStore = { events: GameEvent[] };
+type QuestStore = { quests: GameQuest[] };
+
+describe('quest <-> event link sync', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('addQuest with eventIds adds the new quest id onto the linked events', async () => {
+    const eventA = makeEvent({ id: 'event-a' });
+    const eventB = makeEvent({ id: 'event-b' });
+    const store = installStatefulStore({
+      gameCharacterManager_events: {
+        events: [eventA, eventB],
+        version: '1.0',
+        lastUpdated: TS,
+      },
+      gameCharacterManager_quests: {
+        quests: [],
+        version: '1.0',
+        lastUpdated: TS,
+      },
+    });
+
+    const created = await addQuest({
+      name: 'New Quest',
+      status: QuestStatus.NotStarted,
+      eventIds: ['event-a'],
+    });
+
+    const events = (store.gameCharacterManager_events as EventStore).events;
+    expect(events.find(e => e.id === 'event-a')?.questIds).toEqual([
+      created.id,
+    ]);
+    expect(events.find(e => e.id === 'event-b')?.questIds).toBeUndefined();
+  });
+
+  it('updateQuest syncs added/removed eventIds onto events, and leaves links alone when eventIds is omitted', async () => {
+    const eventA = makeEvent({ id: 'event-a', questIds: ['quest-a'] });
+    const eventB = makeEvent({ id: 'event-b' });
+    const quest = makeQuest({ id: 'quest-a', eventIds: ['event-a'] });
+
+    const store = installStatefulStore({
+      gameCharacterManager_events: {
+        events: [eventA, eventB],
+        version: '1.0',
+        lastUpdated: TS,
+      },
+      gameCharacterManager_quests: {
+        quests: [quest],
+        version: '1.0',
+        lastUpdated: TS,
+      },
+    });
+
+    // Swap the link from event-a to event-b.
+    await updateQuest('quest-a', { eventIds: ['event-b'] });
+
+    let events = (store.gameCharacterManager_events as EventStore).events;
+    expect(events.find(e => e.id === 'event-a')?.questIds).toEqual([]);
+    expect(events.find(e => e.id === 'event-b')?.questIds).toEqual(['quest-a']);
+
+    // A partial update that doesn't mention eventIds must not touch the link.
+    await updateQuest('quest-a', { name: 'Renamed' });
+
+    events = (store.gameCharacterManager_events as EventStore).events;
+    expect(events.find(e => e.id === 'event-b')?.questIds).toEqual(['quest-a']);
+  });
+
+  it('deleteQuest removes the quest id from every event, including drift', async () => {
+    const eventA = makeEvent({ id: 'event-a', questIds: ['quest-a'] });
+    // event-b carries the back-reference even though quest-a's own eventIds
+    // never recorded it (drift) -- delete must still sweep it.
+    const eventB = makeEvent({ id: 'event-b', questIds: ['quest-a'] });
+    const quest = makeQuest({ id: 'quest-a', eventIds: ['event-a'] });
+
+    const store = installStatefulStore({
+      gameCharacterManager_events: {
+        events: [eventA, eventB],
+        version: '1.0',
+        lastUpdated: TS,
+      },
+      gameCharacterManager_quests: {
+        quests: [quest],
+        version: '1.0',
+        lastUpdated: TS,
+      },
+    });
+
+    await deleteQuest('quest-a');
+
+    const events = (store.gameCharacterManager_events as EventStore).events;
+    expect(events.every(e => !e.questIds?.includes('quest-a'))).toBe(true);
+  });
+
+  it('addEvent with questIds adds the new event id onto the linked quests', async () => {
+    const questA = makeQuest({ id: 'quest-a' });
+    const questB = makeQuest({ id: 'quest-b' });
+    const store = installStatefulStore({
+      gameCharacterManager_quests: {
+        quests: [questA, questB],
+        version: '1.0',
+        lastUpdated: TS,
+      },
+      gameCharacterManager_events: {
+        events: [],
+        version: '1.0',
+        lastUpdated: TS,
+      },
+    });
+
+    const created = await addEvent({
+      title: 'New Event',
+      date: '2025-02-01',
+      questIds: ['quest-a'],
+    });
+
+    const quests = (store.gameCharacterManager_quests as QuestStore).quests;
+    expect(quests.find(q => q.id === 'quest-a')?.eventIds).toEqual([
+      created.id,
+    ]);
+    expect(quests.find(q => q.id === 'quest-b')?.eventIds).toBeUndefined();
+  });
+
+  it('updateEvent syncs added/removed questIds onto quests, and leaves links alone when questIds is omitted', async () => {
+    const questA = makeQuest({ id: 'quest-a', eventIds: ['event-a'] });
+    const questB = makeQuest({ id: 'quest-b' });
+    const event = makeEvent({ id: 'event-a', questIds: ['quest-a'] });
+
+    const store = installStatefulStore({
+      gameCharacterManager_quests: {
+        quests: [questA, questB],
+        version: '1.0',
+        lastUpdated: TS,
+      },
+      gameCharacterManager_events: {
+        events: [event],
+        version: '1.0',
+        lastUpdated: TS,
+      },
+    });
+
+    await updateEvent('event-a', { questIds: ['quest-b'] });
+
+    let quests = (store.gameCharacterManager_quests as QuestStore).quests;
+    expect(quests.find(q => q.id === 'quest-a')?.eventIds).toEqual([]);
+    expect(quests.find(q => q.id === 'quest-b')?.eventIds).toEqual(['event-a']);
+
+    await updateEvent('event-a', { title: 'Renamed' });
+
+    quests = (store.gameCharacterManager_quests as QuestStore).quests;
+    expect(quests.find(q => q.id === 'quest-b')?.eventIds).toEqual(['event-a']);
+  });
+
+  it('deleteEvent removes the event id from every quest, including drift', async () => {
+    const questA = makeQuest({ id: 'quest-a', eventIds: ['event-a'] });
+    const questB = makeQuest({ id: 'quest-b', eventIds: ['event-a'] });
+    const event = makeEvent({ id: 'event-a', questIds: ['quest-a'] });
+
+    const store = installStatefulStore({
+      gameCharacterManager_quests: {
+        quests: [questA, questB],
+        version: '1.0',
+        lastUpdated: TS,
+      },
+      gameCharacterManager_events: {
+        events: [event],
+        version: '1.0',
+        lastUpdated: TS,
+      },
+    });
+
+    await deleteEvent('event-a');
+
+    const quests = (store.gameCharacterManager_quests as QuestStore).quests;
+    expect(quests.every(q => !q.eventIds?.includes('event-a'))).toBe(true);
+  });
+
+  describe('reconcileQuestEventLinks', () => {
+    it('backfills a missing back-reference from the other side', async () => {
+      // quest -> event link recorded, but the event has no reciprocal
+      // questIds (e.g. written before GameEvent.questIds existed).
+      const quest = makeQuest({ id: 'quest-a', eventIds: ['event-a'] });
+      const event = makeEvent({ id: 'event-a' });
+
+      const store = installStatefulStore({
+        gameCharacterManager_quests: {
+          quests: [quest],
+          version: '1.0',
+          lastUpdated: TS,
+        },
+        gameCharacterManager_events: {
+          events: [event],
+          version: '1.0',
+          lastUpdated: TS,
+        },
+      });
+
+      await reconcileQuestEventLinks();
+
+      const events = (store.gameCharacterManager_events as EventStore).events;
+      expect(events[0].questIds).toEqual(['quest-a']);
+    });
+
+    it('prunes ids pointing at deleted rows on both sides', async () => {
+      const quest = makeQuest({ id: 'quest-a', eventIds: ['missing-event'] });
+      const event = makeEvent({ id: 'event-a', questIds: ['missing-quest'] });
+
+      const store = installStatefulStore({
+        gameCharacterManager_quests: {
+          quests: [quest],
+          version: '1.0',
+          lastUpdated: TS,
+        },
+        gameCharacterManager_events: {
+          events: [event],
+          version: '1.0',
+          lastUpdated: TS,
+        },
+      });
+
+      await reconcileQuestEventLinks();
+
+      const quests = (store.gameCharacterManager_quests as QuestStore).quests;
+      const events = (store.gameCharacterManager_events as EventStore).events;
+      expect(quests[0].eventIds).toEqual([]);
+      expect(events[0].questIds).toEqual([]);
+    });
+
+    it('does not write either side when links are already consistent', async () => {
+      const quest = makeQuest({ id: 'quest-a', eventIds: ['event-a'] });
+      const event = makeEvent({ id: 'event-a', questIds: ['quest-a'] });
+
+      installStatefulStore({
+        gameCharacterManager_quests: {
+          quests: [quest],
+          version: '1.0',
+          lastUpdated: TS,
+        },
+        gameCharacterManager_events: {
+          events: [event],
+          version: '1.0',
+          lastUpdated: TS,
+        },
+      });
+
+      await reconcileQuestEventLinks();
+
+      expect(SafeAsyncStorageJSONParser.setItem).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tst/utils/questNarrative.test.ts
+++ b/tst/utils/questNarrative.test.ts
@@ -1,0 +1,193 @@
+import {
+  buildQuestTimeline,
+  buildQuestParticipants,
+} from '@utils/questNarrative';
+import {
+  GameEvent,
+  GameQuest,
+  GameCharacter,
+  QuestStatus,
+} from '@models/types';
+
+const TS = '2026-01-01T00:00:00.000Z';
+
+const makeEvent = (overrides: Partial<GameEvent> = {}): GameEvent => ({
+  id: 'event-1',
+  title: 'Test Event',
+  date: '2026-01-01',
+  createdAt: TS,
+  updatedAt: TS,
+  ...overrides,
+});
+
+const makeQuest = (overrides: Partial<GameQuest> = {}): GameQuest => ({
+  id: 'quest-1',
+  name: 'Test Quest',
+  status: QuestStatus.NotStarted,
+  createdAt: TS,
+  updatedAt: TS,
+  ...overrides,
+});
+
+const makeCharacter = (
+  overrides: Partial<GameCharacter> = {}
+): GameCharacter => ({
+  id: 'character-1',
+  name: 'Test Character',
+  species: 'Human',
+  perkIds: [],
+  distinctionIds: [],
+  factions: [],
+  relationships: [],
+  createdAt: TS,
+  updatedAt: TS,
+  ...overrides,
+});
+
+describe('buildQuestTimeline', () => {
+  it('sorts linked events ascending by date', () => {
+    const later = makeEvent({ id: 'e-later', date: '2026-03-01' });
+    const earlier = makeEvent({ id: 'e-earlier', date: '2026-01-01' });
+    const quest = makeQuest({ eventIds: [later.id, earlier.id] });
+
+    const timeline = buildQuestTimeline(quest, [later, earlier]);
+
+    expect(timeline.map(e => e.id)).toEqual([earlier.id, later.id]);
+  });
+
+  it('breaks ties on the same date using time', () => {
+    const late = makeEvent({ id: 'e-late', date: '2026-01-01', time: '18:00' });
+    const early = makeEvent({
+      id: 'e-early',
+      date: '2026-01-01',
+      time: '08:00',
+    });
+    const quest = makeQuest({ eventIds: [late.id, early.id] });
+
+    const timeline = buildQuestTimeline(quest, [late, early]);
+
+    expect(timeline.map(e => e.id)).toEqual([early.id, late.id]);
+  });
+
+  it('sorts events with a missing or malformed date last', () => {
+    const dated = makeEvent({ id: 'e-dated', date: '2026-01-01' });
+    const undated = makeEvent({ id: 'e-undated', date: '' });
+    const malformed = makeEvent({ id: 'e-malformed', date: 'not-a-date' });
+    const quest = makeQuest({
+      eventIds: [undated.id, dated.id, malformed.id],
+    });
+
+    const timeline = buildQuestTimeline(quest, [undated, dated, malformed]);
+
+    expect(timeline[0].id).toBe(dated.id);
+    expect(
+      timeline
+        .slice(1)
+        .map(e => e.id)
+        .sort()
+    ).toEqual([undated.id, malformed.id].sort());
+  });
+
+  it('drops dangling event ids that no longer resolve', () => {
+    const quest = makeQuest({ eventIds: ['missing-event'] });
+
+    expect(buildQuestTimeline(quest, [])).toEqual([]);
+  });
+
+  it('returns an empty timeline when the quest has no linked events', () => {
+    const quest = makeQuest();
+
+    expect(buildQuestTimeline(quest, [makeEvent()])).toEqual([]);
+  });
+});
+
+describe('buildQuestParticipants', () => {
+  it('unions assigned characters with characters appearing in linked events', () => {
+    const assignedOnly = makeCharacter({ id: 'c-assigned', name: 'Assigned' });
+    const eventOnly = makeCharacter({ id: 'c-event', name: 'EventOnly' });
+    const both = makeCharacter({ id: 'c-both', name: 'Both' });
+
+    const event = makeEvent({
+      id: 'event-1',
+      characterIds: [eventOnly.id, both.id],
+    });
+    const quest = makeQuest({
+      assignedCharacterIds: [assignedOnly.id, both.id],
+      eventIds: [event.id],
+    });
+
+    const participants = buildQuestParticipants(
+      quest,
+      [event],
+      [assignedOnly, eventOnly, both]
+    );
+
+    const byId = new Map(participants.map(p => [p.characterId, p]));
+
+    expect(byId.get(assignedOnly.id)).toMatchObject({
+      assigned: true,
+      eventCount: 0,
+    });
+    expect(byId.get(eventOnly.id)).toMatchObject({
+      assigned: false,
+      eventCount: 1,
+    });
+    expect(byId.get(both.id)).toMatchObject({
+      assigned: true,
+      eventCount: 1,
+    });
+  });
+
+  it('counts a character once per linked event it appears in', () => {
+    const character = makeCharacter({ id: 'c-1', name: 'Recurring' });
+    const eventA = makeEvent({ id: 'event-a', characterIds: [character.id] });
+    const eventB = makeEvent({ id: 'event-b', characterIds: [character.id] });
+    const quest = makeQuest({ eventIds: [eventA.id, eventB.id] });
+
+    const participants = buildQuestParticipants(
+      quest,
+      [eventA, eventB],
+      [character]
+    );
+
+    expect(participants).toEqual([
+      {
+        characterId: character.id,
+        name: character.name,
+        assigned: false,
+        eventCount: 2,
+      },
+    ]);
+  });
+
+  it('labels an unresolved character id as Unknown', () => {
+    const quest = makeQuest({ assignedCharacterIds: ['missing-character'] });
+
+    const participants = buildQuestParticipants(quest, [], []);
+
+    expect(participants).toEqual([
+      {
+        characterId: 'missing-character',
+        name: 'Unknown',
+        assigned: true,
+        eventCount: 0,
+      },
+    ]);
+  });
+
+  it('sorts participants by name', () => {
+    const zed = makeCharacter({ id: 'c-z', name: 'Zed' });
+    const anna = makeCharacter({ id: 'c-a', name: 'Anna' });
+    const quest = makeQuest({ assignedCharacterIds: [zed.id, anna.id] });
+
+    const participants = buildQuestParticipants(quest, [], [zed, anna]);
+
+    expect(participants.map(p => p.name)).toEqual(['Anna', 'Zed']);
+  });
+
+  it('returns an empty roster for a quest with no team and no events', () => {
+    const quest = makeQuest();
+
+    expect(buildQuestParticipants(quest, [], [])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #122.

- Add a mirrored `GameQuest.eventIds` ↔ `GameEvent.questIds` back-reference. `addQuest`/`updateQuest`/`deleteQuest` and `addEvent`/`updateEvent`/`deleteEvent` in `characterStorage.ts` keep both sides in sync (each storage key locked sequentially, never nested, following the existing bidirectional-faction-relationship pattern). A partial update that omits `eventIds`/`questIds` leaves existing links alone rather than clearing them.
- Add `reconcileQuestEventLinks()` — an idempotent backfill/prune migration for data written before `GameEvent.questIds` existed, called from `QuestListScreen`/`EventsTimelineScreen`'s load path (same pattern as `migrateFactionDescriptions`).
- Add `src/utils/questNarrative.ts`: pure helpers `buildQuestTimeline` (date/time-ordered, malformed dates sort last, dangling ids dropped) and `buildQuestParticipants` (union of assigned team + characters appearing in linked events, tagged assigned/in-events/both).
- `QuestDetailScreen`: "Related Events" chip list replaced with a tappable, date-ordered **Quest Timeline**; "Assigned Team" replaced with a combined **Participants** roster.
- `EventsDetailScreen`: new **Quests** section listing the quests an event belongs to, tappable to quest detail.
- `EventsFormScreen`: new "Related Quests" picker so quests can be linked directly from the event side.
- `AGENTS.md`: documented the quest↔event link-sync convention next to the existing bidirectional-faction-relationship bullet.

## Test plan

- [x] `npm run check-all` (type-check + lint + format:check + test) is green — 53 suites / 509 tests passing.
- [x] New unit tests: `tst/utils/questNarrative.test.ts`, `tst/utils/questEventLinks.test.ts`, `tst/utils/questEventLinks.concurrency.test.ts` (serialization/deadlock-guard coverage).
- [x] Updated screen tests: `QuestDetailScreen.test.tsx` (timeline ordering + tap-to-navigate, participant tagging), `EventsDetailScreen.test.tsx` (linked quests + tap-to-navigate), `EventsFormScreen.test.tsx` (quest links round-trip through create/update).
- [ ] Manual smoke test in the running app (create linked events/quests from both sides, verify timeline order, participant tagging, and deletion cleanup) — not run in this environment.


---
_Generated by [Claude Code](https://claude.ai/code/session_01B4CzCP3fW97oEqatY8L2L2)_