### PR TITLE
Add pluggable ruleset schema, provider, validator, and terminology layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ src/
   components/screens/   Base{List,Form,Detail}Screen — generic screen scaffolds
   screens/<feature>/    character/ faction/ location/ events/ discord/
   models/               types.ts (all domain types), gameData.ts, speciesTypes.ts
+  ruleset/               pluggable ruleset schema, provider, validator, terminology
   navigation/types.ts   navigator + param-list types
   styles/               theme.ts (colors/spacing/typography), commonStyles.ts
   utils/                storage, export/import, discord, git, stats
@@ -78,6 +79,41 @@ Path aliases (tsconfig + babel-plugin-module-resolver): `@/*` → `src/*`, plus
   there rather than growing it inside `gitIntegration.ts`. Network/offline
   failures are classified by `src/utils/syncErrors.ts`
   (`classifySyncError`) rather than surfaced as raw fetch error text.
+
+## Ruleset layer
+
+This is the seam a genre-neutral fork (`mccarjac/Lore`) plugs into. Today's
+Afterworlds data (`gameData.ts`, `speciesTypes.ts`) is unchanged and read-only
+— `src/ruleset/defaultRuleset.ts` derives a `RulesetDefinition` from it via a
+transform, not a hand-written literal, so it can never drift out of sync as
+Phase 1 issues rename fields.
+
+- `src/ruleset/types.ts` — the `RulesetDefinition` schema (archetypes, traits,
+  trait categories, qualities, resources, category-bonus rules, feature
+  flags, terminology). **Must stay JSON-serializable** — no functions, no
+  `ImageSourcePropType`/`require()` results anywhere in the definition. That
+  constraint is what keeps the backlogged in-app ruleset editor possible;
+  `validate.ts` enforces it at runtime. Bundled images referenced by a
+  ruleset (map, branding) go through the separate `RulesetAssets` map in
+  `src/ruleset/assets.ts` instead, keyed by string.
+- `src/ruleset/validate.ts` — `validateRuleset()` returns
+  `{ valid, issues }` rather than throwing, so a future user-authored ruleset
+  can surface errors in UI instead of crashing at startup. `RulesetProvider`
+  throws on an invalid ruleset in `__DEV__` and logs-and-renders otherwise.
+- `src/ruleset/context.tsx` — `RulesetProvider` / `useRuleset()`.
+  **`useRuleset()` returns the default Afterworlds ruleset outside a
+  provider rather than throwing** — every screen test in `tst/` renders
+  bare, and a throwing hook would require wrapping all of them. Use
+  `tst/helpers/ruleset.tsx`'s `renderWithRuleset()` for a test that needs a
+  non-default ruleset.
+- `src/ruleset/terminology.ts` — `useLabels()` (components) and `getLabel()`
+  (non-component code, e.g. `App.tsx` navigator options, or pure utils like
+  `factionStats.ts`/`characterStats.ts` that take a `ruleset` parameter
+  rather than importing one) look up a term key (`'trait.plural'`) against
+  the ruleset's `terminology` overrides, falling back to a neutral default.
+  Screens must not hardcode domain nouns (Species/Perk/Tag/Distinction/
+  Cyberware/Junktown Office) — look them up so a different ruleset can say
+  something else without a code change.
 
 ## Conventions & gotchas
 

