### PR TITLE
Rework relationship graph layout: d3-force, standing-aware spacing, configurable in-app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,12 +137,16 @@ Path aliases (tsconfig + babel-plugin-module-resolver): `@/*` → `src/*`, plus
   order plus a seeded PRNG passed to each force's `initialize`. Edge rest
   distances are standing-aware (`standingDistanceFactor`: Ally/Friend
   shorter, Hostile/Enemy longer; the worse side of a disputed relationship
-  wins). User-tunable spacing lives in `src/utils/graphPreferences.ts`
-  (key `gameCharacterManager_graph_prefs`), edited via sliders in
-  `GraphSettingsPanel` (`@react-native-community/slider`); the screen lays
-  out on a virtual canvas up to 3x the viewport that `GraphCanvas` pans and
-  zooms (`contentSize` vs `containerSize` — content must stay centered for
-  `clampTranslation`'s symmetric bounds to hold). The d3 packages and
+  wins). The layout is an infinite canvas: positions are never clamped —
+  `computeGraphLayout` returns `{ nodes, size }` where `size` is the natural
+  content extent, and `GraphCanvas` pans/zooms it (`contentSize` vs
+  `containerSize` — content must stay centered for `clampTranslation`'s
+  symmetric bounds to hold). Tapping a node navigates straight to its detail
+  screen; long-press opens the info card (Focus / View details).
+  User-tunable spacing plus the persisted Retired / Hide-isolated filter
+  toggles live in `src/utils/graphPreferences.ts` (key
+  `gameCharacterManager_graph_prefs`); sliders in `GraphSettingsPanel`
+  (`@react-native-community/slider`). The d3 packages and
   `@react-native-community` are allow-listed in `jest.config.js`'s
   `transformIgnorePatterns` (ESM-only, like `uuid`).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,12 @@ Path aliases (tsconfig + babel-plugin-module-resolver): `@/*` → `src/*`, plus
   content extent, and `GraphCanvas` pans/zooms it (`contentSize` vs
   `containerSize` — content must stay centered for `clampTranslation`'s
   symmetric bounds to hold). Tapping a node navigates straight to its detail
