### PR TITLE
Add consistency guardrails for gameData tables (#116)

### DIFF
--- a/src/models/gameData.ts
+++ b/src/models/gameData.ts
@@ -40,7 +40,8 @@ export type TagBonusConfig = {
   [key in PerkTag]: TagScoreBonus[];
 };
 
-// TODO : Populate with actual tag score bonuses
+// TODO (#116): placeholder values, not sourced from the actual rulebook.
+// Needs real health/limit bonuses per tag threshold from the maintainer.
 export const TAG_SCORE_BONUSES: TagBonusConfig = {
   Agility: [
     { requiredScore: 3, limit: 1 },
@@ -106,7 +107,8 @@ export const TAG_SCORE_BONUSES: TagBonusConfig = {
 
 export type RecipeId = (typeof AVAILABLE_RECIPES)[number]['id'];
 
-// TODO : Populate with actual recipes
+// TODO (#116): placeholder entries (r1-r4), not the real crafting recipe list.
+// Needs the actual recipes and their material requirements from the maintainer.
 export const AVAILABLE_RECIPES: Recipe[] = [
   {
     id: 'r1',
@@ -154,7 +156,9 @@ export interface Perk {
   recipeIds?: RecipeId[];
 }
 
-// TODO : Populate with actual perks
+// TODO (#116): perk names/tags/species gates are real, but every `description`
+// is empty and `statModifiers`/`recipeIds` are mostly unset. Needs the actual
+// perk text and effects from the maintainer.
 export const AVAILABLE_PERKS: Perk[] = [
   // Agility Perks
   {

--- a/tst/models/gameData.test.ts
+++ b/tst/models/gameData.test.ts
@@ -1,0 +1,148 @@
+import {
+  AVAILABLE_PERKS,
+  AVAILABLE_RECIPES,
+  AVAILABLE_DISTINCTIONS,
+  TAG_SCORE_BONUSES,
+  PerkTag,
+} from '@/models/gameData';
+import { SPECIES_BASE_STATS, Species } from '@/models/speciesTypes';
+
+// Guardrails for the (currently placeholder) game-rules tables in gameData.ts.
+// See issue #116: the real balance data still needs to come from the maintainer.
+// These tests don't validate the *values* are correct — only that the tables are
+// internally consistent, so real data can be dropped in without silently breaking
+// IDs, tags, or references.
+
+const validSpecies = new Set(Object.keys(SPECIES_BASE_STATS));
+
+const tagPrefixFor = (tag: PerkTag): string => tag.toLowerCase();
+
+const assertUniqueIds = (ids: string[]): void => {
+  const seen = new Set<string>();
+  const duplicates = ids.filter(id => {
+    if (seen.has(id)) return true;
+    seen.add(id);
+    return false;
+  });
+  expect(duplicates).toEqual([]);
+};
+
+describe('gameData', () => {
+  describe('AVAILABLE_PERKS', () => {
+    it('has unique ids', () => {
+      assertUniqueIds(AVAILABLE_PERKS.map(p => p.id));
+    });
+
+    it('ids are prefixed with their own tag', () => {
+      const mismatched = AVAILABLE_PERKS.filter(
+        p => !p.id.startsWith(`${tagPrefixFor(p.tag)}_`)
+      ).map(p => `${p.id} (tag: ${p.tag})`);
+      expect(mismatched).toEqual([]);
+    });
+
+    it('recipeIds reference recipes that exist', () => {
+      const recipeIds = new Set(AVAILABLE_RECIPES.map(r => r.id));
+      const dangling = AVAILABLE_PERKS.flatMap(p =>
+        (p.recipeIds ?? []).filter(id => !recipeIds.has(id))
+      );
+      expect(dangling).toEqual([]);
+    });
+
+    it('allowedSpecies only reference known species', () => {
+      const invalid = AVAILABLE_PERKS.flatMap(p =>
+        (p.allowedSpecies ?? [])
+          .filter(species => !validSpecies.has(species))
+          .map(species => `${p.id}: ${species}`)
+      );
+      expect(invalid).toEqual([]);
+    });
+
+    // Ratchet: fails if this count goes UP (new perk landed undocumented) or
+    // DOWN without updating the constant (progress toward #116 that isn't
+    // reflected here). Update EXPECTED_UNDOCUMENTED_PERKS as descriptions land.
+    it('tracks perks still missing a description (#116)', () => {
+      const EXPECTED_UNDOCUMENTED_PERKS = 272;
+      const undocumented = AVAILABLE_PERKS.filter(
+        p => p.description.trim() === ''
+      ).length;
+      expect(undocumented).toBe(EXPECTED_UNDOCUMENTED_PERKS);
+    });
+  });
+
+  describe('AVAILABLE_RECIPES', () => {
+    it('has unique ids', () => {
+      assertUniqueIds(AVAILABLE_RECIPES.map(r => r.id));
+    });
+
+    it('has at least one material per recipe', () => {
+      const empty = AVAILABLE_RECIPES.filter(r => r.materials.length === 0).map(
+        r => r.id
+      );
+      expect(empty).toEqual([]);
+    });
+  });
+
+  describe('AVAILABLE_DISTINCTIONS', () => {
+    it('has unique ids', () => {
+      assertUniqueIds(AVAILABLE_DISTINCTIONS.map(d => d.id));
+    });
+
+    it('allowedSpecies only reference known species', () => {
+      const invalid = AVAILABLE_DISTINCTIONS.flatMap(d =>
+        (d.allowedSpecies ?? [])
+          .filter(species => !validSpecies.has(species))
+          .map(species => `${d.id}: ${species}`)
+      );
+      expect(invalid).toEqual([]);
+    });
+  });
+
+  describe('TAG_SCORE_BONUSES', () => {
+    it('has an entry for every PerkTag', () => {
+      const tags = Object.values(PerkTag);
+      const missing = tags.filter(tag => !TAG_SCORE_BONUSES[tag]);
+      expect(missing).toEqual([]);
+    });
+
+    it('requiredScore is strictly ascending within each tag', () => {
+      const outOfOrder = Object.entries(TAG_SCORE_BONUSES).filter(
+        ([, bonuses]) =>
+          bonuses.some(
+            (bonus, i) =>
+              i > 0 && bonus.requiredScore <= bonuses[i - 1].requiredScore
+          )
+      );
+      expect(outOfOrder.map(([tag]) => tag)).toEqual([]);
+    });
+
+    it('every bonus grants at least one of health/limit', () => {
+      const empty = Object.entries(TAG_SCORE_BONUSES).flatMap(
+        ([tag, bonuses]) =>
+          bonuses
+            .filter(
+              bonus => bonus.health === undefined && bonus.limit === undefined
+            )
+            .map(bonus => `${tag}@${bonus.requiredScore}`)
+      );
+      expect(empty).toEqual([]);
+    });
+  });
+
+  describe('SPECIES_BASE_STATS', () => {
+    it('caps are greater than or equal to their base values', () => {
+      const invalid = (
+        Object.entries(SPECIES_BASE_STATS) as [
+          Species,
+          (typeof SPECIES_BASE_STATS)[Species],
+        ][]
+      )
+        .filter(
+          ([, stats]) =>
+            stats.healthCap < stats.baseHealth ||
+            stats.limitCap < stats.baseLimit
+        )
+        .map(([species]) => species);
+      expect(invalid).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Issue #116 asks to populate the placeholder game-rules tables in `src/models/gameData.ts` (`TAG_SCORE_BONUSES`, `AVAILABLE_RECIPES`, `AVAILABLE_PERKS`) with real balance data, and to resolve the `Mutoid` TODO in `src/models/speciesTypes.ts`.

**This PR does not populate those tables** — the real numbers aren't in the repository (no rulebook, CSV, or fixture exists anywhere), and the issue itself says it "needs the real balance data from the maintainer." Fabricating values would be worse than the current `TODO`s: they'd look authoritative while silently driving `maxHealth`/`maxLimit` on the character and stats screens.

Instead, this adds the guardrails that make the eventual real data entry safe:

- New `tst/models/gameData.test.ts` validates internal consistency across `AVAILABLE_PERKS`, `AVAILABLE_RECIPES`, `AVAILABLE_DISTINCTIONS`, `TAG_SCORE_BONUSES`, and `SPECIES_BASE_STATS`:
  - unique IDs within each table
  - perk ID prefix matches its `tag` (e.g. `agility_*` ⇒ `PerkTag.Agility`)
  - `recipeIds` on perks resolve to a real recipe (currently vacuous — no perk sets it yet, becomes load-bearing once recipes are wired up)
  - `allowedSpecies` on perks/distinctions only reference known `Species`
  - every `PerkTag` has a `TAG_SCORE_BONUSES` entry, thresholds are strictly ascending, and each bonus grants at least one of health/limit
  - species caps are `>=` their base values
  - a ratchet test tracking the count of perks with an empty `description` (272 today), so it fails if that count rises (new perk landed undocumented) or falls without the constant being updated
- Sharpened the three `TODO` comments in `gameData.ts` to say specifically what's missing and reference #116, rather than a bare "populate with actual X".
- `speciesTypes.ts:125` (`Mutoid`) is intentionally left untouched — collapsing it to the organic default would be a no-op on values but would erase the one marker that the rule is still unresolved, without knowing what "weird" actually means.

Verified the new tests actually catch regressions by temporarily injecting a duplicate perk ID and a bogus `allowedSpecies` value and confirming the relevant test fails, then reverting.

### Noted but out of scope

Found two real defects in `src/utils/derivedStats.ts` while tracing the consumers of these tables, left unfixed since #116 scopes this as "pure data, no logic/format change":
- Perk `statModifiers.healthCap`/`limitCap` are declared (e.g. `smarts_20` "Big Brain") but never applied — only `health`/`limit` are read in the perk loop.
- `calculateDerivedStats` mutates the shared `SPECIES_BASE_STATS` module-level constant through cyberware cap modifiers (`baseStats.healthCap += …`), so caps can leak across calls within the same process.

Happy to open a follow-up issue or fix these here if preferred.

Issue #116 stays open — the remaining work is the actual data entry, unblocked whenever the balance source is available.

## Test plan
- [x] `npm run check-all` (type-check, lint, format check, full jest suite) passes — 72 suites / 705 tests
- [x] `npx jest tst/models/gameData.test.ts` passes in isolation
- [x] Injected a duplicate perk ID and confirmed the uniqueness test fails, then reverted
- [x] Injected an invalid `allowedSpecies` value and confirmed that test fails, then reverted
- [x] `npx jest tst/utils/derivedStats.test.ts` unaffected (no runtime values changed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SfePffj1CffCazLEkJQ2cc)_