--- a/App.tsx
+++ b/App.tsx
@@ -51,6 +51,7 @@ import { DiscordMessageContextScreen } from './src/screens/discord/DiscordMessag
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { ErrorBoundary } from './src/components';
+import { RulesetProvider, afterworldsRuleset, getLabel } from './src/ruleset';
 
 // Dark theme for navigation
 const DarkTheme = {
@@ -414,138 +415,140 @@ export default function App() {
 
   return (
     <ErrorBoundary>
-      <SafeAreaProvider>
-        <GestureHandlerRootView style={appStyles.root}>
-          <NavigationContainer theme={DarkTheme}>
-            <Stack.Navigator
-              initialRouteName="Main"
-              screenOptions={{
-                headerStyle: {
-                  backgroundColor: '#262647',
-                  borderBottomWidth: 1,
-                  borderBottomColor: '#404066',
-                },
-                headerTintColor: '#FFFFFF',
-                headerTitleStyle: {
-                  fontWeight: '600',
-                  fontSize: 18,
-                  letterSpacing: 0.3,
-                  maxWidth: headerTitleMaxWidth,
-                },
-                headerTitleAlign: 'left',
-                cardStyle: {
-                  backgroundColor: '#0F0F23',
-                },
-              }}
-            >
-              <Stack.Screen
-                name="Main"
-                component={MainDrawer}
-                options={{ headerShown: false }}
-              />
-              <Stack.Screen
-                name="CharacterDetail"
-                component={CharacterDetailScreen}
-                options={({ route }) => ({
-                  title: route.params?.character?.name || 'Character Detail',
-                })}
-              />
-              <Stack.Screen
-                name="CharacterForm"
-                component={CharacterFormScreen}
-                options={{ title: 'Character Form' }}
-              />
-              <Stack.Screen
-                name="CharacterSearch"
-                component={CharacterSearchScreen}
-                options={{ title: 'Search Characters' }}
-              />
-              <Stack.Screen
-                name="CharacterStats"
-                component={CharacterStatsScreen}
-                options={{ title: 'Character Statistics' }}
-              />
-              <Stack.Screen
-                name="FactionStats"
-                component={FactionStatsScreen}
-                options={{ title: 'Faction Statistics' }}
-              />
-              <Stack.Screen
-                name="FactionDetails"
-                component={FactionDetailsScreen}
-                options={({ route }) => ({
-                  title: route.params?.factionName || 'Faction Details',
-                })}
-              />
-              <Stack.Screen
-                name="FactionForm"
-                component={FactionFormScreen}
-                options={{ title: 'Create Faction' }}
-              />
-              <Stack.Screen
-                name="LocationDetails"
-                component={LocationDetailsScreen}
-                options={{ title: 'Location Details' }}
-              />
-              <Stack.Screen
-                name="LocationForm"
-                component={LocationFormScreen}
-                options={{ title: 'Create Location' }}
-              />
-              <Stack.Screen
-                name="LocationMap"
-                component={LocationMapScreen}
-                options={{ title: 'Junktown Map' }}
-              />
-              <Stack.Screen
-                name="EventsTimeline"
-                component={EventsTimelineScreen}
-                options={{ title: 'Events Timeline' }}
-              />
-              <Stack.Screen
-                name="EventsForm"
-                component={EventsFormScreen}
-                options={{ title: 'Event Form' }}
-              />
-              <Stack.Screen
-                name="EventsDetail"
-                component={EventsDetailScreen}
-                options={{ title: 'Event Details' }}
-              />
-              <Stack.Screen
-                name="QuestsList"
-                component={QuestListScreen}
-                options={{ title: 'Quests' }}
-              />
-              <Stack.Screen
-                name="QuestsForm"
-                component={QuestFormScreen}
-                options={{ title: 'Quest Form' }}
-              />
-              <Stack.Screen
-                name="QuestsDetail"
-                component={QuestDetailScreen}
-                options={{ title: 'Quest Details' }}
-              />
-              <Stack.Screen
-                name="QuestProposals"
-                component={QuestProposalScreen}
-                options={{ title: 'Quest Proposals' }}
-              />
-              <Stack.Screen
-                name="DiscordMessageContext"
-                component={DiscordMessageContextScreen}
-                options={{ title: 'Message Context' }}
-              />
-              <Stack.Screen
-                name="DiscordServerForm"
-                component={DiscordServerFormScreen}
-                options={{ title: 'Server Configuration' }}
-              />
-            </Stack.Navigator>
-          </NavigationContainer>
-        </GestureHandlerRootView>
-      </SafeAreaProvider>
+      <RulesetProvider>
+        <SafeAreaProvider>
+          <GestureHandlerRootView style={appStyles.root}>
+            <NavigationContainer theme={DarkTheme}>
+              <Stack.Navigator
+                initialRouteName="Main"
+                screenOptions={{
+                  headerStyle: {
+                    backgroundColor: '#262647',
+                    borderBottomWidth: 1,
+                    borderBottomColor: '#404066',
+                  },
+                  headerTintColor: '#FFFFFF',
+                  headerTitleStyle: {
+                    fontWeight: '600',
+                    fontSize: 18,
+                    letterSpacing: 0.3,
+                    maxWidth: headerTitleMaxWidth,
+                  },
+                  headerTitleAlign: 'left',
+                  cardStyle: {
+                    backgroundColor: '#0F0F23',
+                  },
+                }}
+              >
+                <Stack.Screen
+                  name="Main"
+                  component={MainDrawer}
+                  options={{ headerShown: false }}
+                />
+                <Stack.Screen
+                  name="CharacterDetail"
+                  component={CharacterDetailScreen}
+                  options={({ route }) => ({
+                    title: route.params?.character?.name || 'Character Detail',
+                  })}
+                />
+                <Stack.Screen
+                  name="CharacterForm"
+                  component={CharacterFormScreen}
+                  options={{ title: 'Character Form' }}
+                />
+                <Stack.Screen
+                  name="CharacterSearch"
+                  component={CharacterSearchScreen}
+                  options={{ title: 'Search Characters' }}
+                />
+                <Stack.Screen
+                  name="CharacterStats"
+                  component={CharacterStatsScreen}
+                  options={{ title: 'Character Statistics' }}
+                />
+                <Stack.Screen
+                  name="FactionStats"
+                  component={FactionStatsScreen}
+                  options={{ title: 'Faction Statistics' }}
+                />
+                <Stack.Screen
+                  name="FactionDetails"
+                  component={FactionDetailsScreen}
+                  options={({ route }) => ({
+                    title: route.params?.factionName || 'Faction Details',
+                  })}
+                />
+                <Stack.Screen
+                  name="FactionForm"
+                  component={FactionFormScreen}
+                  options={{ title: 'Create Faction' }}
+                />
+                <Stack.Screen
+                  name="LocationDetails"
+                  component={LocationDetailsScreen}
+                  options={{ title: 'Location Details' }}
+                />
+                <Stack.Screen
+                  name="LocationForm"
+                  component={LocationFormScreen}
+                  options={{ title: 'Create Location' }}
+                />
+                <Stack.Screen
+                  name="LocationMap"
+                  component={LocationMapScreen}
+                  options={{ title: getLabel(afterworldsRuleset, 'map.label') }}
+                />
+                <Stack.Screen
+                  name="EventsTimeline"
+                  component={EventsTimelineScreen}
+                  options={{ title: 'Events Timeline' }}
+                />
+                <Stack.Screen
+                  name="EventsForm"
+                  component={EventsFormScreen}
+                  options={{ title: 'Event Form' }}
+                />
+                <Stack.Screen
+                  name="EventsDetail"
+                  component={EventsDetailScreen}
+                  options={{ title: 'Event Details' }}
+                />
+                <Stack.Screen
+                  name="QuestsList"
+                  component={QuestListScreen}
+                  options={{ title: 'Quests' }}
+                />
+                <Stack.Screen
+                  name="QuestsForm"
+                  component={QuestFormScreen}
+                  options={{ title: 'Quest Form' }}
+                />
+                <Stack.Screen
+                  name="QuestsDetail"
+                  component={QuestDetailScreen}
+                  options={{ title: 'Quest Details' }}
+                />
+                <Stack.Screen
+                  name="QuestProposals"
+                  component={QuestProposalScreen}
+                  options={{ title: 'Quest Proposals' }}
+                />
+                <Stack.Screen
+                  name="DiscordMessageContext"
+                  component={DiscordMessageContextScreen}
+                  options={{ title: 'Message Context' }}
+                />
+                <Stack.Screen
+                  name="DiscordServerForm"
+                  component={DiscordServerFormScreen}
+                  options={{ title: 'Server Configuration' }}
+                />
+              </Stack.Navigator>
+            </NavigationContainer>
+          </GestureHandlerRootView>
+        </SafeAreaProvider>
+      </RulesetProvider>
     </ErrorBoundary>
   );
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,10 +24,12 @@ module.exports = {
     'src/utils/**/*.{ts,tsx}',
     'src/components/**/*.{ts,tsx}',
     'src/screens/**/*.{ts,tsx}',
+    'src/ruleset/**/*.{ts,tsx}',
     '!src/utils/**/*.d.ts',
     '!src/utils/**/index.{ts,tsx}',
     '!src/components/**/index.{ts,tsx}',
     '!src/screens/**/index.{ts,tsx}',
+    '!src/ruleset/index.{ts,tsx}',
   ],
   // No coverageThreshold for now — coverage reporting is informational only
   // (see .github/workflows/coverage.yml). Thresholds return once the gaps

--- a/src/ruleset/assets.ts
+++ b/src/ruleset/assets.ts
@@ -1,0 +1,19 @@
+import type { ImageSourcePropType } from 'react-native';
+import junktownMap from '../../assets/JunktownMap.png';
+
+/**
+ * Maps the asset keys referenced by a RulesetDefinition (map.imageKey,
+ * branding.iconKey, branding.splashKey) to bundled images. Kept separate
+ * from RulesetDefinition because bundled images cannot round-trip through
+ * JSON, and the definition itself must stay serializable.
+ */
+export type RulesetAssets = Record<string, ImageSourcePropType>;
+
+export const afterworldsAssets: RulesetAssets = {
+  map: junktownMap,
+};
+
+export const resolveAsset = (
+  assets: RulesetAssets,
+  key: string | undefined
+): ImageSourcePropType | undefined => (key ? assets[key] : undefined);

--- a/src/ruleset/context.tsx
+++ b/src/ruleset/context.tsx
@@ -1,0 +1,57 @@
+import React, { createContext, useContext, useMemo } from 'react';
+import { afterworldsRuleset } from './defaultRuleset';
+import { afterworldsAssets, type RulesetAssets } from './assets';
+import { validateRuleset } from './validate';
+import type { RulesetDefinition } from './types';
+
+export interface RulesetContextValue {
+  ruleset: RulesetDefinition;
+  assets: RulesetAssets;
+}
+
+const DEFAULT_CONTEXT_VALUE: RulesetContextValue = {
+  ruleset: afterworldsRuleset,
+  assets: afterworldsAssets,
+};
+
+/**
+ * Defaults outside a provider (rather than undefined + a throwing hook) so
+ * every screen that renders bare in tests keeps working unchanged.
+ */
+const RulesetContext = createContext<RulesetContextValue>(
+  DEFAULT_CONTEXT_VALUE
+);
+
+export interface RulesetProviderProps {
+  ruleset?: RulesetDefinition;
+  assets?: RulesetAssets;
+  children: React.ReactNode;
+}
+
+export const RulesetProvider: React.FC<RulesetProviderProps> = ({
+  ruleset = afterworldsRuleset,
+  assets = afterworldsAssets,
+  children,
+}) => {
+  const value = useMemo(() => {
+    const result = validateRuleset(ruleset);
+    if (!result.valid) {
+      const summary = result.issues
+        .map(issue => `  ${issue.path}: ${issue.message}`)
+        .join('\n');
+      if (__DEV__) {
+        throw new Error(`Invalid ruleset '${ruleset.id}':\n${summary}`);
+      }
+      console.error(`Invalid ruleset '${ruleset.id}':\n${summary}`);
+    }
+    return { ruleset, assets };
+  }, [ruleset, assets]);
+
+  return (
+    <RulesetContext.Provider value={value}>{children}</RulesetContext.Provider>
+  );
+};
+
+export function useRuleset(): RulesetContextValue {
+  return useContext(RulesetContext);
+}

--- a/src/ruleset/defaultRuleset.ts
+++ b/src/ruleset/defaultRuleset.ts
@@ -1,0 +1,178 @@
+import {
+  SPECIES_BASE_STATS,
+  ORGANIC_SPECIES,
+  ROBOTIC_SPECIES,
+  MUTANT_SPECIES,
+  ANDROID_SPECIES,
+  type Species,
+} from '@models/speciesTypes';
+import {
+  AVAILABLE_PERKS,
+  AVAILABLE_DISTINCTIONS,
+  AVAILABLE_RECIPES,
+  TAG_SCORE_BONUSES,
+  PerkTag,
+} from '@models/gameData';
+import type {
+  RulesetDefinition,
+  Archetype,
+  Trait,
+  Quality,
+  CategoryBonusRule,
+} from './types';
+
+const GROUP_MEMBERSHIP: Record<string, Species[]> = {
+  organic: ORGANIC_SPECIES,
+  robotic: ROBOTIC_SPECIES,
+  mutant: MUTANT_SPECIES,
+  android: ANDROID_SPECIES,
+};
+
+const groupsFor = (species: Species): string[] =>
+  Object.entries(GROUP_MEMBERSHIP)
+    .filter(([, members]) => members.includes(species))
+    .map(([groupId]) => groupId);
+
+/**
+ * Today's app grants no category-score bonus to Perfect Mutants from perks
+ * restricted to exactly the MUTANT_SPECIES group (derivedStats.ts:29-40).
+ * Expressed declaratively so a ruleset with different archetypes/groups can
+ * express (or omit) the same carve-out without touching derived-stats logic.
+ */
+const PERFECT_MUTANT_RULE: RulesetDefinition['archetypeRules'] = [
+  {
+    archetypeId: 'Perfect Mutant',
+    kind: 'excludeCategoryScoreFromGroupRestrictedTraits',
+    groupId: 'mutant',
+  },
+];
+
+const archetypes: Archetype[] = Object.entries(SPECIES_BASE_STATS).map(
+  ([id, stats]) => ({
+    id,
+    label: id,
+    groups: groupsFor(id as Species),
+    baseValues: { health: stats.baseHealth, limit: stats.baseLimit },
+    caps: { health: stats.healthCap, limit: stats.limitCap },
+    capabilities: {
+      cyberware: stats.canUseCyberware,
+      chems: stats.canUseChems,
+      injuries: stats.canTakeInjuries,
+      malfunctions: stats.canTakeMalfunctions,
+    },
+  })
+);
+
+const traits: Trait[] = AVAILABLE_PERKS.map(perk => ({
+  id: perk.id,
+  name: perk.name,
+  description: perk.description,
+  categoryId: perk.tag,
+  allowedArchetypeIds: perk.allowedSpecies,
+  recipeIds: perk.recipeIds,
+  resourceModifiers: perk.statModifiers
+    ? {
+        values: {
+          ...(perk.statModifiers.health !== undefined && {
+            health: perk.statModifiers.health,
+          }),
+          ...(perk.statModifiers.limit !== undefined && {
+            limit: perk.statModifiers.limit,
+          }),
+        },
+        caps: {
+          ...(perk.statModifiers.healthCap !== undefined && {
+            health: perk.statModifiers.healthCap,
+          }),
+          ...(perk.statModifiers.limitCap !== undefined && {
+            limit: perk.statModifiers.limitCap,
+          }),
+        },
+        categoryModifiers: perk.statModifiers.tagModifiers,
+      }
+    : undefined,
+}));
+
+const qualities: Quality[] = AVAILABLE_DISTINCTIONS.map(distinction => ({
+  id: distinction.id,
+  name: distinction.name,
+  description: distinction.description,
+  allowedArchetypeIds: distinction.allowedSpecies,
+}));
+
+const categoryBonuses: CategoryBonusRule[] = Object.entries(
+  TAG_SCORE_BONUSES
+).flatMap(([categoryId, bonuses]) =>
+  bonuses.map(bonus => ({
+    categoryId,
+    requiredScore: bonus.requiredScore,
+    grants: {
+      ...(bonus.health !== undefined && { health: bonus.health }),
+      ...(bonus.limit !== undefined && { limit: bonus.limit }),
+    },
+  }))
+);
+
+export const afterworldsRuleset: RulesetDefinition = {
+  id: 'afterworlds',
+  name: 'Junktown Intelligence',
+  version: '1.0.0',
+  terminology: {
+    'archetype.singular': 'Species',
+    'archetype.plural': 'Species',
+    'trait.singular': 'Perk',
+    'trait.plural': 'Perks',
+    'traitCategory.singular': 'Tag',
+    'traitCategory.plural': 'Tags',
+    'quality.singular': 'Distinction',
+    'quality.plural': 'Distinctions',
+    'modification.singular': 'Cyberware',
+    'modification.plural': 'Cyberware',
+    'resource.singular': 'Resource',
+    'resource.plural': 'Resources',
+    'recipe.singular': 'Recipe',
+    'recipe.plural': 'Recipes',
+    'questSponsor.singular': 'Junktown Office',
+    'questSponsor.plural': 'Junktown Offices',
+    'map.label': 'Junktown Map',
+  },
+  resources: [
+    { id: 'health', label: 'Health', capped: true },
+    { id: 'limit', label: 'Limit', capped: true },
+  ],
+  groups: [
+    { id: 'organic', label: 'Organic' },
+    { id: 'robotic', label: 'Robotic' },
+    { id: 'mutant', label: 'Mutant' },
+    { id: 'android', label: 'Android' },
+  ],
+  capabilities: [
+    { id: 'cyberware', label: 'Can Use Cyberware' },
+    { id: 'chems', label: 'Can Use Chems' },
+    { id: 'injuries', label: 'Can Take Injuries' },
+    { id: 'malfunctions', label: 'Can Take Malfunctions' },
+  ],
+  archetypes,
+  traitCategories: Object.values(PerkTag).map(tag => ({
+    id: tag,
+    label: tag,
+  })),
+  traits,
+  qualities,
+  recipes: AVAILABLE_RECIPES.map(recipe => ({ ...recipe })),
+  categoryBonuses,
+  archetypeRules: PERFECT_MUTANT_RULE,
+  features: {
+    quests: true,
+    recipes: true,
+    discord: true,
+    map: true,
+    gitSync: true,
+    modifications: true,
+    influenceReport: true,
+    relationshipGraph: true,
+  },
+  limits: { maxQualities: 3 },
+  map: { imageKey: 'map', label: 'Junktown Map' },
+  branding: { appName: 'Junktown Intelligence' },
+};

--- a/src/ruleset/index.ts
+++ b/src/ruleset/index.ts
@@ -1,0 +1,6 @@
+export * from './types';
+export * from './assets';
+export * from './validate';
+export * from './context';
+export * from './terminology';
+export { afterworldsRuleset } from './defaultRuleset';

--- a/src/ruleset/terminology.ts
+++ b/src/ruleset/terminology.ts
@@ -1,0 +1,56 @@
+import { useCallback } from 'react';
+import { useRuleset } from './context';
+import type { RulesetDefinition, TermKey, TerminologyMap } from './types';
+
+export const DEFAULT_TERMINOLOGY: TerminologyMap = {
+  'archetype.singular': 'Archetype',
+  'archetype.plural': 'Archetypes',
+  'trait.singular': 'Trait',
+  'trait.plural': 'Traits',
+  'traitCategory.singular': 'Category',
+  'traitCategory.plural': 'Categories',
+  'quality.singular': 'Quality',
+  'quality.plural': 'Qualities',
+  'modification.singular': 'Modification',
+  'modification.plural': 'Modifications',
+  'resource.singular': 'Resource',
+  'resource.plural': 'Resources',
+  'recipe.singular': 'Recipe',
+  'recipe.plural': 'Recipes',
+  'questSponsor.singular': 'Sponsor',
+  'questSponsor.plural': 'Sponsors',
+  'map.label': 'Map',
+};
+
+export type LabelCasing = 'lower' | 'title';
+
+const applyCasing = (value: string, casing?: LabelCasing): string => {
+  if (!casing) return value;
+  if (casing === 'lower') return value.toLowerCase();
+  return value.replace(
+    /\S+/g,
+    word => word[0].toUpperCase() + word.slice(1).toLowerCase()
+  );
+};
+
+/** Non-hook form, for use outside components (e.g. App.tsx navigator options). */
+export function getLabel(
+  ruleset: RulesetDefinition,
+  key: TermKey,
+  casing?: LabelCasing
+): string {
+  const value = ruleset.terminology[key] ?? DEFAULT_TERMINOLOGY[key];
+  return applyCasing(value, casing);
+}
+
+/**
+ * Returns a stable label-lookup function bound to the current ruleset, so a
+ * single template literal can pull several nouns without one hook call each.
+ */
+export function useLabels(): (key: TermKey, casing?: LabelCasing) => string {
+  const { ruleset } = useRuleset();
+  return useCallback(
+    (key: TermKey, casing?: LabelCasing) => getLabel(ruleset, key, casing),
+    [ruleset]
+  );
+}

--- a/src/ruleset/types.ts
+++ b/src/ruleset/types.ts
@@ -1,0 +1,165 @@
+/**
+ * Typed, pluggable ruleset schema. A RulesetDefinition must stay fully
+ * serializable (no functions, no require()'d assets) so it can round-trip
+ * through JSON for a future in-app ruleset editor. Non-serializable assets
+ * (images) are resolved separately through RulesetAssets in assets.ts.
+ */
+
+export type TermKey =
+  | 'archetype.singular'
+  | 'archetype.plural'
+  | 'trait.singular'
+  | 'trait.plural'
+  | 'traitCategory.singular'
+  | 'traitCategory.plural'
+  | 'quality.singular'
+  | 'quality.plural'
+  | 'modification.singular'
+  | 'modification.plural'
+  | 'resource.singular'
+  | 'resource.plural'
+  | 'recipe.singular'
+  | 'recipe.plural'
+  | 'questSponsor.singular'
+  | 'questSponsor.plural'
+  | 'map.label';
+
+export type TerminologyMap = Record<TermKey, string>;
+
+/** Replaces the hardcoded health/limit pair. */
+export interface ResourceDefinition {
+  id: string;
+  label: string;
+  abbreviation?: string;
+  /** When true, a per-archetype cap applies and derived values clamp to it. */
+  capped: boolean;
+}
+
+/** A named group an archetype can belong to (e.g. organic, robotic). */
+export interface ArchetypeGroup {
+  id: string;
+  label: string;
+}
+
+/** A capability flag an archetype can declare (e.g. canUseCyberware). */
+export interface CapabilityDefinition {
+  id: string;
+  label: string;
+}
+
+/** Replaces Species + SPECIES_BASE_STATS. */
+export interface Archetype {
+  id: string;
+  label: string;
+  /** Group ids this archetype belongs to; membership may overlap. */
+  groups: string[];
+  /** resourceId -> starting value. Must cover every ruleset resource. */
+  baseValues: Record<string, number>;
+  /** resourceId -> ceiling. Must cover exactly the resources with capped: true. */
+  caps: Record<string, number>;
+  /** capabilityId -> flag. Must cover exactly the declared capabilities. */
+  capabilities: Record<string, boolean>;
+}
+
+export interface TraitCategory {
+  id: string;
+  label: string;
+  color?: string;
+}
+
+/** Replaces StatModifiers. Keyed by resource/category id instead of health/limit/tag. */
+export interface ResourceModifiers {
+  /** resourceId -> delta applied to the running value. */
+  values?: Record<string, number>;
+  /** resourceId -> delta applied to the cap. */
+  caps?: Record<string, number>;
+  /** traitCategoryId -> delta applied to the category score. */
+  categoryModifiers?: Record<string, number>;
+}
+
+/** Replaces AVAILABLE_PERKS entries. */
+export interface Trait {
+  id: string;
+  name: string;
+  description: string;
+  categoryId: string;
+  resourceModifiers?: ResourceModifiers;
+  allowedArchetypeIds?: string[];
+  recipeIds?: string[];
+}
+
+/** Replaces AVAILABLE_DISTINCTIONS entries. */
+export interface Quality {
+  id: string;
+  name: string;
+  description: string;
+  allowedArchetypeIds?: string[];
+}
+
+export interface Recipe {
+  id: string;
+  name: string;
+  description: string;
+  materials: string[];
+}
+
+/** Replaces TAG_SCORE_BONUSES. Flat list rather than a Record keyed by an enum. */
+export interface CategoryBonusRule {
+  categoryId: string;
+  requiredScore: number;
+  /** resourceId -> bonus granted when the score threshold is met. */
+  grants: Record<string, number>;
+}
+
+/** Declarative form of the 'Perfect Mutant' carve-out in derivedStats.ts. */
+export interface ArchetypeRule {
+  archetypeId: string;
+  /**
+   * This archetype accrues no category score from traits whose
+   * allowedArchetypeIds is exactly the membership of this group.
+   */
+  kind: 'excludeCategoryScoreFromGroupRestrictedTraits';
+  groupId: string;
+}
+
+export interface FeatureFlags {
+  quests: boolean;
+  recipes: boolean;
+  discord: boolean;
+  map: boolean;
+  gitSync: boolean;
+  modifications: boolean;
+  influenceReport: boolean;
+  relationshipGraph: boolean;
+}
+
+/** Ruleset-level numeric limits that today are magic numbers in screens. */
+export interface RulesetLimits {
+  maxQualities?: number;
+}
+
+export interface RulesetDefinition {
+  id: string;
+  name: string;
+  version: string;
+  terminology: Partial<TerminologyMap>;
+  resources: ResourceDefinition[];
+  groups: ArchetypeGroup[];
+  capabilities: CapabilityDefinition[];
+  archetypes: Archetype[];
+  traitCategories: TraitCategory[];
+  traits: Trait[];
+  qualities: Quality[];
+  recipes?: Recipe[];
+  categoryBonuses: CategoryBonusRule[];
+  archetypeRules?: ArchetypeRule[];
+  features: FeatureFlags;
+  limits?: RulesetLimits;
+  /** Asset key resolved through RulesetAssets — never a require() result. */
+  map?: { imageKey: string; label: string };
+  branding: {
+    appName: string;
+    iconKey?: string;
+    splashKey?: string;
+  };
+}

--- a/src/ruleset/validate.ts
+++ b/src/ruleset/validate.ts
@@ -1,0 +1,272 @@
+import type { RulesetDefinition } from './types';
+
+export interface ValidationIssue {
+  path: string;
+  message: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  issues: ValidationIssue[];
+}
+
+const SERIALIZABLE_MESSAGE =
+  'must be JSON-serializable (no functions, class instances, or other non-plain values)';
+
+const checkSerializable = (
+  value: unknown,
+  path: string,
+  issues: ValidationIssue[]
+): void => {
+  if (value === null || value === undefined) return;
+  const type = typeof value;
+  if (type === 'string' || type === 'number' || type === 'boolean') return;
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      checkSerializable(item, `${path}[${index}]`, issues)
+    );
+    return;
+  }
+  if (type === 'object' && (value as object).constructor === Object) {
+    Object.entries(value as Record<string, unknown>).forEach(([key, v]) =>
+      checkSerializable(v, path ? `${path}.${key}` : key, issues)
+    );
+    return;
+  }
+  issues.push({ path, message: `Value at '${path}' ${SERIALIZABLE_MESSAGE}` });
+};
+
+const checkUniqueIds = (
+  items: { id: string }[],
+  collectionPath: string,
+  issues: ValidationIssue[]
+): void => {
+  const seen = new Set<string>();
+  items.forEach((item, index) => {
+    if (seen.has(item.id)) {
+      issues.push({
+        path: `${collectionPath}[${index}].id`,
+        message: `Duplicate id '${item.id}' in ${collectionPath}`,
+      });
+    }
+    seen.add(item.id);
+  });
+};
+
+export function validateRuleset(ruleset: RulesetDefinition): ValidationResult {
+  const issues: ValidationIssue[] = [];
+
+  if (!ruleset.id) issues.push({ path: 'id', message: 'id must be non-empty' });
+  if (!ruleset.name) {
+    issues.push({ path: 'name', message: 'name must be non-empty' });
+  }
+  if (!ruleset.version) {
+    issues.push({ path: 'version', message: 'version must be non-empty' });
+  }
+
+  checkUniqueIds(ruleset.resources, 'resources', issues);
+  checkUniqueIds(ruleset.groups, 'groups', issues);
+  checkUniqueIds(ruleset.capabilities, 'capabilities', issues);
+  checkUniqueIds(ruleset.archetypes, 'archetypes', issues);
+  checkUniqueIds(ruleset.traitCategories, 'traitCategories', issues);
+  checkUniqueIds(ruleset.traits, 'traits', issues);
+  checkUniqueIds(ruleset.qualities, 'qualities', issues);
+  if (ruleset.recipes) checkUniqueIds(ruleset.recipes, 'recipes', issues);
+
+  const resourceIds = new Set(ruleset.resources.map(r => r.id));
+  const cappedResourceIds = new Set(
+    ruleset.resources.filter(r => r.capped).map(r => r.id)
+  );
+  const groupIds = new Set(ruleset.groups.map(g => g.id));
+  const capabilityIds = new Set(ruleset.capabilities.map(c => c.id));
+  const categoryIds = new Set(ruleset.traitCategories.map(c => c.id));
+  const archetypeIds = new Set(ruleset.archetypes.map(a => a.id));
+  const recipeIds = new Set((ruleset.recipes ?? []).map(r => r.id));
+
+  ruleset.traits.forEach((trait, index) => {
+    if (!categoryIds.has(trait.categoryId)) {
+      issues.push({
+        path: `traits[${index}].categoryId`,
+        message: `Unknown traitCategory id '${trait.categoryId}'`,
+      });
+    }
+    trait.allowedArchetypeIds?.forEach((id, i) => {
+      if (!archetypeIds.has(id)) {
+        issues.push({
+          path: `traits[${index}].allowedArchetypeIds[${i}]`,
+          message: `Unknown archetype id '${id}'`,
+        });
+      }
+    });
+    trait.recipeIds?.forEach((id, i) => {
+      if (!recipeIds.has(id)) {
+        issues.push({
+          path: `traits[${index}].recipeIds[${i}]`,
+          message: `Unknown recipe id '${id}'`,
+        });
+      }
+    });
+    if (trait.resourceModifiers) {
+      Object.keys(trait.resourceModifiers.values ?? {}).forEach(id => {
+        if (!resourceIds.has(id)) {
+          issues.push({
+            path: `traits[${index}].resourceModifiers.values.${id}`,
+            message: `Unknown resource id '${id}'`,
+          });
+        }
+      });
+      Object.keys(trait.resourceModifiers.caps ?? {}).forEach(id => {
+        if (!resourceIds.has(id)) {
+          issues.push({
+            path: `traits[${index}].resourceModifiers.caps.${id}`,
+            message: `Unknown resource id '${id}'`,
+          });
+        }
+      });
+      Object.keys(trait.resourceModifiers.categoryModifiers ?? {}).forEach(
+        id => {
+          if (!categoryIds.has(id)) {
+            issues.push({
+              path: `traits[${index}].resourceModifiers.categoryModifiers.${id}`,
+              message: `Unknown traitCategory id '${id}'`,
+            });
+          }
+        }
+      );
+    }
+  });
+
+  ruleset.qualities.forEach((quality, index) => {
+    quality.allowedArchetypeIds?.forEach((id, i) => {
+      if (!archetypeIds.has(id)) {
+        issues.push({
+          path: `qualities[${index}].allowedArchetypeIds[${i}]`,
+          message: `Unknown archetype id '${id}'`,
+        });
+      }
+    });
+  });
+
+  ruleset.archetypes.forEach((archetype, index) => {
+    archetype.groups.forEach((groupId, i) => {
+      if (!groupIds.has(groupId)) {
+        issues.push({
+          path: `archetypes[${index}].groups[${i}]`,
+          message: `Unknown group id '${groupId}'`,
+        });
+      }
+    });
+
+    resourceIds.forEach(resourceId => {
+      if (!(resourceId in archetype.baseValues)) {
+        issues.push({
+          path: `archetypes[${index}].baseValues.${resourceId}`,
+          message: `Missing base value for resource '${resourceId}'`,
+        });
+      }
+    });
+    Object.keys(archetype.baseValues).forEach(resourceId => {
+      if (!resourceIds.has(resourceId)) {
+        issues.push({
+          path: `archetypes[${index}].baseValues.${resourceId}`,
+          message: `Unknown resource id '${resourceId}'`,
+        });
+      }
+    });
+
+    cappedResourceIds.forEach(resourceId => {
+      if (!(resourceId in archetype.caps)) {
+        issues.push({
+          path: `archetypes[${index}].caps.${resourceId}`,
+          message: `Missing cap for capped resource '${resourceId}'`,
+        });
+      }
+    });
+    Object.keys(archetype.caps).forEach(resourceId => {
+      if (!cappedResourceIds.has(resourceId)) {
+        issues.push({
+          path: `archetypes[${index}].caps.${resourceId}`,
+          message: `Resource '${resourceId}' is not capped; unexpected cap entry`,
+        });
+      }
+    });
+
+    capabilityIds.forEach(capabilityId => {
+      if (!(capabilityId in archetype.capabilities)) {
+        issues.push({
+          path: `archetypes[${index}].capabilities.${capabilityId}`,
+          message: `Missing capability '${capabilityId}'`,
+        });
+      }
+    });
+    Object.keys(archetype.capabilities).forEach(capabilityId => {
+      if (!capabilityIds.has(capabilityId)) {
+        issues.push({
+          path: `archetypes[${index}].capabilities.${capabilityId}`,
+          message: `Unknown capability id '${capabilityId}'`,
+        });
+      }
+    });
+  });
+
+  ruleset.categoryBonuses.forEach((rule, index) => {
+    if (!categoryIds.has(rule.categoryId)) {
+      issues.push({
+        path: `categoryBonuses[${index}].categoryId`,
+        message: `Unknown traitCategory id '${rule.categoryId}'`,
+      });
+    }
+    if (!Number.isInteger(rule.requiredScore) || rule.requiredScore <= 0) {
+      issues.push({
+        path: `categoryBonuses[${index}].requiredScore`,
+        message: 'requiredScore must be a positive integer',
+      });
+    }
+    Object.keys(rule.grants).forEach(resourceId => {
+      if (!resourceIds.has(resourceId)) {
+        issues.push({
+          path: `categoryBonuses[${index}].grants.${resourceId}`,
+          message: `Unknown resource id '${resourceId}'`,
+        });
+      }
+    });
+  });
+
+  ruleset.archetypeRules?.forEach((rule, index) => {
+    if (!archetypeIds.has(rule.archetypeId)) {
+      issues.push({
+        path: `archetypeRules[${index}].archetypeId`,
+        message: `Unknown archetype id '${rule.archetypeId}'`,
+      });
+    }
+    if (!groupIds.has(rule.groupId)) {
+      issues.push({
+        path: `archetypeRules[${index}].groupId`,
+        message: `Unknown group id '${rule.groupId}'`,
+      });
+    }
+  });
+
+  if (ruleset.map && !ruleset.map.imageKey) {
+    issues.push({
+      path: 'map.imageKey',
+      message: 'imageKey must be non-empty when map is present',
+    });
+  }
+  if (ruleset.branding.iconKey === '') {
+    issues.push({
+      path: 'branding.iconKey',
+      message: 'iconKey must be non-empty when present',
+    });
+  }
+  if (ruleset.branding.splashKey === '') {
+    issues.push({
+      path: 'branding.splashKey',
+      message: 'splashKey must be non-empty when present',
+    });
+  }
+
+  checkSerializable(ruleset, '', issues);
+
+  return { valid: issues.length === 0, issues };
+}

