### PR TITLE
Add project Claude Code settings: plan mode default, opusplan model

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "model": "opusplan",
+  "permissions": {
+    "defaultMode": "plan"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a checked-in `.claude/settings.json` so every Claude Code session in this repository starts with:

- **`permissions.defaultMode: "plan"`** — sessions begin in plan mode, so Claude presents a plan for approval before making changes.
- **`model: "opusplan"`** — uses Opus while planning and switches to Sonnet for execution.

These project settings apply to anyone (and any session) working in this repo; individual users can still override them in `.claude/settings.local.json` or with in-session commands like `/model`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKYQWRUu1WW59zDNSs73Hp

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKYQWRUu1WW59zDNSs73Hp)_