-  screen; long-press opens the info card (Focus / View details).
+  screen; long-press opens the info card (Focus / View details). Node taps
+  are detected by canvas-level RNGH Tap/LongPress gestures that invert the
+  pan/zoom transform (`containerPointToNormalized`) and hit-test node
+  centers — SVG-element `onPress` does not fire reliably on-device inside a
+  `GestureDetector`; the marker handlers remain only as a deduplicated
+  fallback (and for tests/accessibility).
   User-tunable spacing plus the persisted Retired / Hide-isolated filter
   toggles live in `src/utils/graphPreferences.ts` (key
   `gameCharacterManager_graph_prefs`); sliders in `GraphSettingsPanel`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,22 @@ Path aliases (tsconfig + babel-plugin-module-resolver): `@/*` → `src/*`, plus
   only backfills factions that had a non-empty embedded description. This
   screen is the first direct `react-native-svg` consumer in `src/`; it
   renders under Jest without any mock (`Circle`/`G` support `onPress` and
-  `accessibilityLabel` directly).
+  `accessibilityLabel` directly). Layout (`computeGraphLayout`) runs d3-force
+  forces through a manual synchronous tick loop — deliberately NOT
+  `forceSimulation()`, whose constructor auto-starts an async d3-timer
+  stepper that leaks a frame callback into Jest teardown. Determinism is a
+  documented, tested contract: circle-seeded positions in stable (type, id)
+  order plus a seeded PRNG passed to each force's `initialize`. Edge rest
+  distances are standing-aware (`standingDistanceFactor`: Ally/Friend
+  shorter, Hostile/Enemy longer; the worse side of a disputed relationship
+  wins). User-tunable spacing lives in `src/utils/graphPreferences.ts`
+  (key `gameCharacterManager_graph_prefs`), edited via sliders in
+  `GraphSettingsPanel` (`@react-native-community/slider`); the screen lays
+  out on a virtual canvas up to 3x the viewport that `GraphCanvas` pans and
+  zooms (`contentSize` vs `containerSize` — content must stay centered for
+  `clampTranslation`'s symmetric bounds to hold). The d3 packages and
+  `@react-native-community` are allow-listed in `jest.config.js`'s
+  `transformIgnorePatterns` (ESM-only, like `uuid`).
 
 ## Testing
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,8 +8,12 @@ module.exports = {
   // gitIntegration.ts that were previously excluded from the report.
   // `uuid` ships ESM-only and must be transformed so test files can automock
   // modules that import it (e.g. `jest.mock('@utils/characterStorage')`).
+  // `d3-force` and its transitive deps (`d3-quadtree`, `d3-dispatch`,
+  // `d3-timer`) are ESM-only too. `@react-native-community` needs its own
+  // entry: the `@react-native` alternative requires a `/` right after it, so
+  // it does not match `@react-native-community/slider`.
   transformIgnorePatterns: [
-    'node_modules/(?!(react-native|@react-native|@react-navigation|expo|expo-.*|@expo|@unimodules|@octokit|react-native-.*|uuid)/)',
+    'node_modules/(?!(react-native|@react-native|@react-native-community|@react-navigation|expo|expo-.*|@expo|@unimodules|@octokit|react-native-.*|uuid|d3-force|d3-quadtree|d3-dispatch|d3-timer)/)',
   ],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   moduleNameMapper: {

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -114,6 +114,7 @@ jest.mock('react-native-gesture-handler', () => {
       Tap: jest.fn(createGestureStub),
       LongPress: jest.fn(createGestureStub),
       Simultaneous: jest.fn((...gestures) => gestures),
+      Exclusive: jest.fn((...gestures) => gestures),
     },
     TouchableOpacity: 'TouchableOpacity',
     ScrollView: 'ScrollView',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@octokit/rest": "^22.0.1",
         "@react-native-async-storage/async-storage": "^2.2.0",
+        "@react-native-community/slider": "^5.0.1",
         "@react-native-picker/picker": "^2.11.4",
         "@react-navigation/bottom-tabs": "^7.6.0",
         "@react-navigation/drawer": "^7.7.0",
@@ -18,6 +19,7 @@
         "@react-navigation/stack": "^7.4.10",
         "babel-preset-expo": "^54.0.6",
         "buffer": "^6.0.3",
+        "d3-force": "^3.0.0",
         "expo": "54.0.23",
         "expo-dev-client": "~6.0.16",
         "expo-document-picker": "^14.0.7",
@@ -52,6 +54,7 @@
         "@eslint/js": "^9.38.0",
         "@testing-library/jest-native": "^5.4.3",
         "@testing-library/react-native": "^13.3.3",
+        "@types/d3-force": "^3.0.10",
         "@types/jest": "^30.0.0",
         "@types/node": "^24.10.0",
         "@types/react": "~19.1.0",
@@ -4554,6 +4557,12 @@
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
+    "node_modules/@react-native-community/slider": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-5.0.1.tgz",
+      "integrity": "sha512-K3JRWkIW4wQ79YJ6+BPZzp1SamoikxfPRw7Yw4B4PElEQmqZFrmH9M5LxvIo460/3QSrZF/wCgi3qizJt7g/iw==",
+      "license": "MIT"
+    },
     "node_modules/@react-native-picker/picker": {
       "version": "2.11.4",
       "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.11.4.tgz",
@@ -5190,6 +5199,13 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -7404,6 +7420,47 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-urls": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@octokit/rest": "^22.0.1",
     "@react-native-async-storage/async-storage": "^2.2.0",
+    "@react-native-community/slider": "^5.0.1",
     "@react-native-picker/picker": "^2.11.4",
     "@react-navigation/bottom-tabs": "^7.6.0",
     "@react-navigation/drawer": "^7.7.0",
@@ -34,6 +35,7 @@
     "@react-navigation/stack": "^7.4.10",
     "babel-preset-expo": "^54.0.6",
     "buffer": "^6.0.3",
+    "d3-force": "^3.0.0",
     "expo": "54.0.23",
     "expo-dev-client": "~6.0.16",
     "expo-document-picker": "^14.0.7",
@@ -68,6 +70,7 @@
     "@eslint/js": "^9.38.0",
     "@testing-library/jest-native": "^5.4.3",
     "@testing-library/react-native": "^13.3.3",
+    "@types/d3-force": "^3.0.10",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.10.0",
     "@types/react": "~19.1.0",

--- a/src/components/graph/GraphCanvas.tsx
+++ b/src/components/graph/GraphCanvas.tsx
@@ -13,15 +13,24 @@ import { standingEdgeColor } from './graphColors';
 import { GraphNodeMarker } from './GraphNodeMarker';
 
 interface GraphCanvasProps {
-  size: Size;
+  /** Visible viewport size. */
+  containerSize: Size;
+  /**
+   * Size of the layout canvas the nodes were positioned on. May be larger
+   * than `containerSize` (spread-out layouts); pan/zoom navigates it.
+   */
+  contentSize: Size;
   nodes: PositionedNode[];
   edges: GraphEdge[];
   selectedNodeId: string | null;
   onSelectNode: (node: PositionedNode) => void;
 }
 
+const MAX_SCALE = 3;
+
 export const GraphCanvas: React.FC<GraphCanvasProps> = ({
-  size,
+  containerSize,
+  contentSize,
   nodes,
   edges,
   selectedNodeId,
@@ -34,6 +43,17 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({
   const savedTranslateX = useSharedValue(0);
   const savedTranslateY = useSharedValue(0);
 
+  // Zooming out to minScale fits the whole (possibly oversized) content in
+  // the viewport; never above 1 so a small graph isn't blown up.
+  const minScale =
+    contentSize.width > 0 && contentSize.height > 0
+      ? Math.min(
+          1,
+          containerSize.width / contentSize.width,
+          containerSize.height / contentSize.height
+        )
+      : 1;
+
   const pinchGesture = Gesture.Pinch()
     .onUpdate(e => {
       scale.value = savedScale.value * e.scale;
@@ -41,25 +61,25 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({
         translateX.value,
         translateY.value,
         scale.value,
-        size,
-        size
+        contentSize,
+        containerSize
       );
       translateX.value = clamped.x;
       translateY.value = clamped.y;
     })
     .onEnd(() => {
       let targetScale = scale.value;
-      if (targetScale < 1) {
-        targetScale = 1;
-      } else if (targetScale > 3) {
-        targetScale = 3;
+      if (targetScale < minScale) {
+        targetScale = minScale;
+      } else if (targetScale > MAX_SCALE) {
+        targetScale = MAX_SCALE;
       }
       const clamped = clampTranslation(
         translateX.value,
         translateY.value,
         targetScale,
-        size,
-        size
+        contentSize,
+        containerSize
       );
       scale.value = withTiming(targetScale);
       translateX.value = withTiming(clamped.x);
@@ -75,8 +95,8 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({
         savedTranslateX.value + e.translationX,
         savedTranslateY.value + e.translationY,
         scale.value,
-        size,
-        size
+        contentSize,
+        containerSize
       );
       translateX.value = clamped.x;
       translateY.value = clamped.y;
@@ -89,9 +109,10 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({
   const doubleTap = Gesture.Tap()
     .numberOfTaps(2)
     .onEnd(() => {
-      if (scale.value > 1) {
-        scale.value = withTiming(1);
-        savedScale.value = 1;
+      if (scale.value > minScale) {
+        // Zoom out to fit the whole graph.
+        scale.value = withTiming(minScale);
+        savedScale.value = minScale;
         translateX.value = withTiming(0);
         translateY.value = withTiming(0);
         savedTranslateX.value = 0;
@@ -102,8 +123,8 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({
           translateX.value,
           translateY.value,
           targetScale,
-          size,
-          size
+          contentSize,
+          containerSize
         );
         scale.value = withTiming(targetScale);
         savedScale.value = targetScale;
@@ -134,9 +155,12 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({
         accessibilityLabel="Relationship graph canvas"
       >
         <Animated.View
-          style={[{ width: size.width, height: size.height }, animatedStyle]}
+          style={[
+            { width: contentSize.width, height: contentSize.height },
+            animatedStyle,
+          ]}
         >
-          <Svg width={size.width} height={size.height}>
+          <Svg width={contentSize.width} height={contentSize.height}>
             {edges.map(edge => {
               const source = nodes.find(n => n.id === edge.sourceId);
               const target = nodes.find(n => n.id === edge.targetId);
@@ -175,5 +199,10 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     overflow: 'hidden',
+    // clampTranslation's symmetric bounds assume the content is centered in
+    // the viewport (same pattern as LocationMapScreen's imageContainer);
+    // without this an oversized canvas anchors top-left and pans wrong.
+    justifyContent: 'center',
+    alignItems: 'center',
   },
 });

--- a/src/components/graph/GraphCanvas.tsx
+++ b/src/components/graph/GraphCanvas.tsx
@@ -1,13 +1,19 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { StyleSheet } from 'react-native';
 import { GestureDetector, Gesture } from 'react-native-gesture-handler';
 import Animated, {
+  runOnJS,
   useSharedValue,
   useAnimatedStyle,
   withTiming,
 } from 'react-native-reanimated';
 import Svg, { Line } from 'react-native-svg';
-import { clampTranslation, Size } from '@utils/mapCoordinates';
+import {
+  clampTranslation,
+  containerPointToNormalized,
+  normalizedToImagePoint,
+  Size,
+} from '@utils/mapCoordinates';
 import type { GraphEdge, PositionedNode } from '@utils/relationshipGraph';
 import { standingEdgeColor } from './graphColors';
 import { GraphNodeMarker } from './GraphNodeMarker';
@@ -30,6 +36,21 @@ interface GraphCanvasProps {
 }
 
 const MAX_SCALE = 3;
+/** How close (in content px) a tap must land to a node's center to hit it. */
+const NODE_HIT_RADIUS = 30;
+/**
+ * Node presses are detected twice: canvas-level gestures (below) and the
+ * SVG markers' own onPress/onLongPress. The SVG path doesn't fire reliably
+ * on-device inside a GestureDetector (notably Android / New Architecture),
+ * so the gestures are the primary mechanism — but where both DO fire, this
+ * window swallows the duplicate.
+ */
+const DUPLICATE_PRESS_WINDOW_MS = 600;
+
+interface LastPress {
+  id: string;
+  time: number;
+}
 
 export const GraphCanvas: React.FC<GraphCanvasProps> = ({
   containerSize,
@@ -47,6 +68,9 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({
   const savedTranslateX = useSharedValue(0);
   const savedTranslateY = useSharedValue(0);
 
+  const lastPress = useRef<LastPress>({ id: '', time: 0 });
+  const lastLongPress = useRef<LastPress>({ id: '', time: 0 });
+
   // Zooming out to minScale fits the whole (possibly oversized) content in
   // the viewport; never above 1 so a small graph isn't blown up.
   const minScale =
@@ -57,6 +81,109 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({
           containerSize.height / contentSize.height
         )
       : 1;
+
+  const shouldHandle = (
+    ref: React.MutableRefObject<LastPress>,
+    node: PositionedNode
+  ): boolean => {
+    const now = Date.now();
+    if (
+      ref.current.id === node.id &&
+      now - ref.current.time < DUPLICATE_PRESS_WINDOW_MS
+    ) {
+      return false;
+    }
+    ref.current = { id: node.id, time: now };
+    return true;
+  };
+
+  const handleMarkerPress = (node: PositionedNode) => {
+    if (shouldHandle(lastPress, node)) {
+      onPressNode(node);
+    }
+  };
+
+  const handleMarkerLongPress = (node: PositionedNode) => {
+    if (shouldHandle(lastLongPress, node)) {
+      onLongPressNode(node);
+    }
+  };
+
+  /**
+   * Maps a touch point in container coordinates to content coordinates
+   * (inverting the centered pan/zoom transform) and returns the node whose
+   * center is nearest, if within NODE_HIT_RADIUS.
+   */
+  const nodeAtContainerPoint = (
+    x: number,
+    y: number,
+    currentScale: number,
+    currentTranslateX: number,
+    currentTranslateY: number
+  ): PositionedNode | null => {
+    const normalized = containerPointToNormalized(
+      { x, y },
+      containerSize,
+      contentSize,
+      {
+        scale: currentScale,
+        translateX: currentTranslateX,
+        translateY: currentTranslateY,
+      }
+    );
+    if (!normalized) {
+      return null;
+    }
+    const point = normalizedToImagePoint(normalized, contentSize);
+    let nearest: PositionedNode | null = null;
+    let nearestDist = Infinity;
+    nodes.forEach(node => {
+      const dist = Math.hypot(node.x - point.x, node.y - point.y);
+      if (dist < nearestDist) {
+        nearest = node;
+        nearestDist = dist;
+      }
+    });
+    return nearest && nearestDist <= NODE_HIT_RADIUS ? nearest : null;
+  };
+
+  const handleCanvasTap = (
+    x: number,
+    y: number,
+    currentScale: number,
+    currentTranslateX: number,
+    currentTranslateY: number
+  ) => {
+    const node = nodeAtContainerPoint(
+      x,
+      y,
+      currentScale,
+      currentTranslateX,
+      currentTranslateY
+    );
+    if (node) {
+      handleMarkerPress(node);
+    }
+  };
+
+  const handleCanvasLongPress = (
+    x: number,
+    y: number,
+    currentScale: number,
+    currentTranslateX: number,
+    currentTranslateY: number
+  ) => {
+    const node = nodeAtContainerPoint(
+      x,
+      y,
+      currentScale,
+      currentTranslateX,
+      currentTranslateY
+    );
+    if (node) {
+      handleMarkerLongPress(node);
+    }
+  };
 
   const pinchGesture = Gesture.Pinch()
     .onUpdate(e => {
@@ -139,8 +266,38 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({
       }
     });
 
+  const singleTap = Gesture.Tap()
+    .numberOfTaps(1)
+    .onEnd((e, success) => {
+      if (!success) {
+        return;
+      }
+      runOnJS(handleCanvasTap)(
+        e.x,
+        e.y,
+        scale.value,
+        translateX.value,
+        translateY.value
+      );
+    });
+
+  const longPressGesture = Gesture.LongPress()
+    .minDuration(400)
+    .onStart(e => {
+      runOnJS(handleCanvasLongPress)(
+        e.x,
+        e.y,
+        scale.value,
+        translateX.value,
+        translateY.value
+      );
+    });
+
   const composedGesture = Gesture.Simultaneous(
-    doubleTap,
+    // Single tap must wait for double-tap to fail, or it fires on the first
+    // tap of a double-tap zoom.
+    Gesture.Exclusive(doubleTap, singleTap),
+    longPressGesture,
     Gesture.Simultaneous(pinchGesture, panGesture)
   );
 
@@ -189,8 +346,8 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({
                 key={node.id}
                 node={node}
                 selected={node.id === selectedNodeId}
-                onPress={onPressNode}
-                onLongPress={onLongPressNode}
+                onPress={handleMarkerPress}
+                onLongPress={handleMarkerLongPress}
               />
             ))}
           </Svg>

--- a/src/components/graph/GraphCanvas.tsx
+++ b/src/components/graph/GraphCanvas.tsx
@@ -23,7 +23,10 @@ interface GraphCanvasProps {
   nodes: PositionedNode[];
   edges: GraphEdge[];
   selectedNodeId: string | null;
-  onSelectNode: (node: PositionedNode) => void;
+  /** Tap on a node: navigate straight to its detail screen. */
+  onPressNode: (node: PositionedNode) => void;
+  /** Long-press on a node: open the info card (focus / details). */
+  onLongPressNode: (node: PositionedNode) => void;
 }
 
 const MAX_SCALE = 3;
@@ -34,7 +37,8 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({
   nodes,
   edges,
   selectedNodeId,
-  onSelectNode,
+  onPressNode,
+  onLongPressNode,
 }) => {
   const scale = useSharedValue(1);
   const savedScale = useSharedValue(1);
@@ -185,7 +189,8 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({
                 key={node.id}
                 node={node}
                 selected={node.id === selectedNodeId}
-                onPress={onSelectNode}
+                onPress={onPressNode}
+                onLongPress={onLongPressNode}
               />
             ))}
           </Svg>

--- a/src/components/graph/GraphNodeMarker.tsx
+++ b/src/components/graph/GraphNodeMarker.tsx
@@ -15,19 +15,24 @@ const truncateLabel = (label: string): string =>
 interface GraphNodeMarkerProps {
   node: PositionedNode;
   selected: boolean;
+  /** Tap: navigate straight to the entity's detail screen. */
   onPress: (node: PositionedNode) => void;
+  /** Long-press: open the info card (focus / details). */
+  onLongPress: (node: PositionedNode) => void;
 }
 
 export const GraphNodeMarker: React.FC<GraphNodeMarkerProps> = ({
   node,
   selected,
   onPress,
+  onLongPress,
 }) => {
   const fill = nodeTypeColor(node.type);
 
   return (
     <G
       onPress={() => onPress(node)}
+      onLongPress={() => onLongPress(node)}
       accessibilityRole="button"
       accessibilityLabel={node.label}
     >

--- a/src/components/graph/GraphSettingsPanel.tsx
+++ b/src/components/graph/GraphSettingsPanel.tsx
@@ -1,0 +1,146 @@
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import Slider from '@react-native-community/slider';
+import { colors, spacing, borderRadius, typography } from '@/styles/theme';
+import type { GraphPreferences } from '@utils/graphPreferences';
+
+interface GraphSettingsPanelProps {
+  preferences: GraphPreferences;
+  /** Fired live while a slider is dragged — the layout recomputes. */
+  onChange: (prefs: GraphPreferences) => void;
+  /** Fired when a slider is released — persist the value here. */
+  onCommit: (prefs: GraphPreferences) => void;
+  onReset: () => void;
+}
+
+/**
+ * Collapsible layout controls for the relationship graph: overall node
+ * spacing and how strongly relationship standing pulls friendly nodes
+ * together / pushes hostile ones apart.
+ */
+export const GraphSettingsPanel: React.FC<GraphSettingsPanelProps> = ({
+  preferences,
+  onChange,
+  onCommit,
+  onReset,
+}) => {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity
+        style={styles.toggle}
+        onPress={() => setExpanded(prev => !prev)}
+        accessibilityRole="button"
+        accessibilityLabel="Layout settings"
+        accessibilityState={{ expanded }}
+      >
+        <Text style={styles.toggleText}>
+          Layout settings {expanded ? '▾' : '▸'}
+        </Text>
+      </TouchableOpacity>
+
+      {expanded && (
+        <View style={styles.panel}>
+          <View style={styles.row}>
+            <Text style={styles.label}>Spacing</Text>
+            <Slider
+              testID="graph-spacing-slider"
+              style={styles.slider}
+              minimumValue={1}
+              maximumValue={3}
+              step={0.25}
+              value={preferences.spacing}
+              minimumTrackTintColor={colors.accent.primary}
+              maximumTrackTintColor={colors.border}
+              thumbTintColor={colors.accent.primary}
+              onValueChange={value =>
+                onChange({ ...preferences, spacing: value })
+              }
+              onSlidingComplete={value =>
+                onCommit({ ...preferences, spacing: value })
+              }
+            />
+          </View>
+          <View style={styles.row}>
+            <Text style={styles.label}>Standing effect</Text>
+            <Slider
+              testID="graph-standing-slider"
+              style={styles.slider}
+              minimumValue={0}
+              maximumValue={2}
+              step={0.25}
+              value={preferences.standingSpread}
+              minimumTrackTintColor={colors.accent.primary}
+              maximumTrackTintColor={colors.border}
+              thumbTintColor={colors.accent.primary}
+              onValueChange={value =>
+                onChange({ ...preferences, standingSpread: value })
+              }
+              onSlidingComplete={value =>
+                onCommit({ ...preferences, standingSpread: value })
+              }
+            />
+          </View>
+          <TouchableOpacity
+            onPress={onReset}
+            accessibilityRole="button"
+            accessibilityLabel="Reset layout settings"
+          >
+            <Text style={styles.resetText}>Reset to defaults</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: spacing.base,
+    paddingBottom: spacing.sm,
+  },
+  toggle: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    borderRadius: borderRadius.full,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.surface,
+  },
+  toggleText: {
+    fontSize: typography.fontSize.sm,
+    color: colors.text.secondary,
+    fontWeight: typography.fontWeight.medium,
+  },
+  panel: {
+    marginTop: spacing.sm,
+    padding: spacing.md,
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.surface,
+    gap: spacing.sm,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+  },
+  label: {
+    width: 110,
+    fontSize: typography.fontSize.sm,
+    color: colors.text.primary,
+    fontWeight: typography.fontWeight.medium,
+  },
+  slider: {
+    flex: 1,
+    height: 32,
+  },
+  resetText: {
+    color: colors.accent.primary,
+    fontSize: typography.fontSize.sm,
+    fontWeight: typography.fontWeight.semibold,
+  },
+});

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -20,3 +20,4 @@ export { GraphFilterBar } from './graph/GraphFilterBar';
 export type { GraphFilters } from './graph/GraphFilterBar';
 export { GraphLegend } from './graph/GraphLegend';
 export { GraphInfoCard } from './graph/GraphInfoCard';
+export { GraphSettingsPanel } from './graph/GraphSettingsPanel';

--- a/src/screens/RelationshipGraphScreen.tsx
+++ b/src/screens/RelationshipGraphScreen.tsx
@@ -26,6 +26,13 @@ import {
   GraphNodeType,
   PositionedNode,
 } from '@utils/relationshipGraph';
+import {
+  DEFAULT_GRAPH_PREFERENCES,
+  getGraphPreferences,
+  GraphPreferences,
+  resetGraphPreferences,
+  updateGraphPreferences,
+} from '@utils/graphPreferences';
 import { Size } from '@utils/mapCoordinates';
 import { colors, spacing, typography, borderRadius } from '@/styles/theme';
 import { commonStyles } from '@/styles/commonStyles';
@@ -35,6 +42,7 @@ import {
   GraphFilters,
   GraphInfoCard,
   GraphLegend,
+  GraphSettingsPanel,
 } from '@/components';
 
 type RelationshipGraphNavigationProp = StackNavigationProp<RootStackParamList>;
@@ -60,16 +68,25 @@ export const RelationshipGraphScreen: React.FC = () => {
   const [filters, setFilters] = useState<GraphFilters>(DEFAULT_FILTERS);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [focusNodeId, setFocusNodeId] = useState<string | null>(null);
+  const [preferences, setPreferences] = useState<GraphPreferences>(
+    DEFAULT_GRAPH_PREFERENCES
+  );
 
   const loadData = useCallback(async () => {
     setLoading(true);
     try {
       await migrateFactionDescriptions();
-      const [loadedCharacters, loadedFactions, loadedLocations] =
-        await Promise.all([loadCharacters(), loadFactions(), loadLocations()]);
+      const [loadedCharacters, loadedFactions, loadedLocations, loadedPrefs] =
+        await Promise.all([
+          loadCharacters(),
+          loadFactions(),
+          loadLocations(),
+          getGraphPreferences(),
+        ]);
       setCharacters(loadedCharacters);
       setFactions(loadedFactions);
       setLocations(loadedLocations);
+      setPreferences(loadedPrefs);
     } catch {
       // Loaders resolve [] on failure; the screen just shows the empty state.
     } finally {
@@ -109,9 +126,23 @@ export const RelationshipGraphScreen: React.FC = () => {
     return getNeighborhood(fullGraph, focusedNode.id, 1);
   }, [fullGraph, focusedNode]);
 
+  // The layout runs on a virtual canvas that grows with the spacing
+  // preference; the GraphCanvas pan/zoom gestures navigate the overflow.
+  const virtualSize = useMemo<Size>(() => {
+    const spreadFactor = Math.min(3, Math.max(1, preferences.spacing));
+    return {
+      width: containerSize.width * spreadFactor,
+      height: containerSize.height * spreadFactor,
+    };
+  }, [containerSize, preferences.spacing]);
+
   const positionedNodes = useMemo(
-    () => computeGraphLayout(displayedGraph, containerSize),
-    [displayedGraph, containerSize]
+    () =>
+      computeGraphLayout(displayedGraph, virtualSize, {
+        spacing: preferences.spacing,
+        standingSpread: preferences.standingSpread,
+      }),
+    [displayedGraph, virtualSize, preferences]
   );
 
   const selectedNode: PositionedNode | null =
@@ -172,6 +203,17 @@ export const RelationshipGraphScreen: React.FC = () => {
     setFilters(prev => ({ ...prev, hideIsolated: !prev.hideIsolated }));
   };
 
+  const handlePreferencesCommit = (prefs: GraphPreferences) => {
+    setPreferences(prefs);
+    // Persistence failures are non-fatal — the in-memory value still applies.
+    updateGraphPreferences(prefs).catch(() => {});
+  };
+
+  const handlePreferencesReset = () => {
+    setPreferences(DEFAULT_GRAPH_PREFERENCES);
+    resetGraphPreferences().catch(() => {});
+  };
+
   const hasAnyData =
     characters.length > 0 || factions.length > 0 || locations.length > 0;
 
@@ -184,6 +226,12 @@ export const RelationshipGraphScreen: React.FC = () => {
         onToggleHideIsolated={handleToggleHideIsolated}
       />
       <GraphLegend />
+      <GraphSettingsPanel
+        preferences={preferences}
+        onChange={setPreferences}
+        onCommit={handlePreferencesCommit}
+        onReset={handlePreferencesReset}
+      />
 
       {focusedNode && (
         <View style={styles.focusPill}>
@@ -224,7 +272,8 @@ export const RelationshipGraphScreen: React.FC = () => {
           </View>
         ) : containerSize.width > 0 ? (
           <GraphCanvas
-            size={containerSize}
+            containerSize={containerSize}
+            contentSize={virtualSize}
             nodes={positionedNodes}
             edges={displayedGraph.edges}
             selectedNodeId={selectedNodeId}

--- a/src/screens/RelationshipGraphScreen.tsx
+++ b/src/screens/RelationshipGraphScreen.tsx
@@ -47,11 +47,11 @@ import {
 
 type RelationshipGraphNavigationProp = StackNavigationProp<RootStackParamList>;
 
-const DEFAULT_FILTERS: GraphFilters = {
-  visibleTypes: new Set<GraphNodeType>(['character', 'faction', 'location']),
-  showRetired: false,
-  hideIsolated: false,
-};
+const DEFAULT_VISIBLE_TYPES = new Set<GraphNodeType>([
+  'character',
+  'faction',
+  'location',
+]);
 
 export const RelationshipGraphScreen: React.FC = () => {
   const navigation = useNavigation<RelationshipGraphNavigationProp>();
@@ -65,11 +65,24 @@ export const RelationshipGraphScreen: React.FC = () => {
     width: 0,
     height: 0,
   });
-  const [filters, setFilters] = useState<GraphFilters>(DEFAULT_FILTERS);
+  const [visibleTypes, setVisibleTypes] = useState<Set<GraphNodeType>>(
+    DEFAULT_VISIBLE_TYPES
+  );
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [focusNodeId, setFocusNodeId] = useState<string | null>(null);
+  // Single source of truth for everything persisted: layout spacing sliders
+  // plus the retired/isolated filter toggles.
   const [preferences, setPreferences] = useState<GraphPreferences>(
     DEFAULT_GRAPH_PREFERENCES
+  );
+
+  const filters: GraphFilters = useMemo(
+    () => ({
+      visibleTypes,
+      showRetired: preferences.showRetired,
+      hideIsolated: preferences.hideIsolated,
+    }),
+    [visibleTypes, preferences.showRetired, preferences.hideIsolated]
   );
 
   const loadData = useCallback(async () => {
@@ -126,9 +139,10 @@ export const RelationshipGraphScreen: React.FC = () => {
     return getNeighborhood(fullGraph, focusedNode.id, 1);
   }, [fullGraph, focusedNode]);
 
-  // The layout runs on a virtual canvas that grows with the spacing
-  // preference; the GraphCanvas pan/zoom gestures navigate the overflow.
-  const virtualSize = useMemo<Size>(() => {
+  // The reference frame for the simulation grows with the spacing
+  // preference; the layout itself is an infinite canvas — it returns its
+  // natural content size and GraphCanvas pan/zoom navigates the overflow.
+  const referenceFrame = useMemo<Size>(() => {
     const spreadFactor = Math.min(3, Math.max(1, preferences.spacing));
     return {
       width: containerSize.width * spreadFactor,
@@ -136,14 +150,15 @@ export const RelationshipGraphScreen: React.FC = () => {
     };
   }, [containerSize, preferences.spacing]);
 
-  const positionedNodes = useMemo(
+  const graphLayout = useMemo(
     () =>
-      computeGraphLayout(displayedGraph, virtualSize, {
+      computeGraphLayout(displayedGraph, referenceFrame, {
         spacing: preferences.spacing,
         standingSpread: preferences.standingSpread,
       }),
-    [displayedGraph, virtualSize, preferences]
+    [displayedGraph, referenceFrame, preferences]
   );
+  const positionedNodes = graphLayout.nodes;
 
   const selectedNode: PositionedNode | null =
     positionedNodes.find(n => n.id === selectedNodeId) ?? null;
@@ -153,7 +168,9 @@ export const RelationshipGraphScreen: React.FC = () => {
     setContainerSize({ width, height });
   };
 
-  const handleSelectNode = (node: PositionedNode) => {
+  // Tap navigates straight to the entity; long-press opens the info card
+  // (which still offers Focus and View details).
+  const handleLongPressNode = (node: PositionedNode) => {
     setSelectedNodeId(prev => (prev === node.id ? null : node.id));
   };
 
@@ -184,28 +201,32 @@ export const RelationshipGraphScreen: React.FC = () => {
   };
 
   const handleToggleType = (type: GraphNodeType) => {
-    setFilters(prev => {
-      const visibleTypes = new Set(prev.visibleTypes);
-      if (visibleTypes.has(type)) {
-        visibleTypes.delete(type);
+    setVisibleTypes(prev => {
+      const next = new Set(prev);
+      if (next.has(type)) {
+        next.delete(type);
       } else {
-        visibleTypes.add(type);
+        next.add(type);
       }
-      return { ...prev, visibleTypes };
+      return next;
     });
   };
 
   const handleToggleRetired = () => {
-    setFilters(prev => ({ ...prev, showRetired: !prev.showRetired }));
+    const showRetired = !preferences.showRetired;
+    setPreferences(prev => ({ ...prev, showRetired }));
+    // Persistence failures are non-fatal — the in-memory value still applies.
+    updateGraphPreferences({ showRetired }).catch(() => {});
   };
 
   const handleToggleHideIsolated = () => {
-    setFilters(prev => ({ ...prev, hideIsolated: !prev.hideIsolated }));
+    const hideIsolated = !preferences.hideIsolated;
+    setPreferences(prev => ({ ...prev, hideIsolated }));
+    updateGraphPreferences({ hideIsolated }).catch(() => {});
   };
 
   const handlePreferencesCommit = (prefs: GraphPreferences) => {
     setPreferences(prefs);
-    // Persistence failures are non-fatal — the in-memory value still applies.
     updateGraphPreferences(prefs).catch(() => {});
   };
 
@@ -273,11 +294,12 @@ export const RelationshipGraphScreen: React.FC = () => {
         ) : containerSize.width > 0 ? (
           <GraphCanvas
             containerSize={containerSize}
-            contentSize={virtualSize}
+            contentSize={graphLayout.size}
             nodes={positionedNodes}
             edges={displayedGraph.edges}
             selectedNodeId={selectedNodeId}
-            onSelectNode={handleSelectNode}
+            onPressNode={handleViewDetails}
+            onLongPressNode={handleLongPressNode}
           />
         ) : null}
       </View>

--- a/src/utils/graphPreferences.ts
+++ b/src/utils/graphPreferences.ts
@@ -1,0 +1,61 @@
+import { SafeAsyncStorageJSONParser } from './safeAsyncStorageJSONParser';
+import { runExclusive } from './storageQueue';
+
+const GRAPH_PREFS_KEY = 'gameCharacterManager_graph_prefs';
+
+export interface GraphPreferences {
+  /**
+   * Overall spacing multiplier, 1–3. Scales link rest distances, node
+   * repulsion, AND the virtual layout canvas the graph screen renders onto.
+   */
+  spacing: number;
+  /**
+   * How strongly relationship standing modulates edge distance, 0–2.
+   * 0 means standings don't affect distance at all.
+   */
+  standingSpread: number;
+}
+
+export const DEFAULT_GRAPH_PREFERENCES: GraphPreferences = {
+  spacing: 1.5,
+  standingSpread: 1,
+};
+
+const clampPreferences = (prefs: GraphPreferences): GraphPreferences => ({
+  spacing: Math.min(3, Math.max(1, prefs.spacing)),
+  standingSpread: Math.min(2, Math.max(0, prefs.standingSpread)),
+});
+
+/**
+ * NOTE: intentionally NOT wrapped in `runExclusive` — it is called from
+ * inside `updateGraphPreferences`, which already holds the key's lock
+ * (same-key nesting deadlocks; see AGENTS.md and the `getDiscordConfig`
+ * precedent). Merging a Partial over the defaults keeps stored data from
+ * older app versions forward-compatible when fields are added.
+ */
+export const getGraphPreferences = async (): Promise<GraphPreferences> => {
+  const stored =
+    await SafeAsyncStorageJSONParser.getItem<Partial<GraphPreferences>>(
+      GRAPH_PREFS_KEY
+    );
+  return clampPreferences({ ...DEFAULT_GRAPH_PREFERENCES, ...stored });
+};
+
+export const updateGraphPreferences = (
+  updates: Partial<GraphPreferences>
+): Promise<GraphPreferences> =>
+  runExclusive(GRAPH_PREFS_KEY, async () => {
+    const current = await getGraphPreferences();
+    const next = clampPreferences({ ...current, ...updates });
+    await SafeAsyncStorageJSONParser.setItem(GRAPH_PREFS_KEY, next);
+    return next;
+  });
+
+export const resetGraphPreferences = (): Promise<GraphPreferences> =>
+  runExclusive(GRAPH_PREFS_KEY, async () => {
+    await SafeAsyncStorageJSONParser.setItem(
+      GRAPH_PREFS_KEY,
+      DEFAULT_GRAPH_PREFERENCES
+    );
+    return DEFAULT_GRAPH_PREFERENCES;
+  });

--- a/src/utils/graphPreferences.ts
+++ b/src/utils/graphPreferences.ts
@@ -14,16 +14,24 @@ export interface GraphPreferences {
    * 0 means standings don't affect distance at all.
    */
   standingSpread: number;
+  /** Show retired characters/factions in the graph. */
+  showRetired: boolean;
+  /** Hide entities with no connections. */
+  hideIsolated: boolean;
 }
 
 export const DEFAULT_GRAPH_PREFERENCES: GraphPreferences = {
   spacing: 1.5,
   standingSpread: 1,
+  showRetired: false,
+  hideIsolated: false,
 };
 
 const clampPreferences = (prefs: GraphPreferences): GraphPreferences => ({
   spacing: Math.min(3, Math.max(1, prefs.spacing)),
   standingSpread: Math.min(2, Math.max(0, prefs.standingSpread)),
+  showRetired: prefs.showRetired === true,
+  hideIsolated: prefs.hideIsolated === true,
 });
 
 /**

--- a/src/utils/relationshipGraph.ts
+++ b/src/utils/relationshipGraph.ts
@@ -1,10 +1,19 @@
 import {
+  forceCollide,
+  forceLink,
+  forceManyBody,
+  forceX,
+  forceY,
+  type SimulationLinkDatum,
+  type SimulationNodeDatum,
+} from 'd3-force';
+import {
   GameCharacter,
   GameLocation,
   RelationshipStanding,
 } from '@models/types';
 import type { StoredFaction } from '@utils/characterStorage';
-import { Point, Size } from '@utils/mapCoordinates';
+import { Size } from '@utils/mapCoordinates';
 
 /**
  * Pure, dependency-free graph model + layout for the relationship graph
@@ -281,27 +290,131 @@ export interface PositionedNode extends GraphNode {
 }
 
 export interface LayoutOptions {
-  /** Force-simulation iteration count. Default 150. */
+  /**
+   * d3-force tick count. Default 300 (roughly d3's default alpha schedule
+   * from 1 down to alphaMin).
+   */
   iterations?: number;
+  /** Kept-in-bounds margin around the layout canvas. Default 24. */
   padding?: number;
+  /**
+   * Overall spacing multiplier (>= 1). Scales link rest distances and
+   * node repulsion together. Default 1.
+   */
+  spacing?: number;
+  /**
+   * How strongly relationship standing modulates link distance, 0 (off)
+   * to 2. Default 1.
+   */
+  standingSpread?: number;
 }
 
 const TYPE_ORDER: GraphNodeType[] = ['character', 'faction', 'location'];
 
+/** Rest distance of a Neutral edge at spacing 1, in layout pixels. */
+const BASE_LINK_DISTANCE = 90;
 /**
- * Deterministic force-directed layout: nodes seed on a circle in a stable
- * (type, id) order, then repulsion/attraction/centering forces run for a
- * fixed iteration count — no randomness, so identical input always produces
- * identical positions (needed both for testability and so the graph doesn't
- * visually reshuffle on every re-render). O(nodes^2 * iterations); fine for
- * the dozens-to-low-hundreds of nodes this app's campaigns produce.
+ * Collision radius: NODE_RADIUS (16) plus the label band drawn below the
+ * circle in GraphNodeMarker — covers the label height and roughly half of a
+ * truncated 12-char label's width.
+ */
+const COLLIDE_RADIUS = 44;
+const CHARGE_STRENGTH = -160;
+const CENTER_PULL = 0.06;
+/** Arbitrary fixed seed for the layout PRNG. */
+const LAYOUT_SEED = 0x2545f491;
+
+/**
+ * Relative rest-distance adjustment per standing: negative pulls the pair
+ * closer, positive pushes it apart. The asymmetry (Enemy pushes further than
+ * Ally pulls) keeps hostile clusters visually distinct without collapsing
+ * friendly ones into each other.
+ */
+const STANDING_DISTANCE_DELTA: Record<RelationshipStanding, number> = {
+  [RelationshipStanding.Ally]: -0.35,
+  [RelationshipStanding.Friend]: -0.2,
+  [RelationshipStanding.Neutral]: 0,
+  [RelationshipStanding.Hostile]: 0.45,
+  [RelationshipStanding.Enemy]: 0.8,
+};
+
+/**
+ * Multiplier applied to an edge's rest distance. Uses the WORSE of
+ * `standing`/`reciprocalStanding` (max delta): a one-sided Ally + Hostile
+ * pair should not be drawn close — antagonism dominates. Floored at 0.4 so
+ * a large `standingSpread` can never produce a zero or negative distance.
+ */
+export function standingDistanceFactor(
+  edge: Pick<GraphEdge, 'standing' | 'reciprocalStanding'>,
+  standingSpread: number
+): number {
+  const delta = Math.max(
+    STANDING_DISTANCE_DELTA[edge.standing],
+    edge.reciprocalStanding !== undefined
+      ? STANDING_DISTANCE_DELTA[edge.reciprocalStanding]
+      : -Infinity
+  );
+  return Math.max(0.4, 1 + delta * standingSpread);
+}
+
+/**
+ * Small deterministic PRNG (mulberry32) handed to d3's `randomSource` so the
+ * simulation never falls back to `Math.random` (d3 only draws randoms to
+ * jiggle coincident nodes apart).
+ */
+const mulberry32 = (seed: number): (() => number) => {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+interface SimNode extends SimulationNodeDatum {
+  id: string;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+}
+
+interface SimLink extends SimulationLinkDatum<SimNode> {
+  distance: number;
+}
+
+// d3-force simulation defaults (alphaMin, alphaDecay over ~300 ticks,
+// velocityDecay 0.4), mirrored here because the tick loop below runs the
+// forces directly instead of through `forceSimulation` — whose constructor
+// auto-starts an async d3-timer stepper that would leak a frame callback
+// into the app (one stray no-op frame per layout) and crash Jest teardown.
+const ALPHA_MIN = 0.001;
+const ALPHA_DECAY = 1 - Math.pow(ALPHA_MIN, 1 / 300);
+const VELOCITY_RETAIN = 0.6;
+
+/**
+ * Deterministic force-directed layout on d3-force: nodes seed on a circle in
+ * a stable (type, id) order, then a fixed number of synchronous ticks run
+ * with a seeded `randomSource` — identical input always produces identical
+ * positions (needed both for testability and so the graph doesn't visually
+ * reshuffle on every re-render). Edge rest distances are standing-aware
+ * (Ally/Friend shorter, Hostile/Enemy longer — see `standingDistanceFactor`)
+ * and scale with `spacing`. `size` is the layout canvas, which callers may
+ * make larger than the visible viewport; positions are clamped inside it.
  */
 export function computeGraphLayout(
   graph: RelationshipGraph,
   size: Size,
   options: LayoutOptions = {}
 ): PositionedNode[] {
-  const { iterations = 150, padding = 24 } = options;
+  const {
+    iterations = 300,
+    padding = 24,
+    spacing = 1,
+    standingSpread = 1,
+  } = options;
   const { nodes, edges } = graph;
   const count = nodes.length;
   if (count === 0) {
@@ -319,92 +432,80 @@ export function computeGraphLayout(
     return typeDiff !== 0 ? typeDiff : a.id.localeCompare(b.id);
   });
 
-  const positions = new Map<string, Point>();
-  ordered.forEach((node, index) => {
-    const angle = (2 * Math.PI * index) / count;
-    positions.set(node.id, {
-      x: centerX + startRadius * Math.cos(angle),
-      y: centerY + startRadius * Math.sin(angle),
-    });
-  });
-
   if (count === 1) {
     const only = ordered[0];
     return [{ ...only, x: centerX, y: centerY }];
   }
 
-  const REPULSION = (width * height) / count / 4;
-  const ATTRACTION = 0.02;
-  const CENTERING = 0.01;
+  // d3 mutates its node objects (x/y/vx/vy) — build copies, never hand it
+  // the caller's GraphNodes. `index` is normally assigned by forceSimulation
+  // and is required by the force accessors, so set it here.
+  const simNodes: SimNode[] = ordered.map((node, index) => {
+    const angle = (2 * Math.PI * index) / count;
+    return {
+      id: node.id,
+      index,
+      x: centerX + startRadius * Math.cos(angle),
+      y: centerY + startRadius * Math.sin(angle),
+      vx: 0,
+      vy: 0,
+    };
+  });
 
-  for (let iter = 0; iter < iterations; iter++) {
-    const forces = new Map<string, Point>();
-    ordered.forEach(node => forces.set(node.id, { x: 0, y: 0 }));
+  // forceLink throws on ids missing from the node set; subgraphs (e.g. from
+  // getNeighborhood) may carry edges to omitted endpoints, so filter first.
+  const nodeIds = new Set(ordered.map(node => node.id));
+  const links: SimLink[] = edges
+    .filter(edge => nodeIds.has(edge.sourceId) && nodeIds.has(edge.targetId))
+    .map(edge => ({
+      source: edge.sourceId,
+      target: edge.targetId,
+      distance:
+        BASE_LINK_DISTANCE *
+        spacing *
+        standingDistanceFactor(edge, standingSpread),
+    }));
 
-    for (let i = 0; i < ordered.length; i++) {
-      for (let j = i + 1; j < ordered.length; j++) {
-        const nodeA = ordered[i];
-        const nodeB = ordered[j];
-        const posA = positions.get(nodeA.id) as Point;
-        const posB = positions.get(nodeB.id) as Point;
-        let dx = posA.x - posB.x;
-        let dy = posA.y - posB.y;
-        let distSq = dx * dx + dy * dy;
-        if (distSq < 0.01) {
-          // Deterministic jitter for coincident points, seeded by index.
-          dx = Math.cos(i - j);
-          dy = Math.sin(i - j);
-          distSq = 0.01;
-        }
-        const dist = Math.sqrt(distSq);
-        const force = REPULSION / distSq;
-        const fx = (dx / dist) * force;
-        const fy = (dy / dist) * force;
-        const forceA = forces.get(nodeA.id) as Point;
-        const forceB = forces.get(nodeB.id) as Point;
-        forceA.x += fx;
-        forceA.y += fy;
-        forceB.x -= fx;
-        forceB.y -= fy;
-      }
-    }
+  const forces = [
+    forceLink<SimNode, SimLink>(links)
+      .id(node => node.id)
+      .distance(link => link.distance),
+    forceManyBody<SimNode>()
+      .strength(CHARGE_STRENGTH * spacing)
+      // Without a range cap, disconnected components repel each other all
+      // the way to the canvas edges.
+      .distanceMax(Math.min(width, height) / 2),
+    forceCollide<SimNode>(COLLIDE_RADIUS).iterations(2),
+    // forceX/forceY rather than forceCenter: forceCenter only translates the
+    // mean position and lets stray nodes sit far outside the canvas.
+    forceX<SimNode>(centerX).strength(CENTER_PULL),
+    forceY<SimNode>(centerY).strength(CENTER_PULL),
+  ];
 
-    edges.forEach(edge => {
-      const posA = positions.get(edge.sourceId);
-      const posB = positions.get(edge.targetId);
-      const forceA = forces.get(edge.sourceId);
-      const forceB = forces.get(edge.targetId);
-      if (!posA || !posB || !forceA || !forceB) {
-        // Guards subgraphs (e.g. from getNeighborhood) that may omit an
-        // endpoint; shouldn't happen for a full graph.
-        return;
-      }
-      const dx = posB.x - posA.x;
-      const dy = posB.y - posA.y;
-      const fx = dx * ATTRACTION;
-      const fy = dy * ATTRACTION;
-      forceA.x += fx;
-      forceA.y += fy;
-      forceB.x -= fx;
-      forceB.y -= fy;
-    });
+  const random = mulberry32(LAYOUT_SEED);
+  forces.forEach(force => force.initialize?.(simNodes, random));
 
-    ordered.forEach(node => {
-      const pos = positions.get(node.id) as Point;
-      const force = forces.get(node.id) as Point;
-      force.x += (centerX - pos.x) * CENTERING;
-      force.y += (centerY - pos.y) * CENTERING;
-      positions.set(node.id, {
-        x: Math.min(width - padding, Math.max(padding, pos.x + force.x)),
-        y: Math.min(height - padding, Math.max(padding, pos.y + force.y)),
-      });
+  let alpha = 1;
+  for (let i = 0; i < iterations; i++) {
+    alpha += (0 - alpha) * ALPHA_DECAY;
+    forces.forEach(force => force(alpha));
+    simNodes.forEach(node => {
+      node.vx *= VELOCITY_RETAIN;
+      node.vy *= VELOCITY_RETAIN;
+      node.x += node.vx;
+      node.y += node.vy;
     });
   }
 
-  return ordered.map(node => ({
-    ...node,
-    ...(positions.get(node.id) as Point),
-  }));
+  const simById = new Map(simNodes.map(node => [node.id, node]));
+  return ordered.map(node => {
+    const sim = simById.get(node.id) as SimNode;
+    return {
+      ...node,
+      x: Math.min(width - padding, Math.max(padding, sim.x)),
+      y: Math.min(height - padding, Math.max(padding, sim.y)),
+    };
+  });
 }
 
 /**

--- a/src/utils/relationshipGraph.ts
+++ b/src/utils/relationshipGraph.ts
@@ -289,13 +289,23 @@ export interface PositionedNode extends GraphNode {
   y: number;
 }
 
+export interface GraphLayout {
+  nodes: PositionedNode[];
+  /**
+   * Natural size of the laid-out content: the node bounding box plus
+   * `padding` on every side (never smaller than the reference frame's
+   * padded minimum). The canvas should be rendered at this size.
+   */
+  size: Size;
+}
+
 export interface LayoutOptions {
   /**
    * d3-force tick count. Default 300 (roughly d3's default alpha schedule
    * from 1 down to alphaMin).
    */
   iterations?: number;
-  /** Kept-in-bounds margin around the layout canvas. Default 24. */
+  /** Margin kept between the node bounding box and the canvas edge. Default 24. */
   padding?: number;
   /**
    * Overall spacing multiplier (>= 1). Scales link rest distances and
@@ -401,14 +411,16 @@ const VELOCITY_RETAIN = 0.6;
  * positions (needed both for testability and so the graph doesn't visually
  * reshuffle on every re-render). Edge rest distances are standing-aware
  * (Ally/Friend shorter, Hostile/Enemy longer — see `standingDistanceFactor`)
- * and scale with `spacing`. `size` is the layout canvas, which callers may
- * make larger than the visible viewport; positions are clamped inside it.
+ * and scale with `spacing`. `size` is only a reference frame (seed radius,
+ * centering target, repulsion range) — the layout is an "infinite canvas":
+ * positions are never clamped, and the returned `size` is the natural extent
+ * of the content, however large it settles.
  */
 export function computeGraphLayout(
   graph: RelationshipGraph,
   size: Size,
   options: LayoutOptions = {}
-): PositionedNode[] {
+): GraphLayout {
   const {
     iterations = 300,
     padding = 24,
@@ -417,12 +429,14 @@ export function computeGraphLayout(
   } = options;
   const { nodes, edges } = graph;
   const count = nodes.length;
-  if (count === 0) {
-    return [];
-  }
 
   const width = Math.max(size.width, padding * 2 + 1);
   const height = Math.max(size.height, padding * 2 + 1);
+  const referenceSize: Size = { width, height };
+  if (count === 0) {
+    return { nodes: [], size: referenceSize };
+  }
+
   const centerX = width / 2;
   const centerY = height / 2;
   const startRadius = Math.max(1, Math.min(width, height) / 2 - padding);
@@ -434,7 +448,10 @@ export function computeGraphLayout(
 
   if (count === 1) {
     const only = ordered[0];
-    return [{ ...only, x: centerX, y: centerY }];
+    return {
+      nodes: [{ ...only, x: centerX, y: centerY }],
+      size: referenceSize,
+    };
   }
 
   // d3 mutates its node objects (x/y/vx/vy) — build copies, never hand it
@@ -472,8 +489,8 @@ export function computeGraphLayout(
       .distance(link => link.distance),
     forceManyBody<SimNode>()
       .strength(CHARGE_STRENGTH * spacing)
-      // Without a range cap, disconnected components repel each other all
-      // the way to the canvas edges.
+      // Without a range cap, disconnected components repel each other
+      // indefinitely and the canvas balloons.
       .distanceMax(Math.min(width, height) / 2),
     forceCollide<SimNode>(COLLIDE_RADIUS).iterations(2),
     // forceX/forceY rather than forceCenter: forceCenter only translates the
@@ -497,15 +514,33 @@ export function computeGraphLayout(
     });
   }
 
-  const simById = new Map(simNodes.map(node => [node.id, node]));
-  return ordered.map(node => {
-    const sim = simById.get(node.id) as SimNode;
-    return {
-      ...node,
-      x: Math.min(width - padding, Math.max(padding, sim.x)),
-      y: Math.min(height - padding, Math.max(padding, sim.y)),
-    };
+  // Infinite canvas: instead of clamping into the reference frame (which
+  // piled nodes up along the edges), shift the whole layout so its bounding
+  // box starts at `padding` and report the natural content size.
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  simNodes.forEach(node => {
+    minX = Math.min(minX, node.x);
+    minY = Math.min(minY, node.y);
+    maxX = Math.max(maxX, node.x);
+    maxY = Math.max(maxY, node.y);
   });
+  const offsetX = padding - minX;
+  const offsetY = padding - minY;
+
+  const simById = new Map(simNodes.map(node => [node.id, node]));
+  return {
+    nodes: ordered.map(node => {
+      const sim = simById.get(node.id) as SimNode;
+      return { ...node, x: sim.x + offsetX, y: sim.y + offsetY };
+    }),
+    size: {
+      width: maxX - minX + padding * 2,
+      height: maxY - minY + padding * 2,
+    },
+  };
 }
 
 /**

--- a/tst/components/graph/GraphCanvas.test.tsx
+++ b/tst/components/graph/GraphCanvas.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { Gesture } from 'react-native-gesture-handler';
+import { GraphCanvas } from '@components/graph/GraphCanvas';
+import type { PositionedNode } from '@utils/relationshipGraph';
+
+// The jest.setup.js gesture-handler mock records every chained callback on
+// the stub each Gesture.X() call returns, so tests can drive the canvas-level
+// tap/long-press hit-testing exactly as RNGH would on-device.
+
+const SIZE = { width: 400, height: 400 };
+
+const makeNode = (
+  id: string,
+  label: string,
+  x: number,
+  y: number
+): PositionedNode => ({
+  id,
+  type: 'character',
+  label,
+  refId: id,
+  degree: 0,
+  x,
+  y,
+});
+
+type GestureStub = {
+  callbacks: Record<string, (...args: unknown[]) => void>;
+};
+
+// With container == content, scale 1, translate 0, container coordinates map
+// 1:1 onto content coordinates.
+const IDENTITY_TAP = (x: number, y: number) => ({ x, y });
+
+describe('GraphCanvas', () => {
+  const nodeAlice = makeNode('character:c-alice', 'Alice', 100, 100);
+  const nodeBob = makeNode('character:c-bob', 'Bob', 300, 300);
+
+  const renderCanvas = () => {
+    const onPressNode = jest.fn();
+    const onLongPressNode = jest.fn();
+    const utils = render(
+      <GraphCanvas
+        containerSize={SIZE}
+        contentSize={SIZE}
+        nodes={[nodeAlice, nodeBob]}
+        edges={[]}
+        selectedNodeId={null}
+        onPressNode={onPressNode}
+        onLongPressNode={onLongPressNode}
+      />
+    );
+    // Component creation order: Tap #1 = double-tap, Tap #2 = single tap.
+    const tapStubs = (Gesture.Tap as jest.Mock).mock.results.map(
+      result => result.value as GestureStub
+    );
+    const singleTap = tapStubs[tapStubs.length - 1];
+    const longPressStubs = (Gesture.LongPress as jest.Mock).mock.results.map(
+      result => result.value as GestureStub
+    );
+    const longPress = longPressStubs[longPressStubs.length - 1];
+    return { ...utils, onPressNode, onLongPressNode, singleTap, longPress };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('fires onPressNode for a canvas tap that lands on a node', () => {
+    const { onPressNode, singleTap } = renderCanvas();
+
+    singleTap.callbacks.onEnd(IDENTITY_TAP(102, 98), true);
+
+    expect(onPressNode).toHaveBeenCalledWith(nodeAlice);
+  });
+
+  it('ignores canvas taps that land on empty space', () => {
+    const { onPressNode, singleTap } = renderCanvas();
+
+    singleTap.callbacks.onEnd(IDENTITY_TAP(200, 200), true);
+
+    expect(onPressNode).not.toHaveBeenCalled();
+  });
+
+  it('fires onLongPressNode for a canvas long-press on a node', () => {
+    const { onLongPressNode, longPress } = renderCanvas();
+
+    longPress.callbacks.onStart(IDENTITY_TAP(295, 305));
+
+    expect(onLongPressNode).toHaveBeenCalledWith(nodeBob);
+  });
+
+  it('swallows the duplicate when the SVG marker press fires alongside the gesture', () => {
+    const { onPressNode, singleTap, getByLabelText } = renderCanvas();
+
+    // On platforms where the SVG responder works, the marker press fires
+    // first and the canvas tap arrives a beat later for the same node.
+    fireEvent.press(getByLabelText('Alice'));
+    singleTap.callbacks.onEnd(IDENTITY_TAP(100, 100), true);
+
+    expect(onPressNode).toHaveBeenCalledTimes(1);
+  });
+
+  it('still delivers SVG marker presses (fallback path)', () => {
+    const { onPressNode, getByLabelText } = renderCanvas();
+
+    fireEvent.press(getByLabelText('Bob'));
+
+    expect(onPressNode).toHaveBeenCalledWith(nodeBob);
+  });
+});

--- a/tst/components/graph/GraphSettingsPanel.test.tsx
+++ b/tst/components/graph/GraphSettingsPanel.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { GraphSettingsPanel } from '@components/graph/GraphSettingsPanel';
+import { DEFAULT_GRAPH_PREFERENCES } from '@utils/graphPreferences';
+
+describe('GraphSettingsPanel', () => {
+  const renderPanel = () => {
+    const onChange = jest.fn();
+    const onCommit = jest.fn();
+    const onReset = jest.fn();
+    const utils = render(
+      <GraphSettingsPanel
+        preferences={DEFAULT_GRAPH_PREFERENCES}
+        onChange={onChange}
+        onCommit={onCommit}
+        onReset={onReset}
+      />
+    );
+    return { ...utils, onChange, onCommit, onReset };
+  };
+
+  it('starts collapsed and expands when the toggle is pressed', () => {
+    const { getByLabelText, queryByTestId } = renderPanel();
+
+    expect(queryByTestId('graph-spacing-slider')).toBeNull();
+
+    fireEvent.press(getByLabelText('Layout settings'));
+
+    expect(queryByTestId('graph-spacing-slider')).not.toBeNull();
+    expect(queryByTestId('graph-standing-slider')).not.toBeNull();
+  });
+
+  it('reports live spacing changes through onChange', () => {
+    const { getByLabelText, getByTestId, onChange } = renderPanel();
+    fireEvent.press(getByLabelText('Layout settings'));
+
+    fireEvent(getByTestId('graph-spacing-slider'), 'valueChange', 2);
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...DEFAULT_GRAPH_PREFERENCES,
+      spacing: 2,
+    });
+  });
+
+  it('reports released slider values through onCommit', () => {
+    const { getByLabelText, getByTestId, onCommit } = renderPanel();
+    fireEvent.press(getByLabelText('Layout settings'));
+
+    fireEvent(getByTestId('graph-standing-slider'), 'slidingComplete', 1.5);
+
+    expect(onCommit).toHaveBeenCalledWith({
+      ...DEFAULT_GRAPH_PREFERENCES,
+      standingSpread: 1.5,
+    });
+  });
+
+  it('fires onReset from the reset button', () => {
+    const { getByLabelText, onReset } = renderPanel();
+    fireEvent.press(getByLabelText('Layout settings'));
+
+    fireEvent.press(getByLabelText('Reset layout settings'));
+
+    expect(onReset).toHaveBeenCalled();
+  });
+});

--- a/tst/screens/RelationshipGraphScreen.test.tsx
+++ b/tst/screens/RelationshipGraphScreen.test.tsx
@@ -15,6 +15,18 @@ import {
 } from '../helpers/navigation';
 
 jest.mock('@utils/characterStorage');
+jest.mock('@utils/graphPreferences', () => ({
+  ...jest.requireActual('@utils/graphPreferences'),
+  getGraphPreferences: jest.fn(),
+  updateGraphPreferences: jest.fn(),
+  resetGraphPreferences: jest.fn(),
+}));
+
+import {
+  DEFAULT_GRAPH_PREFERENCES,
+  getGraphPreferences,
+  updateGraphPreferences,
+} from '@utils/graphPreferences';
 
 const storage = getStorageMock();
 
@@ -36,6 +48,12 @@ describe('RelationshipGraphScreen', () => {
     jest.clearAllMocks();
     primeStorageDefaults();
     installFocusEffectOnce();
+    (getGraphPreferences as jest.Mock).mockResolvedValue(
+      DEFAULT_GRAPH_PREFERENCES
+    );
+    (updateGraphPreferences as jest.Mock).mockResolvedValue(
+      DEFAULT_GRAPH_PREFERENCES
+    );
   });
 
   afterEach(() => {
@@ -204,6 +222,25 @@ describe('RelationshipGraphScreen', () => {
     fireEvent.press(getByLabelText('Faction'));
 
     await waitFor(() => expect(queryByLabelText('Brotherhood')).toBeNull());
+    expect(getByLabelText('Alice')).toBeTruthy();
+  });
+
+  it('persists spacing changes from the layout settings panel', async () => {
+    const alice = makeCharacter({ id: 'c-alice', name: 'Alice' });
+    storage.loadCharacters.mockResolvedValue([alice]);
+
+    const { getByTestId, getByLabelText } = render(<RelationshipGraphScreen />);
+    fireCanvasLayout(getByTestId);
+    await waitFor(() => expect(getByLabelText('Alice')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Layout settings'));
+    fireEvent(getByTestId('graph-spacing-slider'), 'slidingComplete', 2.5);
+
+    expect(updateGraphPreferences).toHaveBeenCalledWith({
+      ...DEFAULT_GRAPH_PREFERENCES,
+      spacing: 2.5,
+    });
+    // The graph still renders after the relayout on the larger canvas.
     expect(getByLabelText('Alice')).toBeTruthy();
   });
 });

--- a/tst/screens/RelationshipGraphScreen.test.tsx
+++ b/tst/screens/RelationshipGraphScreen.test.tsx
@@ -94,26 +94,23 @@ describe('RelationshipGraphScreen', () => {
     expect(getByLabelText('The Docks')).toBeTruthy();
   });
 
-  it('navigates to CharacterDetail with the character object from the info card', async () => {
+  it('navigates to CharacterDetail when a character node is tapped', async () => {
     const alice = makeCharacter({ id: 'c-alice', name: 'Alice' });
     storage.loadCharacters.mockResolvedValue([alice]);
     const nav = installNavigationMock();
 
-    const { getByTestId, getByLabelText, findByText } = render(
-      <RelationshipGraphScreen />
-    );
+    const { getByTestId, getByLabelText } = render(<RelationshipGraphScreen />);
     fireCanvasLayout(getByTestId);
 
     const node = await waitFor(() => getByLabelText('Alice'));
     fireEvent.press(node);
-    fireEvent.press(await findByText('View details'));
 
     expect(nav.navigate).toHaveBeenCalledWith('CharacterDetail', {
       character: alice,
     });
   });
 
-  it('navigates to FactionDetails with the faction name from the info card', async () => {
+  it('navigates to FactionDetails when a faction node is tapped', async () => {
     const alice = makeCharacter({
       id: 'c-alice',
       name: 'Alice',
@@ -125,21 +122,18 @@ describe('RelationshipGraphScreen', () => {
     ]);
     const nav = installNavigationMock();
 
-    const { getByTestId, getByLabelText, findByText } = render(
-      <RelationshipGraphScreen />
-    );
+    const { getByTestId, getByLabelText } = render(<RelationshipGraphScreen />);
     fireCanvasLayout(getByTestId);
 
     const node = await waitFor(() => getByLabelText('Brotherhood'));
     fireEvent.press(node);
-    fireEvent.press(await findByText('View details'));
 
     expect(nav.navigate).toHaveBeenCalledWith('FactionDetails', {
       factionName: 'Brotherhood',
     });
   });
 
-  it('navigates to LocationDetails with the location id from the info card', async () => {
+  it('navigates to LocationDetails when a location node is tapped', async () => {
     const alice = makeCharacter({
       id: 'c-alice',
       name: 'Alice',
@@ -151,17 +145,33 @@ describe('RelationshipGraphScreen', () => {
     ]);
     const nav = installNavigationMock();
 
+    const { getByTestId, getByLabelText } = render(<RelationshipGraphScreen />);
+    fireCanvasLayout(getByTestId);
+
+    const node = await waitFor(() => getByLabelText('The Docks'));
+    fireEvent.press(node);
+
+    expect(nav.navigate).toHaveBeenCalledWith('LocationDetails', {
+      locationId: 'loc-1',
+    });
+  });
+
+  it('opens the info card on long-press and navigates via "View details"', async () => {
+    const alice = makeCharacter({ id: 'c-alice', name: 'Alice' });
+    storage.loadCharacters.mockResolvedValue([alice]);
+    const nav = installNavigationMock();
+
     const { getByTestId, getByLabelText, findByText } = render(
       <RelationshipGraphScreen />
     );
     fireCanvasLayout(getByTestId);
 
-    const node = await waitFor(() => getByLabelText('The Docks'));
-    fireEvent.press(node);
+    const node = await waitFor(() => getByLabelText('Alice'));
+    fireEvent(node, 'longPress');
     fireEvent.press(await findByText('View details'));
 
-    expect(nav.navigate).toHaveBeenCalledWith('LocationDetails', {
-      locationId: 'loc-1',
+    expect(nav.navigate).toHaveBeenCalledWith('CharacterDetail', {
+      character: alice,
     });
   });
 
@@ -189,7 +199,7 @@ describe('RelationshipGraphScreen', () => {
     const aliceNode = await waitFor(() => getByLabelText('Alice'));
     expect(getByLabelText('Dave')).toBeTruthy();
 
-    fireEvent.press(aliceNode);
+    fireEvent(aliceNode, 'longPress');
     fireEvent.press(await findByText('Focus'));
 
     expect(await findByText('Focused on Alice')).toBeTruthy();
@@ -223,6 +233,21 @@ describe('RelationshipGraphScreen', () => {
 
     await waitFor(() => expect(queryByLabelText('Brotherhood')).toBeNull());
     expect(getByLabelText('Alice')).toBeTruthy();
+  });
+
+  it('persists the retired and isolated filter toggles', async () => {
+    const alice = makeCharacter({ id: 'c-alice', name: 'Alice' });
+    storage.loadCharacters.mockResolvedValue([alice]);
+
+    const { getByTestId, getByLabelText } = render(<RelationshipGraphScreen />);
+    fireCanvasLayout(getByTestId);
+    await waitFor(() => expect(getByLabelText('Alice')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Retired'));
+    expect(updateGraphPreferences).toHaveBeenCalledWith({ showRetired: true });
+
+    fireEvent.press(getByLabelText('Hide isolated'));
+    expect(updateGraphPreferences).toHaveBeenCalledWith({ hideIsolated: true });
   });
 
   it('persists spacing changes from the layout settings panel', async () => {

--- a/tst/utils/graphPreferences.test.ts
+++ b/tst/utils/graphPreferences.test.ts
@@ -1,0 +1,78 @@
+import {
+  DEFAULT_GRAPH_PREFERENCES,
+  getGraphPreferences,
+  resetGraphPreferences,
+  updateGraphPreferences,
+} from '@/utils/graphPreferences';
+import { SafeAsyncStorageJSONParser } from '@/utils/safeAsyncStorageJSONParser';
+
+jest.mock('@/utils/safeAsyncStorageJSONParser');
+
+describe('graphPreferences', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getGraphPreferences', () => {
+    it('returns the defaults when nothing is stored', async () => {
+      (SafeAsyncStorageJSONParser.getItem as jest.Mock).mockResolvedValue(null);
+
+      expect(await getGraphPreferences()).toEqual(DEFAULT_GRAPH_PREFERENCES);
+    });
+
+    it('merges a partial stored value over the defaults', async () => {
+      (SafeAsyncStorageJSONParser.getItem as jest.Mock).mockResolvedValue({
+        spacing: 2,
+      });
+
+      expect(await getGraphPreferences()).toEqual({
+        spacing: 2,
+        standingSpread: DEFAULT_GRAPH_PREFERENCES.standingSpread,
+      });
+    });
+
+    it('clamps out-of-range stored values on read', async () => {
+      (SafeAsyncStorageJSONParser.getItem as jest.Mock).mockResolvedValue({
+        spacing: 99,
+        standingSpread: -5,
+      });
+
+      expect(await getGraphPreferences()).toEqual({
+        spacing: 3,
+        standingSpread: 0,
+      });
+    });
+  });
+
+  describe('updateGraphPreferences', () => {
+    it('writes the merged and clamped preferences and returns them', async () => {
+      (SafeAsyncStorageJSONParser.getItem as jest.Mock).mockResolvedValue({
+        spacing: 2,
+        standingSpread: 1,
+      });
+      (SafeAsyncStorageJSONParser.setItem as jest.Mock).mockResolvedValue(true);
+
+      const result = await updateGraphPreferences({ standingSpread: 7 });
+
+      expect(result).toEqual({ spacing: 2, standingSpread: 2 });
+      expect(SafeAsyncStorageJSONParser.setItem).toHaveBeenCalledWith(
+        'gameCharacterManager_graph_prefs',
+        { spacing: 2, standingSpread: 2 }
+      );
+    });
+  });
+
+  describe('resetGraphPreferences', () => {
+    it('writes and returns the defaults', async () => {
+      (SafeAsyncStorageJSONParser.setItem as jest.Mock).mockResolvedValue(true);
+
+      const result = await resetGraphPreferences();
+
+      expect(result).toEqual(DEFAULT_GRAPH_PREFERENCES);
+      expect(SafeAsyncStorageJSONParser.setItem).toHaveBeenCalledWith(
+        'gameCharacterManager_graph_prefs',
+        DEFAULT_GRAPH_PREFERENCES
+      );
+    });
+  });
+});

--- a/tst/utils/graphPreferences.test.ts
+++ b/tst/utils/graphPreferences.test.ts
@@ -26,8 +26,8 @@ describe('graphPreferences', () => {
       });
 
       expect(await getGraphPreferences()).toEqual({
+        ...DEFAULT_GRAPH_PREFERENCES,
         spacing: 2,
-        standingSpread: DEFAULT_GRAPH_PREFERENCES.standingSpread,
       });
     });
 
@@ -35,11 +35,14 @@ describe('graphPreferences', () => {
       (SafeAsyncStorageJSONParser.getItem as jest.Mock).mockResolvedValue({
         spacing: 99,
         standingSpread: -5,
+        showRetired: 'yes',
       });
 
       expect(await getGraphPreferences()).toEqual({
         spacing: 3,
         standingSpread: 0,
+        showRetired: false,
+        hideIsolated: false,
       });
     });
   });
@@ -54,11 +57,32 @@ describe('graphPreferences', () => {
 
       const result = await updateGraphPreferences({ standingSpread: 7 });
 
-      expect(result).toEqual({ spacing: 2, standingSpread: 2 });
+      const expected = {
+        ...DEFAULT_GRAPH_PREFERENCES,
+        spacing: 2,
+        standingSpread: 2,
+      };
+      expect(result).toEqual(expected);
       expect(SafeAsyncStorageJSONParser.setItem).toHaveBeenCalledWith(
         'gameCharacterManager_graph_prefs',
-        { spacing: 2, standingSpread: 2 }
+        expected
       );
+    });
+
+    it('persists the filter toggles', async () => {
+      (SafeAsyncStorageJSONParser.getItem as jest.Mock).mockResolvedValue(null);
+      (SafeAsyncStorageJSONParser.setItem as jest.Mock).mockResolvedValue(true);
+
+      const result = await updateGraphPreferences({
+        showRetired: true,
+        hideIsolated: true,
+      });
+
+      expect(result).toEqual({
+        ...DEFAULT_GRAPH_PREFERENCES,
+        showRetired: true,
+        hideIsolated: true,
+      });
     });
   });
 

--- a/tst/utils/relationshipGraph.test.ts
+++ b/tst/utils/relationshipGraph.test.ts
@@ -11,6 +11,7 @@ import {
   factionNodeId,
   getNeighborhood,
   locationNodeId,
+  standingDistanceFactor,
 } from '@/utils/relationshipGraph';
 
 describe('buildRelationshipGraph', () => {
@@ -392,6 +393,161 @@ describe('computeGraphLayout', () => {
     expect(
       computeGraphLayout({ nodes: [], edges: [] }, { width: 100, height: 100 })
     ).toEqual([]);
+  });
+
+  it('does not throw on edges whose endpoints are missing from the node set', () => {
+    const graph = buildRelationshipGraph({
+      characters: [makeCharacter({ id: 'c-1', name: 'One' })],
+      factions: [],
+      locations: [],
+    });
+    const withDanglingEdge = {
+      nodes: [
+        ...graph.nodes,
+        {
+          id: characterNodeId('c-2'),
+          type: 'character' as const,
+          label: 'Two',
+          refId: 'c-2',
+          degree: 0,
+        },
+      ],
+      edges: [
+        {
+          id: 'dangling',
+          sourceId: characterNodeId('c-1'),
+          targetId: characterNodeId('c-ghost'),
+          kind: 'character-character' as const,
+          standing: RelationshipStanding.Ally,
+        },
+      ],
+    };
+
+    expect(() =>
+      computeGraphLayout(withDanglingEdge, { width: 400, height: 400 })
+    ).not.toThrow();
+  });
+
+  it('places positively-related pairs closer than negatively-related ones', () => {
+    const hub = makeCharacter({
+      id: 'c-hub',
+      name: 'Hub',
+      relationships: [
+        { characterName: 'Buddy', relationshipType: RelationshipStanding.Ally },
+        {
+          characterName: 'Rival',
+          relationshipType: RelationshipStanding.Enemy,
+        },
+      ],
+    });
+    const buddy = makeCharacter({ id: 'c-buddy', name: 'Buddy' });
+    const rival = makeCharacter({ id: 'c-rival', name: 'Rival' });
+    const graph = buildRelationshipGraph({
+      characters: [hub, buddy, rival],
+      factions: [],
+      locations: [],
+    });
+
+    const positions = computeGraphLayout(graph, { width: 1200, height: 1200 });
+    const positionOf = (id: string) => {
+      const position = positions.find(p => p.id === id);
+      if (!position) {
+        throw new Error(`missing position for ${id}`);
+      }
+      return position;
+    };
+    const hubPos = positionOf(characterNodeId('c-hub'));
+    const buddyPos = positionOf(characterNodeId('c-buddy'));
+    const rivalPos = positionOf(characterNodeId('c-rival'));
+
+    expect(
+      Math.hypot(buddyPos.x - hubPos.x, buddyPos.y - hubPos.y)
+    ).toBeLessThan(Math.hypot(rivalPos.x - hubPos.x, rivalPos.y - hubPos.y));
+  });
+
+  it('spreads nodes further apart with a larger spacing option', () => {
+    const characters = [
+      makeCharacter({
+        id: 'c-1',
+        name: 'One',
+        relationships: [
+          {
+            characterName: 'Two',
+            relationshipType: RelationshipStanding.Neutral,
+          },
+          {
+            characterName: 'Three',
+            relationshipType: RelationshipStanding.Neutral,
+          },
+        ],
+      }),
+      makeCharacter({ id: 'c-2', name: 'Two' }),
+      makeCharacter({ id: 'c-3', name: 'Three' }),
+    ];
+    const graph = buildRelationshipGraph({
+      characters,
+      factions: [],
+      locations: [],
+    });
+    const size = { width: 2000, height: 2000 };
+
+    const meanPairwiseDistance = (spacing: number): number => {
+      const positions = computeGraphLayout(graph, size, { spacing });
+      let total = 0;
+      let pairs = 0;
+      for (let i = 0; i < positions.length; i++) {
+        for (let j = i + 1; j < positions.length; j++) {
+          total += Math.hypot(
+            positions[i].x - positions[j].x,
+            positions[i].y - positions[j].y
+          );
+          pairs++;
+        }
+      }
+      return total / pairs;
+    };
+
+    expect(meanPairwiseDistance(2)).toBeGreaterThan(meanPairwiseDistance(1));
+  });
+});
+
+describe('standingDistanceFactor', () => {
+  it('orders factors Ally < Friend < Neutral < Hostile < Enemy', () => {
+    const factors = [
+      RelationshipStanding.Ally,
+      RelationshipStanding.Friend,
+      RelationshipStanding.Neutral,
+      RelationshipStanding.Hostile,
+      RelationshipStanding.Enemy,
+    ].map(standing => standingDistanceFactor({ standing }, 1));
+
+    const sorted = [...factors].sort((a, b) => a - b);
+    expect(factors).toEqual(sorted);
+    expect(new Set(factors).size).toBe(factors.length);
+  });
+
+  it('returns 1 for every standing when standingSpread is 0', () => {
+    Object.values(RelationshipStanding).forEach(standing => {
+      expect(standingDistanceFactor({ standing }, 0)).toBe(1);
+    });
+  });
+
+  it('lets the worse standing win when the reciprocal side disagrees', () => {
+    expect(
+      standingDistanceFactor(
+        {
+          standing: RelationshipStanding.Ally,
+          reciprocalStanding: RelationshipStanding.Enemy,
+        },
+        1
+      )
+    ).toBe(standingDistanceFactor({ standing: RelationshipStanding.Enemy }, 1));
+  });
+
+  it('never drops below the 0.4 floor, even at maximum spread', () => {
+    expect(
+      standingDistanceFactor({ standing: RelationshipStanding.Ally }, 2)
+    ).toBeGreaterThanOrEqual(0.4);
   });
 });
 

--- a/tst/utils/relationshipGraph.test.ts
+++ b/tst/utils/relationshipGraph.test.ts
@@ -322,7 +322,7 @@ describe('buildRelationshipGraph', () => {
 });
 
 describe('computeGraphLayout', () => {
-  it('returns a position for every node, clamped within the given size', () => {
+  it('returns a position for every node within the reported content size', () => {
     const alice = makeCharacter({
       id: 'c-alice',
       name: 'Alice',
@@ -337,17 +337,45 @@ describe('computeGraphLayout', () => {
       locations: [],
     });
 
-    const positions = computeGraphLayout(graph, { width: 400, height: 300 });
+    const layout = computeGraphLayout(graph, { width: 400, height: 300 });
 
-    expect(positions).toHaveLength(2);
-    positions.forEach(p => {
+    expect(layout.nodes).toHaveLength(2);
+    layout.nodes.forEach(p => {
       expect(p.x).toBeGreaterThanOrEqual(0);
-      expect(p.x).toBeLessThanOrEqual(400);
+      expect(p.x).toBeLessThanOrEqual(layout.size.width);
       expect(p.y).toBeGreaterThanOrEqual(0);
-      expect(p.y).toBeLessThanOrEqual(300);
+      expect(p.y).toBeLessThanOrEqual(layout.size.height);
       expect(Number.isFinite(p.x)).toBe(true);
       expect(Number.isFinite(p.y)).toBe(true);
     });
+  });
+
+  it('grows the content size beyond the reference frame instead of piling nodes on the edges', () => {
+    // 8 mutually-hostile factions on a tiny reference frame: the old
+    // clamped layout would pin most of them to the border; the infinite
+    // canvas must expand instead.
+    const names = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
+    const factions = names.map(name =>
+      makeStoredFaction({
+        name,
+        relationships: names
+          .filter(other => other !== name)
+          .map(other => ({
+            factionName: other,
+            relationshipType: RelationshipStanding.Enemy,
+          })),
+      })
+    );
+    const graph = buildRelationshipGraph({
+      characters: [],
+      factions,
+      locations: [],
+    });
+
+    const layout = computeGraphLayout(graph, { width: 100, height: 100 });
+
+    expect(layout.size.width).toBeGreaterThan(100);
+    expect(layout.size.height).toBeGreaterThan(100);
   });
 
   it('is deterministic: identical input produces identical positions', () => {
@@ -384,14 +412,16 @@ describe('computeGraphLayout', () => {
       locations: [],
     });
 
-    const positions = computeGraphLayout(graph, { width: 200, height: 100 });
+    const layout = computeGraphLayout(graph, { width: 200, height: 100 });
 
-    expect(positions).toEqual([expect.objectContaining({ x: 100, y: 50 })]);
+    expect(layout.nodes).toEqual([expect.objectContaining({ x: 100, y: 50 })]);
+    expect(layout.size).toEqual({ width: 200, height: 100 });
   });
 
-  it('returns an empty array for an empty graph', () => {
+  it('returns no nodes for an empty graph', () => {
     expect(
       computeGraphLayout({ nodes: [], edges: [] }, { width: 100, height: 100 })
+        .nodes
     ).toEqual([]);
   });
 
@@ -448,7 +478,10 @@ describe('computeGraphLayout', () => {
       locations: [],
     });
 
-    const positions = computeGraphLayout(graph, { width: 1200, height: 1200 });
+    const { nodes: positions } = computeGraphLayout(graph, {
+      width: 1200,
+      height: 1200,
+    });
     const positionOf = (id: string) => {
       const position = positions.find(p => p.id === id);
       if (!position) {
@@ -492,7 +525,9 @@ describe('computeGraphLayout', () => {
     const size = { width: 2000, height: 2000 };
 
     const meanPairwiseDistance = (spacing: number): number => {
-      const positions = computeGraphLayout(graph, size, { spacing });
+      const { nodes: positions } = computeGraphLayout(graph, size, {
+        spacing,
+      });
       let total = 0;
       let pairs = 0;
       for (let i = 0; i < positions.length; i++) {


### PR DESCRIPTION
## Problem

The relationship graph was hard to read: node spacing collapsed as the graph grew. Two root causes in the hand-rolled layout — repulsion was divided by node count (more nodes → weaker separation), and the spring attraction had no rest length, so edges pulled nodes together with no notion of ideal distance. Positions were also hard-clamped to the visible screen, capping how much separation was possible at all.

## Changes

**Layout engine (`src/utils/relationshipGraph.ts`)**
- `computeGraphLayout` now runs d3-force forces (`forceLink`, `forceManyBody`, `forceCollide`, `forceX`/`forceY`) through a manual synchronous tick loop. `forceSimulation()` is deliberately avoided: its constructor auto-starts an async d3-timer stepper that would leak a frame callback into the app and crash Jest teardown.
- The pure/deterministic contract is preserved (circle-seeded positions in stable (type, id) order + a seeded mulberry32 PRNG passed to each force's `initialize`).
- **Standing-aware distances**: edge rest length is scaled by `standingDistanceFactor` — Ally/Friend pull pairs closer, Hostile/Enemy push them apart, Neutral in between. When the two sides of a relationship disagree, the worse standing wins.

**Infinite canvas (`relationshipGraph.ts`, `GraphCanvas.tsx`, `RelationshipGraphScreen.tsx`)**
- Positions are never clamped, so nodes no longer pile up along the canvas edges. The layout returns `{ nodes, size }` where `size` is the natural content extent; the SVG renders at that size and the existing pinch/pan gestures navigate the overflow.
- `GraphCanvas` takes `containerSize` + `contentSize`, keeps content centered so `clampTranslation`'s symmetric bounds hold (also fixing the pre-existing bug where the graph couldn't be panned at scale 1), and double-tap toggles between fit-to-screen (min scale) and 2× zoom.

**Node interactions**
- Tapping a node navigates straight to its detail screen (character / faction / location).
- Long-press opens the info card, which keeps the Focus and View details actions.

**Configurable + persisted preferences (`graphPreferences.ts`, `GraphSettingsPanel.tsx`)**
- New collapsible "Layout settings" panel on the graph screen with two sliders (d3's convention of pairing continuous force parameters with range sliders): **Spacing** (1–3×) and **Standing effect** (0–2×), plus a reset button.
- The **Retired** and **Hide isolated** filter chips now persist too, so the graph stays tailored to the current dataset across sessions.
- All of it is stored via a new `graphPreferences` module following the `discordStorage` shape (`SafeAsyncStorageJSONParser` + `runExclusive`, per the AGENTS.md storage rule).

**Dependencies / config**
- Added `d3-force` (+ `@types/d3-force`) and `@react-native-community/slider@5.0.1` (the Expo SDK 54-pinned version, included in Expo Go).
- Jest `transformIgnorePatterns` allow-lists the ESM-only d3 packages and `@react-native-community`.
- AGENTS.md updated with the new layout contract and gotchas.

## Testing

- New unit tests: `standingDistanceFactor` ordering/floor/worse-wins, positively-related pairs land closer than negatively-related ones, larger `spacing` increases mean pairwise distance, content size grows beyond the reference frame instead of edge-piling, dangling-edge subgraphs don't throw (d3's `forceLink` throws on unknown ids without the pre-filter), `graphPreferences` defaults/merge/clamp/persist (including the filter toggles), `GraphSettingsPanel` expand/change/commit/reset, tap-to-navigate + long-press info card, and filter/slider persistence wiring at the screen level.
- `npm run check-all` green: 70 suites, 687 tests, 0 lint errors, formatting clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVn4e6DCkamG9pP8oZgpAk