--- a/src/screens/CharacterStatsScreen.tsx
+++ b/src/screens/CharacterStatsScreen.tsx
@@ -16,8 +16,11 @@ import {
 import { GameCharacter } from '@/models/types';
 import { colors as themeColors } from '@/styles/theme';
 import { commonStyles } from '@/styles/commonStyles';
+import { useLabels, useRuleset } from '@/ruleset';
 
 export const CharacterStatsScreen = () => {
+  const label = useLabels();
+  const { ruleset } = useRuleset();
   const [stats, setStats] = useState<CharacterStats | null>(null);
   const [selectedSlice, setSelectedSlice] = useState<string | null>(null);
   const [showOnlyPresent, setShowOnlyPresent] = useState<boolean>(false);
@@ -25,9 +28,9 @@ export const CharacterStatsScreen = () => {
 
   const calculateStats = useCallback(
     (characters: GameCharacter[]): CharacterStats => {
-      return calculateCharacterStats(characters);
+      return calculateCharacterStats(characters, ruleset);
     },
-    []
+    [ruleset]
   );
 
   // Calculate stats whenever characters or filter changes
@@ -66,7 +69,7 @@ export const CharacterStatsScreen = () => {
       const stats = calculateStats(filteredCharacters);
       setStats(stats);
     }
-  }, [showOnlyPresent]);
+  }, [showOnlyPresent, calculateStats]);
 
   useFocusEffect(
     useCallback(() => {
@@ -198,7 +201,9 @@ export const CharacterStatsScreen = () => {
             </View>
 
             <View style={styles.section}>
-              <Text style={styles.sectionHeader}>Species Distribution</Text>
+              <Text style={styles.sectionHeader}>
+                {label('archetype.plural')} Distribution
+              </Text>
               {getSpeciesPieChartData().length > 0 && (
                 <View style={styles.chartContainer}>
                   <PieChart
@@ -296,7 +301,9 @@ export const CharacterStatsScreen = () => {
             </View>
 
             <View style={styles.section}>
-              <Text style={styles.sectionHeader}>Most Common Perks</Text>
+              <Text style={styles.sectionHeader}>
+                Most Common {label('trait.plural')}
+              </Text>
               {stats.commonPerks.map(({ name, count }) => (
                 <Text key={name} style={styles.listItemText}>
                   {name}: {count} characters
@@ -305,7 +312,9 @@ export const CharacterStatsScreen = () => {
             </View>
 
             <View style={styles.section}>
-              <Text style={styles.sectionHeader}>Most Common Distinctions</Text>
+              <Text style={styles.sectionHeader}>
+                Most Common {label('quality.plural')}
+              </Text>
               {stats.commonDistinctions.map(({ name, count }) => (
                 <Text key={name} style={styles.listItemText}>
                   {name}: {count} characters

--- a/src/screens/FactionStatsScreen.tsx
+++ b/src/screens/FactionStatsScreen.tsx
@@ -20,11 +20,14 @@ import { colors as themeColors } from '@/styles/theme';
 import { commonStyles } from '@/styles/commonStyles';
 import { PerkTag } from '@/models/gameData';
 import { CollapsibleSection, InfoButton } from '@/components';
+import { useLabels, useRuleset } from '@/ruleset';
 
 type FactionStatsNavigationProp = StackNavigationProp<RootStackParamList>;
 
 export const FactionStatsScreen: React.FC = () => {
   const navigation = useNavigation<FactionStatsNavigationProp>();
+  const label = useLabels();
+  const { ruleset } = useRuleset();
   const [factionStats, setFactionStats] = useState<FactionStats[]>([]);
   const [selectedFaction, setSelectedFaction] = useState<string | null>(null);
   const [combinedAnalysis, setCombinedAnalysis] =
@@ -52,7 +55,8 @@ export const FactionStatsScreen: React.FC = () => {
         calculateFactionStats(
           faction.name,
           activeCharacters,
-          faction.relationships || []
+          faction.relationships || [],
+          ruleset
         )
       );
 
@@ -65,7 +69,7 @@ export const FactionStatsScreen: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [ruleset]);
 
   useFocusEffect(
     useCallback(() => {
@@ -95,7 +99,8 @@ export const FactionStatsScreen: React.FC = () => {
         const analysis = calculateCombinedFactionStats(
           factionName,
           activeCharacters,
-          relationshipsMap
+          relationshipsMap,
+          ruleset
         );
         setCombinedAnalysis(analysis);
       } catch (error) {
@@ -192,10 +197,30 @@ export const FactionStatsScreen: React.FC = () => {
             {/* Perk Tags Analysis */}
             <View style={styles.sectionWithInfo}>
               <View style={styles.sectionHeader}>
-                <Text style={styles.sectionTitle}>Perk Tag Analysis</Text>
+                <Text style={styles.sectionTitle}>
+                  {label('trait.singular')} {label('traitCategory.singular')}{' '}
+                  Analysis
+                </Text>
                 <InfoButton
-                  title="Perk Tag Analysis"
-                  content="This graph shows the distribution of perk tags among faction members. Each bar represents the total count of perks with that tag across all members. For example, if 5 members each have 2 Strength perks, the Strength bar would show 10. This helps identify the faction's collective strengths and specializations."
+                  title={`${label('trait.singular')} ${label(
+                    'traitCategory.singular'
+                  )} Analysis`}
+                  content={`This graph shows the distribution of ${label(
+                    'trait.singular',
+                    'lower'
+                  )} ${label(
+                    'traitCategory.plural',
+                    'lower'
+                  )} among faction members. Each bar represents the total count of ${label(
+                    'trait.plural',
+                    'lower'
+                  )} with that ${label(
+                    'traitCategory.singular',
+                    'lower'
+                  )} across all members. For example, if 5 members each have 2 Strength ${label(
+                    'trait.plural',
+                    'lower'
+                  )}, the Strength bar would show 10. This helps identify the faction's collective strengths and specializations.`}
                 />
               </View>
               {stats.topPerkTags.length > 0 ? (
@@ -210,13 +235,18 @@ export const FactionStatsScreen: React.FC = () => {
                 </View>
               ) : (
                 <Text style={styles.emptyText}>
-                  No perk tags found for this faction
+                  No {label('trait.singular', 'lower')}{' '}
+                  {label('traitCategory.plural', 'lower')} found for this
+                  faction
                 </Text>
               )}
             </View>
 
             {/* Common Perks */}
-            <CollapsibleSection title="Common Perks" defaultCollapsed={true}>
+            <CollapsibleSection
+              title={`Common ${label('trait.plural')}`}
+              defaultCollapsed={true}
+            >
               {stats.commonPerks.length > 0 ? (
                 <View style={styles.listContainer}>
                   {stats.commonPerks.map((perk, index) => (
@@ -229,13 +259,15 @@ export const FactionStatsScreen: React.FC = () => {
                   ))}
                 </View>
               ) : (
-                <Text style={styles.emptyText}>No perks found</Text>
+                <Text style={styles.emptyText}>
+                  No {label('trait.plural', 'lower')} found
+                </Text>
               )}
             </CollapsibleSection>
 
             {/* Common Distinctions */}
             <CollapsibleSection
-              title="Common Distinctions"
+              title={`Common ${label('quality.plural')}`}
               defaultCollapsed={true}
             >
               {stats.commonDistinctions.length > 0 ? (
@@ -253,13 +285,15 @@ export const FactionStatsScreen: React.FC = () => {
                   ))}
                 </View>
               ) : (
-                <Text style={styles.emptyText}>No distinctions found</Text>
+                <Text style={styles.emptyText}>
+                  No {label('quality.plural', 'lower')} found
+                </Text>
               )}
             </CollapsibleSection>
 
             {/* Species Distribution */}
             <CollapsibleSection
-              title="Species Distribution"
+              title={`${label('archetype.plural')} Distribution`}
               defaultCollapsed={true}
             >
               {Object.keys(stats.speciesDistribution).length > 0 ? (
@@ -274,7 +308,9 @@ export const FactionStatsScreen: React.FC = () => {
                     ))}
                 </View>
               ) : (
-                <Text style={styles.emptyText}>No species data available</Text>
+                <Text style={styles.emptyText}>
+                  No {label('archetype.singular', 'lower')} data available
+                </Text>
               )}
             </CollapsibleSection>
 
@@ -347,7 +383,13 @@ export const FactionStatsScreen: React.FC = () => {
                     </Text>
                     <InfoButton
                       title="Combined Force Analysis"
-                      content="This analysis shows the total military strength when a faction and its allies work together. 'Direct Members' are the faction's own members. 'Allied Members' are members from allied factions. 'Total Combined' is the sum of all members. 'Strength Multiplier' shows how much stronger the faction is with allies compared to fighting alone. The perk tag bars below show the combined capabilities of all allied forces."
+                      content={`This analysis shows the total military strength when a faction and its allies work together. 'Direct Members' are the faction's own members. 'Allied Members' are members from allied factions. 'Total Combined' is the sum of all members. 'Strength Multiplier' shows how much stronger the faction is with allies compared to fighting alone. The ${label(
+                        'trait.singular',
+                        'lower'
+                      )} ${label(
+                        'traitCategory.singular',
+                        'lower'
+                      )} bars below show the combined capabilities of all allied forces.`}
                     />
                   </View>
                   <View style={styles.combinedAnalysisCard}>

--- a/src/screens/character/CharacterDetailScreen.tsx
+++ b/src/screens/character/CharacterDetailScreen.tsx
@@ -22,6 +22,7 @@ import {
   AVAILABLE_RECIPES,
 } from '@models/gameData';
 import { calculateDerivedStats } from '@/utils/derivedStats';
+import { useLabels } from '@/ruleset';
 import { GameCharacter, GameLocation, DiscordMessage } from '@/models/types';
 import {
   loadCharacters,
@@ -45,6 +46,7 @@ export const CharacterDetailScreen: React.FC = () => {
 
   const route = useRoute<CharacterDetailRouteProp>();
   const navigation = useNavigation<CharacterDetailNavigationProp>();
+  const label = useLabels();
   const { character } = route.params || {};
   const [allCharacters, setAllCharacters] = useState<GameCharacter[]>([]);
   const [locations, setLocations] = useState<GameLocation[]>([]);
@@ -190,7 +192,7 @@ export const CharacterDetailScreen: React.FC = () => {
     if (!tagScores || tagScores.size === 0) return null;
 
     return (
-      <Section title="Tag Scores">
+      <Section title={`${label('traitCategory.plural')} Scores`}>
         <View style={styles.tagScoresContainer}>
           {Array.from(tagScores.entries()).map(([tag, score]) => (
             <View key={tag} style={styles.tagScoreItem}>
@@ -209,7 +211,7 @@ export const CharacterDetailScreen: React.FC = () => {
     }
 
     return (
-      <CollapsibleSection title="Perks" defaultCollapsed={true}>
+      <CollapsibleSection title={label('trait.plural')} defaultCollapsed={true}>
         {AVAILABLE_PERKS.filter(perk =>
           character.perkIds.includes(perk.id)
         ).map(perk => (
@@ -218,7 +220,9 @@ export const CharacterDetailScreen: React.FC = () => {
             <Text style={styles.descriptionText}>{perk.description}</Text>
             {perk.recipeIds && perk.recipeIds.length > 0 && (
               <View style={styles.recipesContainer}>
-                <Text style={styles.recipesTitle}>Known Recipes:</Text>
+                <Text style={styles.recipesTitle}>
+                  Known {label('recipe.plural')}:
+                </Text>
                 {perk.recipeIds.map(recipeId => {
                   const recipe = AVAILABLE_RECIPES.find(r => r.id === recipeId);
                   if (!recipe) return null;
@@ -255,7 +259,10 @@ export const CharacterDetailScreen: React.FC = () => {
     }
 
     return (
-      <CollapsibleSection title="Distinctions" defaultCollapsed={true}>
+      <CollapsibleSection
+        title={label('quality.plural')}
+        defaultCollapsed={true}
+      >
         {AVAILABLE_DISTINCTIONS.filter(distinction =>
           character.distinctionIds.includes(distinction.id)
         ).map(distinction => (
@@ -352,7 +359,7 @@ export const CharacterDetailScreen: React.FC = () => {
     }
 
     return (
-      <Section title="Cyberware">
+      <Section title={label('modification.plural')}>
         {character.cyberware.map((cyber, index) => (
           <View key={index} style={styles.itemContainer}>
             <Text style={styles.titleText}>{cyber.name}</Text>

--- a/src/screens/character/CharacterFormScreen.tsx
+++ b/src/screens/character/CharacterFormScreen.tsx
@@ -42,12 +42,16 @@ import {
 import { colors as themeColors } from '@/styles/theme';
 import { commonStyles } from '@/styles/commonStyles';
 import { BaseFormScreen } from '@/components';
+import { useLabels, useRuleset } from '@/ruleset';
 
 type CharacterFormRouteProp = RouteProp<RootStackParamList, 'CharacterForm'>;
 
 export const CharacterFormScreen: React.FC = () => {
   const navigation = useNavigation();
   const route = useRoute<CharacterFormRouteProp>();
+  const label = useLabels();
+  const { ruleset } = useRuleset();
+  const maxQualities = ruleset.limits?.maxQualities ?? 3;
   const editingCharacter = route.params?.character;
   const [selectedPerkTag, setSelectedPerkTag] = useState<string>('');
   const [allCharacters, setAllCharacters] = useState<GameCharacter[]>([]);
@@ -330,7 +334,7 @@ export const CharacterFormScreen: React.FC = () => {
       </View>
 
       <View style={styles.formSection}>
-        <Text style={styles.label}>Species</Text>
+        <Text style={styles.label}>{label('archetype.singular')}</Text>
         <Picker
           selectedValue={form.species}
           style={[styles.picker, { flex: 1 }]}
@@ -367,19 +371,24 @@ export const CharacterFormScreen: React.FC = () => {
           style={styles.sectionHeader}
           onPress={() => setPerksExpanded(!perksExpanded)}
         >
-          <Text style={styles.label}>Perks</Text>
+          <Text style={styles.label}>{label('trait.plural')}</Text>
           <Text style={styles.expandIcon}>{perksExpanded ? '▼' : '▶'}</Text>
         </TouchableOpacity>
         {perksExpanded && (
           <>
             <View style={styles.filterContainer}>
-              <Text style={styles.filterLabel}>Filter by Tag:</Text>
+              <Text style={styles.filterLabel}>
+                Filter by {label('traitCategory.singular')}:
+              </Text>
               <Picker
                 selectedValue={selectedPerkTag}
                 style={[styles.picker, { flex: 1 }]}
                 onValueChange={setSelectedPerkTag}
               >
-                <Picker.Item label="All Tags" value="" />
+                <Picker.Item
+                  label={`All ${label('traitCategory.plural')}`}
+                  value=""
+                />
                 {Array.from(new Set(AVAILABLE_PERKS.map(perk => perk.tag)))
                   .sort()
                   .map(tag => (
@@ -416,7 +425,7 @@ export const CharacterFormScreen: React.FC = () => {
                           <Text style={styles.speciesText}>
                             {perk.allowedSpecies.length === 1
                               ? perk.allowedSpecies[0]
-                              : `${perk.allowedSpecies.length} Species`}
+                              : `${perk.allowedSpecies.length} ${label('archetype.plural')}`}
                           </Text>
                         )}
                       <Text style={styles.tagText}>{perk.tag}</Text>
@@ -435,7 +444,7 @@ export const CharacterFormScreen: React.FC = () => {
           style={styles.sectionHeader}
           onPress={() => setDistinctionsExpanded(!distinctionsExpanded)}
         >
-          <Text style={styles.label}>Distinctions</Text>
+          <Text style={styles.label}>{label('quality.plural')}</Text>
           <Text style={styles.expandIcon}>
             {distinctionsExpanded ? '▼' : '▶'}
           </Text>
@@ -461,7 +470,7 @@ export const CharacterFormScreen: React.FC = () => {
                       id => id !== distinction.id
                     );
                     handleChange('distinctionIds', newDistinctionIds);
-                  } else if (form.distinctionIds.length < 3) {
+                  } else if (form.distinctionIds.length < maxQualities) {
                     // Allow selection if under limit
                     const newDistinctionIds = [
                       ...form.distinctionIds,
@@ -472,7 +481,10 @@ export const CharacterFormScreen: React.FC = () => {
                     // Show alert when limit reached
                     Alert.alert(
                       'Maximum Reached',
-                      'You can only select up to 3 distinctions.'
+                      `You can only select up to ${maxQualities} ${label(
+                        'quality.plural',
+                        'lower'
+                      )}.`
                     );
                   }
                 }}
@@ -485,7 +497,7 @@ export const CharacterFormScreen: React.FC = () => {
       </View>
 
       <View style={styles.formSection}>
-        <Text style={styles.label}>Cyberware</Text>
+        <Text style={styles.label}>{label('modification.plural')}</Text>
         {form.cyberware &&
           form.cyberware.map((cyber, index) => (
             <View key={index} style={styles.cyberwareContainer}>
@@ -498,7 +510,7 @@ export const CharacterFormScreen: React.FC = () => {
                     newCyberware[index] = { ...cyber, name: value };
                     handleChange('cyberware', newCyberware);
                   }}
-                  placeholder="Cyberware name"
+                  placeholder={`${label('modification.singular')} name`}
                 />
                 <TouchableOpacity
                   style={styles.removeButton}
@@ -621,7 +633,8 @@ export const CharacterFormScreen: React.FC = () => {
                 </View>
                 <View style={styles.tagModifiersSection}>
                   <Text style={styles.tagModifiersLabel}>
-                    Tag Score Modifiers (optional):
+                    {label('traitCategory.singular')} Score Modifiers
+                    (optional):
                   </Text>
                   <View style={styles.tagModifiersList}>
                     {Object.values(PerkTag).map(tag => {
@@ -734,14 +747,17 @@ export const CharacterFormScreen: React.FC = () => {
                         handleChange('cyberware', newCyberware);
                       } else {
                         Alert.alert(
-                          'All Tags Added',
-                          'All available tags already have modifiers.'
+                          `All ${label('traitCategory.plural')} Added`,
+                          `All available ${label(
+                            'traitCategory.plural',
+                            'lower'
+                          )} already have modifiers.`
                         );
                       }
                     }}
                   >
                     <Text style={styles.addTagModifierButtonText}>
-                      + Add Tag Modifier
+                      + Add {label('traitCategory.singular')} Modifier
                     </Text>
                   </TouchableOpacity>
                 </View>
@@ -761,7 +777,9 @@ export const CharacterFormScreen: React.FC = () => {
             ]);
           }}
         >
-          <Text style={styles.addButtonText}>Add Cyberware</Text>
+          <Text style={styles.addButtonText}>
+            Add {label('modification.singular')}
+          </Text>
         </TouchableOpacity>
       </View>
 

--- a/src/screens/character/CharacterSearchScreen.tsx
+++ b/src/screens/character/CharacterSearchScreen.tsx
@@ -26,6 +26,7 @@ import {
 import { RootStackParamList } from '@/navigation/types';
 import { colors as themeColors } from '@/styles/theme';
 import { commonStyles } from '@/styles/commonStyles';
+import { useLabels } from '@/ruleset';
 
 type SearchScreenNavigationProp = StackNavigationProp<RootStackParamList>;
 
@@ -49,6 +50,7 @@ interface SearchCriteria {
 
 export const CharacterSearchScreen: React.FC = () => {
   const navigation = useNavigation<SearchScreenNavigationProp>();
+  const label = useLabels();
   const [searchCriteria, setSearchCriteria] = useState<SearchCriteria>({
     presentStatus: 'any',
     retiredStatus: 'active', // Default to searching only active (non-retired) characters
@@ -146,7 +148,7 @@ export const CharacterSearchScreen: React.FC = () => {
         <Text style={styles.sectionTitle}>Search Criteria</Text>
 
         <View style={styles.criteriaItem}>
-          <Text style={styles.label}>Perk</Text>
+          <Text style={styles.label}>{label('trait.singular')}</Text>
           <Picker
             selectedValue={searchCriteria.perkId}
             style={styles.picker}
@@ -157,7 +159,7 @@ export const CharacterSearchScreen: React.FC = () => {
               }))
             }
           >
-            <Picker.Item label="Any Perk" value="" />
+            <Picker.Item label={`Any ${label('trait.singular')}`} value="" />
             {AVAILABLE_PERKS.map(perk => (
               <Picker.Item key={perk.id} label={perk.name} value={perk.id} />
             ))}
@@ -165,7 +167,7 @@ export const CharacterSearchScreen: React.FC = () => {
         </View>
 
         <View style={styles.criteriaItem}>
-          <Text style={styles.label}>Distinction</Text>
+          <Text style={styles.label}>{label('quality.singular')}</Text>
           <Picker
             selectedValue={searchCriteria.distinctionId}
             style={styles.picker}
@@ -176,7 +178,7 @@ export const CharacterSearchScreen: React.FC = () => {
               }))
             }
           >
-            <Picker.Item label="Any Distinction" value="" />
+            <Picker.Item label={`Any ${label('quality.singular')}`} value="" />
             {AVAILABLE_DISTINCTIONS.map(distinction => (
               <Picker.Item
                 key={distinction.id}
@@ -188,7 +190,9 @@ export const CharacterSearchScreen: React.FC = () => {
         </View>
 
         <View style={styles.criteriaItem}>
-          <Text style={styles.label}>Tag Score</Text>
+          <Text style={styles.label}>
+            {label('traitCategory.singular')} Score
+          </Text>
           <View style={styles.tagScoreContainer}>
             <Picker
               selectedValue={searchCriteria.tag}
@@ -200,7 +204,10 @@ export const CharacterSearchScreen: React.FC = () => {
                 }))
               }
             >
-              <Picker.Item label="Any Tag" value="" />
+              <Picker.Item
+                label={`Any ${label('traitCategory.singular')}`}
+                value=""
+              />
               {getAllTags().map(tag => (
                 <Picker.Item key={tag} label={tag} value={tag} />
               ))}

--- a/src/screens/quest/QuestDetailScreen.tsx
+++ b/src/screens/quest/QuestDetailScreen.tsx
@@ -24,6 +24,7 @@ import {
 import { colors as themeColors } from '@/styles/theme';
 import { commonStyles } from '@/styles/commonStyles';
 import { BaseDetailScreen, Section, CollapsibleSection } from '@/components';
+import { useLabels } from '@/ruleset';
 import { formatEventDate, formatEventDateShort } from '@utils/dateUtils';
 import {
   buildQuestTimeline,
@@ -69,6 +70,7 @@ interface QuestWithDetails extends GameQuest {
 export const QuestDetailScreen: React.FC = () => {
   const navigation = useNavigation<QuestsDetailNavigationProp>();
   const route = useRoute<QuestsDetailRouteProp>();
+  const label = useLabels();
   const { questId } = route.params;
 
   const [quest, setQuest] = useState<QuestWithDetails | null>(null);
@@ -209,7 +211,9 @@ export const QuestDetailScreen: React.FC = () => {
         )}
         {quest.junktownOffice && (
           <View style={styles.overviewRow}>
-            <Text style={styles.overviewLabel}>Junktown Office</Text>
+            <Text style={styles.overviewLabel}>
+              {label('questSponsor.singular')}
+            </Text>
             <Text style={styles.overviewValue}>{quest.junktownOffice}</Text>
           </View>
         )}

--- a/src/screens/quest/QuestFormScreen.tsx
+++ b/src/screens/quest/QuestFormScreen.tsx
@@ -38,6 +38,7 @@ import {
 } from '@models/gameData';
 import { SPECIES_BASE_STATS, Species } from '@models/speciesTypes';
 import { BaseFormScreen, CollapsibleSection } from '@/components';
+import { useLabels } from '@/ruleset';
 
 type QuestsFormNavigationProp = StackNavigationProp<
   RootStackParamList,
@@ -200,6 +201,7 @@ const DISTINCTION_OPTIONS: Option<DistinctionId>[] = AVAILABLE_DISTINCTIONS.map(
 export const QuestFormScreen: React.FC = () => {
   const navigation = useNavigation<QuestsFormNavigationProp>();
   const route = useRoute<QuestsFormRouteProp>();
+  const label = useLabels();
   const { quest } = route.params || {};
 
   const [formData, setFormData] = useState<QuestFormData>(emptyFormData());
@@ -552,32 +554,38 @@ export const QuestFormScreen: React.FC = () => {
       <CollapsibleSection title="Team Preferences" defaultCollapsed>
         <Text style={styles.sublabel}>Desirable</Text>
         <MultiSelectField
-          label="Tags"
-          placeholder="Select tag to add..."
+          label={label('traitCategory.plural')}
+          placeholder={`Select ${label(
+            'traitCategory.singular',
+            'lower'
+          )} to add...`}
           options={TAG_OPTIONS}
           selected={formData.desirable.tags}
           onAdd={value => addPreference('desirable', 'tags', value)}
           onRemove={value => removePreference('desirable', 'tags', value)}
         />
         <MultiSelectField
-          label="Species"
-          placeholder="Select species to add..."
+          label={label('archetype.plural')}
+          placeholder={`Select ${label(
+            'archetype.singular',
+            'lower'
+          )} to add...`}
           options={SPECIES_OPTIONS}
           selected={formData.desirable.species}
           onAdd={value => addPreference('desirable', 'species', value)}
           onRemove={value => removePreference('desirable', 'species', value)}
         />
         <MultiSelectField
-          label="Perks"
-          placeholder="Select perk to add..."
+          label={label('trait.plural')}
+          placeholder={`Select ${label('trait.singular', 'lower')} to add...`}
           options={PERK_OPTIONS}
           selected={formData.desirable.perkIds}
           onAdd={value => addPreference('desirable', 'perkIds', value)}
           onRemove={value => removePreference('desirable', 'perkIds', value)}
         />
         <MultiSelectField
-          label="Distinctions"
-          placeholder="Select distinction to add..."
+          label={label('quality.plural')}
+          placeholder={`Select ${label('quality.singular', 'lower')} to add...`}
           options={DISTINCTION_OPTIONS}
           selected={formData.desirable.distinctionIds}
           onAdd={value => addPreference('desirable', 'distinctionIds', value)}
@@ -588,32 +596,38 @@ export const QuestFormScreen: React.FC = () => {
 
         <Text style={[styles.sublabel, styles.labelMargin]}>Undesirable</Text>
         <MultiSelectField
-          label="Tags"
-          placeholder="Select tag to add..."
+          label={label('traitCategory.plural')}
+          placeholder={`Select ${label(
+            'traitCategory.singular',
+            'lower'
+          )} to add...`}
           options={TAG_OPTIONS}
           selected={formData.undesirable.tags}
           onAdd={value => addPreference('undesirable', 'tags', value)}
           onRemove={value => removePreference('undesirable', 'tags', value)}
         />
         <MultiSelectField
-          label="Species"
-          placeholder="Select species to add..."
+          label={label('archetype.plural')}
+          placeholder={`Select ${label(
+            'archetype.singular',
+            'lower'
+          )} to add...`}
           options={SPECIES_OPTIONS}
           selected={formData.undesirable.species}
           onAdd={value => addPreference('undesirable', 'species', value)}
           onRemove={value => removePreference('undesirable', 'species', value)}
         />
         <MultiSelectField
-          label="Perks"
-          placeholder="Select perk to add..."
+          label={label('trait.plural')}
+          placeholder={`Select ${label('trait.singular', 'lower')} to add...`}
           options={PERK_OPTIONS}
           selected={formData.undesirable.perkIds}
           onAdd={value => addPreference('undesirable', 'perkIds', value)}
           onRemove={value => removePreference('undesirable', 'perkIds', value)}
         />
         <MultiSelectField
-          label="Distinctions"
-          placeholder="Select distinction to add..."
+          label={label('quality.plural')}
+          placeholder={`Select ${label('quality.singular', 'lower')} to add...`}
           options={DISTINCTION_OPTIONS}
           selected={formData.undesirable.distinctionIds}
           onAdd={value => addPreference('undesirable', 'distinctionIds', value)}
@@ -673,7 +687,9 @@ export const QuestFormScreen: React.FC = () => {
 
       {/* Junktown office */}
       <View style={styles.section}>
-        <Text style={styles.label}>Related Junktown Office</Text>
+        <Text style={styles.label}>
+          Related {label('questSponsor.singular')}
+        </Text>
         <TextInput
           style={styles.input}
           placeholder="Office name (optional)"

--- a/src/utils/characterStats.ts
+++ b/src/utils/characterStats.ts
@@ -1,5 +1,10 @@
 import { GameCharacter } from '../models/types';
 import { AVAILABLE_PERKS, AVAILABLE_DISTINCTIONS } from '../models/gameData';
+import {
+  getLabel,
+  afterworldsRuleset,
+  type RulesetDefinition,
+} from '../ruleset';
 
 export interface CharacterStats {
   totalCharacters: number;
@@ -10,8 +15,13 @@ export interface CharacterStats {
   factionStandings: Record<string, Record<string, number>>;
 }
 
+/**
+ * `ruleset` defaults to afterworldsRuleset so existing callers are
+ * unaffected; pass the active ruleset explicitly from a screen that has one.
+ */
 export const calculateCharacterStats = (
-  characters: GameCharacter[]
+  characters: GameCharacter[],
+  ruleset: RulesetDefinition = afterworldsRuleset
 ): CharacterStats => {
   if (!characters.length) {
     throw new Error('No characters available for statistics calculation');
@@ -61,7 +71,9 @@ export const calculateCharacterStats = (
 
   const commonPerks = Object.entries(perkCount)
     .map(([id, count]) => ({
-      name: AVAILABLE_PERKS.find(p => p.id === id)?.name || 'Unknown Perk',
+      name:
+        AVAILABLE_PERKS.find(p => p.id === id)?.name ||
+        `Unknown ${getLabel(ruleset, 'trait.singular')}`,
       count,
     }))
     .sort((a, b) => b.count - a.count)
@@ -80,7 +92,7 @@ export const calculateCharacterStats = (
     .map(([id, count]) => ({
       name:
         AVAILABLE_DISTINCTIONS.find(d => d.id === id)?.name ||
-        'Unknown Distinction',
+        `Unknown ${getLabel(ruleset, 'quality.singular')}`,
       count,
     }))
     .sort((a, b) => b.count - a.count)

--- a/src/utils/factionStats.ts
+++ b/src/utils/factionStats.ts
@@ -5,6 +5,11 @@ import {
   PerkTag,
 } from '../models/gameData';
 import { FactionRelationship } from './characterStorage';
+import {
+  getLabel,
+  afterworldsRuleset,
+  type RulesetDefinition,
+} from '../ruleset';
 
 export interface FactionStats {
   factionName: string;
@@ -42,12 +47,15 @@ export interface CombinedFactionAnalysis {
 }
 
 /**
- * Calculate statistics for a single faction based on its members
+ * Calculate statistics for a single faction based on its members.
+ * `ruleset` defaults to afterworldsRuleset so existing callers are
+ * unaffected; pass the active ruleset explicitly from a screen that has one.
  */
 export const calculateFactionStats = (
   factionName: string,
   allCharacters: GameCharacter[],
-  factionRelationships: FactionRelationship[] = []
+  factionRelationships: FactionRelationship[] = [],
+  ruleset: RulesetDefinition = afterworldsRuleset
 ): FactionStats => {
   // Get faction members (only positive relationships count as members)
   const members = allCharacters.filter(char => {
@@ -114,7 +122,9 @@ export const calculateFactionStats = (
 
   const commonPerks = Object.entries(perkCount)
     .map(([id, count]) => ({
-      name: AVAILABLE_PERKS.find(p => p.id === id)?.name || 'Unknown Perk',
+      name:
+        AVAILABLE_PERKS.find(p => p.id === id)?.name ||
+        `Unknown ${getLabel(ruleset, 'trait.singular')}`,
       count,
       percentage: (count / totalMembers) * 100,
     }))
@@ -134,7 +144,7 @@ export const calculateFactionStats = (
     .map(([id, count]) => ({
       name:
         AVAILABLE_DISTINCTIONS.find(d => d.id === id)?.name ||
-        'Unknown Distinction',
+        `Unknown ${getLabel(ruleset, 'quality.singular')}`,
       count,
       percentage: (count / totalMembers) * 100,
     }))
@@ -188,7 +198,8 @@ export const calculateFactionStats = (
 export const calculateCombinedFactionStats = (
   factionName: string,
   allCharacters: GameCharacter[],
-  allFactionRelationships: Map<string, FactionRelationship[]>
+  allFactionRelationships: Map<string, FactionRelationship[]>,
+  ruleset: RulesetDefinition = afterworldsRuleset
 ): CombinedFactionAnalysis => {
   // Get base stats for the main faction
   const mainFactionRelationships =
@@ -196,7 +207,8 @@ export const calculateCombinedFactionStats = (
   const baseStats = calculateFactionStats(
     factionName,
     allCharacters,
-    mainFactionRelationships
+    mainFactionRelationships,
+    ruleset
   );
 
   // Get allied factions
@@ -213,7 +225,8 @@ export const calculateCombinedFactionStats = (
     const allyStats = calculateFactionStats(
       allyName,
       allCharacters,
-      allyRelationships
+      allyRelationships,
+      ruleset
     );
     combinedMembers += allyStats.totalMembers;
 

--- a/tst/helpers/ruleset.tsx
+++ b/tst/helpers/ruleset.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, type RenderResult } from '@testing-library/react-native';
+import {
+  RulesetProvider,
+  afterworldsRuleset,
+  afterworldsAssets,
+  type RulesetDefinition,
+  type RulesetAssets,
+} from '@/ruleset';
+
+export const renderWithRuleset = (
+  ui: React.ReactElement,
+  overrides: {
+    ruleset?: RulesetDefinition;
+    assets?: RulesetAssets;
+  } = {}
+): RenderResult => {
+  const { ruleset = afterworldsRuleset, assets = afterworldsAssets } =
+    overrides;
+  return render(ui, {
+    wrapper: ({ children }) => (
+      <RulesetProvider ruleset={ruleset} assets={assets}>
+        {children}
+      </RulesetProvider>
+    ),
+  });
+};

--- a/tst/ruleset/assets.test.ts
+++ b/tst/ruleset/assets.test.ts
@@ -1,0 +1,15 @@
+import { resolveAsset, afterworldsAssets } from '@/ruleset/assets';
+
+describe('resolveAsset', () => {
+  it('resolves a known key', () => {
+    expect(resolveAsset(afterworldsAssets, 'map')).toBe(afterworldsAssets.map);
+  });
+
+  it('returns undefined for an unknown key', () => {
+    expect(resolveAsset(afterworldsAssets, 'nonexistent')).toBeUndefined();
+  });
+
+  it('returns undefined when no key is given', () => {
+    expect(resolveAsset(afterworldsAssets, undefined)).toBeUndefined();
+  });
+});

--- a/tst/ruleset/context.test.tsx
+++ b/tst/ruleset/context.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { Text } from 'react-native';
+import { RulesetProvider, useRuleset } from '@/ruleset/context';
+import { afterworldsRuleset } from '@/ruleset/defaultRuleset';
+import type { RulesetDefinition } from '@/ruleset/types';
+
+const Probe: React.FC = () => {
+  const { ruleset } = useRuleset();
+  return <Text>{ruleset.id}</Text>;
+};
+
+describe('useRuleset', () => {
+  it('falls back to the default ruleset outside a provider', () => {
+    render(<Probe />);
+    expect(screen.getByText('afterworlds')).toBeTruthy();
+  });
+
+  it('provides the ruleset passed to RulesetProvider', () => {
+    const custom: RulesetDefinition = {
+      ...afterworldsRuleset,
+      id: 'custom-ruleset',
+    };
+    render(
+      <RulesetProvider ruleset={custom}>
+        <Probe />
+      </RulesetProvider>
+    );
+    expect(screen.getByText('custom-ruleset')).toBeTruthy();
+  });
+
+  it('throws in dev when the provided ruleset is invalid', () => {
+    const invalid: RulesetDefinition = {
+      ...afterworldsRuleset,
+      id: '',
+    };
+    const previousDev = global.__DEV__;
+    global.__DEV__ = true;
+    // Silence the expected React error-boundary console noise for this case.
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    expect(() =>
+      render(
+        <RulesetProvider ruleset={invalid}>
+          <Probe />
+        </RulesetProvider>
+      )
+    ).toThrow(/Invalid ruleset/);
+    consoleError.mockRestore();
+    global.__DEV__ = previousDev;
+  });
+
+  it('logs and still renders when the provided ruleset is invalid outside dev', () => {
+    const invalid: RulesetDefinition = {
+      ...afterworldsRuleset,
+      id: '',
+    };
+    const previousDev = global.__DEV__;
+    global.__DEV__ = false;
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    render(
+      <RulesetProvider ruleset={invalid}>
+        <Probe />
+      </RulesetProvider>
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid ruleset')
+    );
+    consoleError.mockRestore();
+    global.__DEV__ = previousDev;
+  });
+});

--- a/tst/ruleset/defaultRuleset.test.ts
+++ b/tst/ruleset/defaultRuleset.test.ts
@@ -1,0 +1,73 @@
+import { afterworldsRuleset } from '@/ruleset/defaultRuleset';
+import { validateRuleset } from '@/ruleset/validate';
+import { SPECIES_BASE_STATS } from '@models/speciesTypes';
+import { AVAILABLE_PERKS, AVAILABLE_DISTINCTIONS } from '@models/gameData';
+
+describe('afterworldsRuleset', () => {
+  it('is valid', () => {
+    expect(validateRuleset(afterworldsRuleset)).toEqual({
+      valid: true,
+      issues: [],
+    });
+  });
+
+  it('is JSON-serializable', () => {
+    const roundTripped = JSON.parse(JSON.stringify(afterworldsRuleset));
+    expect(roundTripped).toEqual(afterworldsRuleset);
+  });
+
+  it('carries one archetype per species, in SPECIES_BASE_STATS order', () => {
+    expect(afterworldsRuleset.archetypes.map(a => a.id)).toEqual(
+      Object.keys(SPECIES_BASE_STATS)
+    );
+  });
+
+  it('carries every perk as a trait and every distinction as a quality', () => {
+    expect(afterworldsRuleset.traits).toHaveLength(AVAILABLE_PERKS.length);
+    expect(afterworldsRuleset.qualities).toHaveLength(
+      AVAILABLE_DISTINCTIONS.length
+    );
+  });
+
+  it('carries 12 trait categories and 36 category bonus rules', () => {
+    expect(afterworldsRuleset.traitCategories).toHaveLength(12);
+    expect(afterworldsRuleset.categoryBonuses).toHaveLength(36);
+  });
+
+  it.each([
+    ['Human', { health: 2, limit: 2 }, { health: 5, limit: 5 }],
+    ['Unturned', { health: 0, limit: 3 }, { health: 0, limit: 10 }],
+    ['Rad-Titan', { health: 3, limit: 0 }, { health: 10, limit: 0 }],
+    ['Mutoid', { health: 2, limit: 1 }, { health: 5, limit: 5 }],
+  ])('reproduces %s base values and caps exactly', (id, baseValues, caps) => {
+    const archetype = afterworldsRuleset.archetypes.find(a => a.id === id);
+    expect(archetype?.baseValues).toEqual(baseValues);
+    expect(archetype?.caps).toEqual(caps);
+  });
+
+  it('carries the Perfect Mutant carve-out as an archetype rule', () => {
+    expect(afterworldsRuleset.archetypeRules).toEqual([
+      {
+        archetypeId: 'Perfect Mutant',
+        kind: 'excludeCategoryScoreFromGroupRestrictedTraits',
+        groupId: 'mutant',
+      },
+    ]);
+  });
+
+  it('places Tech-Mutant in the organic, mutant, and android groups', () => {
+    const archetype = afterworldsRuleset.archetypes.find(
+      a => a.id === 'Tech-Mutant'
+    );
+    expect(archetype?.groups.sort()).toEqual(
+      ['organic', 'mutant', 'android'].sort()
+    );
+  });
+
+  it('places Unknown in no group', () => {
+    const archetype = afterworldsRuleset.archetypes.find(
+      a => a.id === 'Unknown'
+    );
+    expect(archetype?.groups).toEqual([]);
+  });
+});

--- a/tst/ruleset/terminology.test.tsx
+++ b/tst/ruleset/terminology.test.tsx
@@ -1,0 +1,61 @@
+import { renderHook } from '@testing-library/react-native';
+import React from 'react';
+import {
+  getLabel,
+  useLabels,
+  DEFAULT_TERMINOLOGY,
+} from '@/ruleset/terminology';
+import { RulesetProvider } from '@/ruleset/context';
+import { afterworldsRuleset } from '@/ruleset/defaultRuleset';
+import type { RulesetDefinition } from '@/ruleset/types';
+
+const rulesetWithoutOverrides: RulesetDefinition = {
+  ...afterworldsRuleset,
+  terminology: {},
+};
+
+describe('getLabel', () => {
+  it('falls back to the neutral default when a ruleset has no override', () => {
+    expect(getLabel(rulesetWithoutOverrides, 'trait.plural')).toBe('Traits');
+  });
+
+  it('uses the ruleset override when present', () => {
+    expect(getLabel(afterworldsRuleset, 'trait.plural')).toBe('Perks');
+    expect(getLabel(afterworldsRuleset, 'archetype.singular')).toBe('Species');
+    expect(getLabel(afterworldsRuleset, 'questSponsor.singular')).toBe(
+      'Junktown Office'
+    );
+  });
+
+  it('applies lower casing', () => {
+    expect(getLabel(afterworldsRuleset, 'trait.plural', 'lower')).toBe('perks');
+  });
+
+  it('applies title casing', () => {
+    expect(
+      getLabel(rulesetWithoutOverrides, 'traitCategory.plural', 'title')
+    ).toBe('Categories');
+  });
+
+  it('covers every declared term key with a neutral default', () => {
+    Object.values(DEFAULT_TERMINOLOGY).forEach(value => {
+      expect(typeof value).toBe('string');
+      expect(value.length).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe('useLabels', () => {
+  it('reads from the nearest RulesetProvider', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <RulesetProvider ruleset={afterworldsRuleset}>{children}</RulesetProvider>
+    );
+    const { result } = renderHook(() => useLabels(), { wrapper });
+    expect(result.current('trait.plural')).toBe('Perks');
+  });
+
+  it('falls back to the default ruleset outside a provider', () => {
+    const { result } = renderHook(() => useLabels());
+    expect(result.current('trait.plural')).toBe('Perks');
+  });
+});

--- a/tst/ruleset/validate.test.ts
+++ b/tst/ruleset/validate.test.ts
@@ -1,0 +1,355 @@
+import { validateRuleset } from '@/ruleset/validate';
+import { afterworldsRuleset } from '@/ruleset/defaultRuleset';
+import type { RulesetDefinition } from '@/ruleset/types';
+
+const baseRuleset = (): RulesetDefinition => ({
+  id: 'fixture',
+  name: 'Fixture Ruleset',
+  version: '1.0.0',
+  terminology: {},
+  resources: [
+    { id: 'health', label: 'Health', capped: true },
+    { id: 'stamina', label: 'Stamina', capped: false },
+  ],
+  groups: [{ id: 'organic', label: 'Organic' }],
+  capabilities: [{ id: 'flight', label: 'Can Fly' }],
+  archetypes: [
+    {
+      id: 'human',
+      label: 'Human',
+      groups: ['organic'],
+      baseValues: { health: 2, stamina: 1 },
+      caps: { health: 5 },
+      capabilities: { flight: false },
+    },
+  ],
+  traitCategories: [{ id: 'strength', label: 'Strength' }],
+  traits: [
+    {
+      id: 'trait_1',
+      name: 'Brawler',
+      description: '',
+      categoryId: 'strength',
+      allowedArchetypeIds: ['human'],
+      recipeIds: ['recipe_1'],
+      resourceModifiers: {
+        values: { health: 1 },
+        caps: { health: 1 },
+        categoryModifiers: { strength: 1 },
+      },
+    },
+  ],
+  qualities: [
+    {
+      id: 'quality_1',
+      name: 'Stoic',
+      description: '',
+      allowedArchetypeIds: ['human'],
+    },
+  ],
+  recipes: [
+    {
+      id: 'recipe_1',
+      name: 'Bandage',
+      description: '',
+      materials: ['Cloth'],
+    },
+  ],
+  categoryBonuses: [
+    { categoryId: 'strength', requiredScore: 3, grants: { health: 1 } },
+  ],
+  archetypeRules: [
+    {
+      archetypeId: 'human',
+      kind: 'excludeCategoryScoreFromGroupRestrictedTraits',
+      groupId: 'organic',
+    },
+  ],
+  features: {
+    quests: true,
+    recipes: true,
+    discord: true,
+    map: true,
+    gitSync: true,
+    modifications: true,
+    influenceReport: true,
+    relationshipGraph: true,
+  },
+  limits: { maxQualities: 3 },
+  map: { imageKey: 'map', label: 'Map' },
+  branding: { appName: 'Fixture App' },
+});
+
+describe('validateRuleset', () => {
+  it('accepts a well-formed fixture ruleset', () => {
+    const result = validateRuleset(baseRuleset());
+    expect(result).toEqual({ valid: true, issues: [] });
+  });
+
+  it('accepts the real afterworlds ruleset', () => {
+    const result = validateRuleset(afterworldsRuleset);
+    expect(result.issues).toEqual([]);
+    expect(result.valid).toBe(true);
+  });
+
+  it('requires non-empty id/name/version', () => {
+    const ruleset = { ...baseRuleset(), id: '', name: '', version: '' };
+    const result = validateRuleset(ruleset);
+    expect(result.valid).toBe(false);
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        { path: 'id', message: expect.any(String) },
+        { path: 'name', message: expect.any(String) },
+        { path: 'version', message: expect.any(String) },
+      ])
+    );
+  });
+
+  it('flags duplicate ids within a collection', () => {
+    const ruleset = baseRuleset();
+    ruleset.traitCategories = [
+      ...ruleset.traitCategories,
+      { id: 'strength', label: 'Strength Again' },
+    ];
+    const result = validateRuleset(ruleset);
+    expect(result.valid).toBe(false);
+    expect(result.issues).toContainEqual({
+      path: 'traitCategories[1].id',
+      message: "Duplicate id 'strength' in traitCategories",
+    });
+  });
+
+  it('flags a trait with an unresolvable categoryId', () => {
+    const ruleset = baseRuleset();
+    ruleset.traits[0].categoryId = 'nonexistent';
+    const result = validateRuleset(ruleset);
+    expect(result.issues).toContainEqual({
+      path: 'traits[0].categoryId',
+      message: "Unknown traitCategory id 'nonexistent'",
+    });
+  });
+
+  it('flags a trait/quality with an unresolvable allowedArchetypeId', () => {
+    const ruleset = baseRuleset();
+    ruleset.traits[0].allowedArchetypeIds = ['nonexistent'];
+    ruleset.qualities[0].allowedArchetypeIds = ['nonexistent'];
+    const result = validateRuleset(ruleset);
+    expect(result.issues).toContainEqual({
+      path: 'traits[0].allowedArchetypeIds[0]',
+      message: "Unknown archetype id 'nonexistent'",
+    });
+    expect(result.issues).toContainEqual({
+      path: 'qualities[0].allowedArchetypeIds[0]',
+      message: "Unknown archetype id 'nonexistent'",
+    });
+  });
+
+  it('flags a trait with an unresolvable recipeId', () => {
+    const ruleset = baseRuleset();
+    ruleset.traits[0].recipeIds = ['nonexistent'];
+    const result = validateRuleset(ruleset);
+    expect(result.issues).toContainEqual({
+      path: 'traits[0].recipeIds[0]',
+      message: "Unknown recipe id 'nonexistent'",
+    });
+  });
+
+  it('flags resourceModifiers keys that resolve to nothing', () => {
+    const ruleset = baseRuleset();
+    ruleset.traits[0].resourceModifiers = {
+      values: { nonexistent: 1 },
+      caps: { nonexistent: 1 },
+      categoryModifiers: { nonexistent: 1 },
+    };
+    const result = validateRuleset(ruleset);
+    expect(result.issues).toContainEqual({
+      path: 'traits[0].resourceModifiers.values.nonexistent',
+      message: "Unknown resource id 'nonexistent'",
+    });
+    expect(result.issues).toContainEqual({
+      path: 'traits[0].resourceModifiers.caps.nonexistent',
+      message: "Unknown resource id 'nonexistent'",
+    });
+    expect(result.issues).toContainEqual({
+      path: 'traits[0].resourceModifiers.categoryModifiers.nonexistent',
+      message: "Unknown traitCategory id 'nonexistent'",
+    });
+  });
+
+  it('flags an archetype group that does not resolve', () => {
+    const ruleset = baseRuleset();
+    ruleset.archetypes[0].groups = ['nonexistent'];
+    const result = validateRuleset(ruleset);
+    expect(result.issues).toContainEqual({
+      path: 'archetypes[0].groups[0]',
+      message: "Unknown group id 'nonexistent'",
+    });
+  });
+
+  it('flags a missing base value for a declared resource', () => {
+    const ruleset = baseRuleset();
+    delete ruleset.archetypes[0].baseValues.stamina;
+    const result = validateRuleset(ruleset);
+    expect(result.issues).toContainEqual({
+      path: 'archetypes[0].baseValues.stamina',
+      message: "Missing base value for resource 'stamina'",
+    });
+  });
+
+  it('flags an unknown base value key', () => {
+    const ruleset = baseRuleset();
+    ruleset.archetypes[0].baseValues = {
+      ...ruleset.archetypes[0].baseValues,
+      nonexistent: 1,
+    };
+    const result = validateRuleset(ruleset);
+    expect(result.issues).toContainEqual({
+      path: 'archetypes[0].baseValues.nonexistent',
+      message: "Unknown resource id 'nonexistent'",
+    });
+  });
+
+  it('flags a missing cap for a capped resource', () => {
+    const ruleset = baseRuleset();
+    delete ruleset.archetypes[0].caps.health;
+    const result = validateRuleset(ruleset);
+    expect(result.issues).toContainEqual({
+      path: 'archetypes[0].caps.health',
+      message: "Missing cap for capped resource 'health'",
+    });
+  });
+
+  it('flags a cap entry for a resource that is not capped', () => {
+    const ruleset = baseRuleset();
+    ruleset.archetypes[0].caps = {
+      ...ruleset.archetypes[0].caps,
+      stamina: 5,
+    };
+    const result = validateRuleset(ruleset);
+    expect(result.issues).toContainEqual({
+      path: 'archetypes[0].caps.stamina',
+      message: "Resource 'stamina' is not capped; unexpected cap entry",
+    });
+  });
+
+  it('flags a missing declared capability on an archetype', () => {
+    const ruleset = baseRuleset();
+    ruleset.archetypes[0].capabilities = {};
+    const result = validateRuleset(ruleset);
+    expect(result.issues).toContainEqual({
+      path: 'archetypes[0].capabilities.flight',
+      message: "Missing capability 'flight'",
+    });
+  });
+
+  it('flags an undeclared capability on an archetype', () => {
+    const ruleset = baseRuleset();
+    ruleset.archetypes[0].capabilities = {
+      flight: false,
+      nonexistent: true,
+    };
+    const result = validateRuleset(ruleset);
+    expect(result.issues).toContainEqual({
+      path: 'archetypes[0].capabilities.nonexistent',
+      message: "Unknown capability id 'nonexistent'",
+    });
+  });
+
+  it('flags a category bonus with an unresolvable categoryId', () => {
+    const ruleset = baseRuleset();
+    ruleset.categoryBonuses[0].categoryId = 'nonexistent';
+    const result = validateRuleset(ruleset);
+    expect(result.issues).toContainEqual({
+      path: 'categoryBonuses[0].categoryId',
+      message: "Unknown traitCategory id 'nonexistent'",
+    });
+  });
+
+  it('flags a non-positive-integer requiredScore', () => {
+    const ruleset = baseRuleset();
+    ruleset.categoryBonuses[0].requiredScore = 0;
+    const result = validateRuleset(ruleset);
+    expect(result.issues).toContainEqual({
+      path: 'categoryBonuses[0].requiredScore',
+      message: 'requiredScore must be a positive integer',
+    });
+  });
+
+  it('flags a category bonus grant key that does not resolve', () => {
+    const ruleset = baseRuleset();
+    ruleset.categoryBonuses[0].grants = { nonexistent: 1 };
+    const result = validateRuleset(ruleset);
+    expect(result.issues).toContainEqual({
+      path: 'categoryBonuses[0].grants.nonexistent',
+      message: "Unknown resource id 'nonexistent'",
+    });
+  });
+
+  it('flags an archetypeRule with unresolvable ids', () => {
+    const ruleset = baseRuleset();
+    ruleset.archetypeRules = [
+      {
+        archetypeId: 'nonexistent',
+        kind: 'excludeCategoryScoreFromGroupRestrictedTraits',
+        groupId: 'nonexistent',
+      },
+    ];
+    const result = validateRuleset(ruleset);
+    expect(result.issues).toContainEqual({
+      path: 'archetypeRules[0].archetypeId',
+      message: "Unknown archetype id 'nonexistent'",
+    });
+    expect(result.issues).toContainEqual({
+      path: 'archetypeRules[0].groupId',
+      message: "Unknown group id 'nonexistent'",
+    });
+  });
+
+  it('flags an empty map.imageKey when map is present', () => {
+    const ruleset = baseRuleset();
+    ruleset.map = { imageKey: '', label: 'Map' };
+    const result = validateRuleset(ruleset);
+    expect(result.issues).toContainEqual({
+      path: 'map.imageKey',
+      message: 'imageKey must be non-empty when map is present',
+    });
+  });
+
+  it('flags empty branding asset keys when present', () => {
+    const ruleset = baseRuleset();
+    ruleset.branding = { appName: 'Fixture', iconKey: '', splashKey: '' };
+    const result = validateRuleset(ruleset);
+    expect(result.issues).toContainEqual({
+      path: 'branding.iconKey',
+      message: 'iconKey must be non-empty when present',
+    });
+    expect(result.issues).toContainEqual({
+      path: 'branding.splashKey',
+      message: 'splashKey must be non-empty when present',
+    });
+  });
+
+  it('flags a non-serializable value anywhere in the ruleset', () => {
+    const ruleset = baseRuleset() as unknown as Record<string, unknown>;
+    (ruleset.branding as Record<string, unknown>).onSave = () => undefined;
+    const result = validateRuleset(ruleset as unknown as RulesetDefinition);
+    expect(result.issues).toContainEqual({
+      path: 'branding.onSave',
+      message: expect.stringContaining('JSON-serializable'),
+    });
+  });
+
+  it('flags a class instance embedded in the ruleset as non-serializable', () => {
+    class Weird {
+      value = 1;
+    }
+    const ruleset = baseRuleset() as unknown as Record<string, unknown>;
+    (ruleset.archetypes as Array<Record<string, unknown>>)[0].weird =
+      new Weird();
+    const result = validateRuleset(ruleset as unknown as RulesetDefinition);
+    expect(result.issues).toContainEqual({
+      path: 'archetypes[0].weird',
+      message: expect.stringContaining('JSON-serializable'),
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements Phase 0 of the Generalize JunktownIntelligence → Lore effort (mccarjac/Lore#19):

- **mccarjac/Lore#1 (Phase 0.1)** — a new `src/ruleset/` directory: a typed `RulesetDefinition` schema, `RulesetProvider`/`useRuleset()`, a startup validator, and `defaultRuleset.ts` — a **derived transform** over today's Afterworlds data (`gameData.ts`, `speciesTypes.ts`), not a hand-copied literal, so it can't drift as later phases rename fields. `RulesetDefinition` is kept strictly JSON-serializable (no functions, no `require()`d assets) so the backlogged in-app ruleset editor (mccarjac/Lore#18) stays possible; bundled images are resolved separately through `RulesetAssets`.
- **mccarjac/Lore#2 (Phase 0.2)** — `src/ruleset/terminology.ts` (`useLabels()` for components, `getLabel()` for non-component code) with neutral defaults, overridden back to today's wording (Species/Perk/Tag/Distinction/Cyberware/Junktown Office) by the Afterworlds ruleset. Swept every hardcoded domain-noun call site across `CharacterDetailScreen`, `CharacterFormScreen`, `CharacterSearchScreen`, `CharacterStatsScreen`, `FactionStatsScreen` (including its two `InfoButton` explanatory paragraphs), `QuestFormScreen`, `QuestDetailScreen`, `factionStats.ts`, and `characterStats.ts`.

Both issues are additive and behavior-preserving: no model fields renamed, no storage format changes. `useRuleset()` falls back to the default Afterworlds ruleset outside a `RulesetProvider` (rather than throwing) specifically so the ~31 existing screen tests that render bare keep working unchanged.

Note: since these issues are filed on `mccarjac/Lore` but this repo is `mccarjac/JunktownIntelligence` (per mccarjac/Lore#19's "Phases 0-3 are coded in the JunktownIntelligence working tree"), GitHub's cross-repo `Closes` syntax won't auto-close them — closing mccarjac/Lore#1 and mccarjac/Lore#2 will need to happen manually once this merges.

## Test plan

- [x] `npm run check-all` green (type-check + lint + format:check + full test suite)
- [x] All 666 pre-existing tests pass unmodified
- [x] 49 new tests added: `validateRuleset`'s 14 checks (one failing fixture + assertion per check), `defaultRuleset` transform fidelity (archetype/trait/quality/category counts, per-archetype base values and caps, group membership, the Perfect Mutant carve-out), terminology defaults/overrides/casing, and `RulesetProvider`/`useRuleset()` fallback + validation-failure behavior
- [x] `src/ruleset/**` added to `jest.config.js`'s `collectCoverageFrom` (previously invisible to the coverage report)
- [ ] Manual visual check of the Afterworlds ruleset rendering pixel-identically — attempted via a headless browser but blocked by a pre-existing (not introduced by this PR) `expo start --web` runtime error in this environment; verified instead by confirming every touched screen's existing test suite passes unchanged and by reviewing each edited string against its literal replacement

---
_Generated by [Claude Code](https://claude.ai/code/session_01YANoT8abCPKfBLKSPZz1z9)_