### PR TITLE
Register the GitHub auto-sync data store from Lore

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -9,7 +9,12 @@ if (typeof global.process === 'undefined') {
 }
 
 import { registerRootComponent } from 'expo';
-import { configureLore } from 'lore';
+import {
+  configureLore,
+  jsonDataStore,
+  pdfDataStore,
+  githubDataStore,
+} from 'lore';
 
 import { afterworldsRuleset } from './src/rulesets/afterworlds';
 import { afterworldsAssets } from './src/rulesets/afterworlds/assets';
@@ -19,6 +24,15 @@ import App from './App';
 // engine's field migration normalizes stored data against the *ruleset's*
 // attribute table, so running it with the engine's default would rewrite real
 // Junktown characters against the wrong one.
-configureLore({ ruleset: afterworldsRuleset, assets: afterworldsAssets });
+//
+// dataStores must be listed explicitly: omitting it defaults to
+// [jsonDataStore, pdfDataStore] with no GitHub store at all, which would
+// silently drop this app's GitHub sync (including the opt-in auto-sync the
+// GitHub store now supports).
+configureLore({
+  ruleset: afterworldsRuleset,
+  assets: afterworldsAssets,
+  dataStores: [jsonDataStore, pdfDataStore, githubDataStore],
+});
 
 registerRootComponent(App);

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "expo-file-system": "~19.0.23",
         "expo-image-picker": "~17.0.11",
         "expo-linear-gradient": "~15.0.8",
+        "expo-print": "~15.0.8",
         "expo-sharing": "~14.0.8",
         "expo-status-bar": "~3.0.9",
         "lore": "git+https://github.com/mccarjac/Lore.git#main",
@@ -8859,6 +8860,16 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-print": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-print/-/expo-print-15.0.8.tgz",
+      "integrity": "sha512-4O0Qzm0On5AmJIl9d+BT+ieTipFp658nHI4aX7vKEFPfj3dfQxG6rDJJpca+rrc9c4Ha8ZFYGvxJG5+4lFq2Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-server": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-1.0.7.tgz",
@@ -14058,7 +14069,7 @@
     },
     "node_modules/lore": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/mccarjac/Lore.git#b574392c6cc180c8138e792f512e4faa777c6c02",
+      "resolved": "git+ssh://git@github.com/mccarjac/Lore.git#96970b65439490cab2c5956f630fb3deed759101",
       "peerDependencies": {
         "@octokit/rest": "^22.0.1",
         "@react-native-async-storage/async-storage": "2.2.0",
@@ -14074,6 +14085,7 @@
         "expo-file-system": "~19.0.23",
         "expo-image-picker": "~17.0.11",
         "expo-linear-gradient": "~15.0.8",
+        "expo-print": "~15.0.8",
         "expo-sharing": "~14.0.8",
         "process": "^0.11.10",
         "react": "19.1.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "expo-file-system": "~19.0.23",
     "expo-image-picker": "~17.0.11",
     "expo-linear-gradient": "~15.0.8",
+    "expo-print": "~15.0.8",
     "expo-sharing": "~14.0.8",
     "expo-status-bar": "~3.0.9",
     "lore": "git+https://github.com/mccarjac/Lore.git#main",

--- a/src/rulesets/afterworlds/index.ts
+++ b/src/rulesets/afterworlds/index.ts
@@ -214,7 +214,6 @@ export const afterworldsRuleset: RulesetDefinition = {
     recipes: true,
     discord: true,
     map: true,
-    gitSync: true,
     modifications: true,
     influenceReport: true,
     relationshipGraph: true,

--- a/tst/rulesets/afterworlds.test.ts
+++ b/tst/rulesets/afterworlds.test.ts
@@ -78,7 +78,7 @@ describe('afterworldsRuleset', () => {
   });
 
   it('enables every feature — Junktown uses all of them', () => {
-    expect(Object.values(afterworldsRuleset.features)).toHaveLength(8);
+    expect(Object.values(afterworldsRuleset.features)).toHaveLength(7);
     Object.values(afterworldsRuleset.features).forEach(enabled => {
       expect(enabled).toBe(true);
     });


### PR DESCRIPTION
## Summary

- Bumps the pinned `lore` dependency commit (via `npm install`) to pick up Lore's recent "data stores are a plugin seam" refactor and its new opt-in GitHub auto-sync capability (`main` @ `96970b6`). No changes were needed in Lore itself — the feature is already merged there.
- `configureLore`'s `dataStores` option is now the only thing that decides which stores are active; omitting it defaults to `[jsonDataStore, pdfDataStore]` with **no GitHub store at all**. `index.ts` now explicitly registers `jsonDataStore`, `pdfDataStore`, and `githubDataStore`, so existing manual GitHub sync keeps working and the GitHub store's new "Automatic Sync" toggle appears in Data Management.
- Removes the now-nonexistent `features.gitSync` ruleset flag from `afterworldsRuleset` (sync is controlled by registering `githubDataStore`, not a feature flag) and updates the parity test that asserted the old feature count.
- Adds `expo-print` as a direct dependency, since Lore's `pdfDataStore` (bundled in the same release) needs it as a peer dependency.

## Test plan

- [x] `npm run check-all` (type-check, lint, format check, tests) passes
- [ ] Launch the app and confirm Data Management shows Local Export/Import, Printable Wiki, and GitHub Repository Sync sections
- [ ] Configure a GitHub token, run manual "Sync from GitHub (Merge)" once, then enable the new "Automatic Sync" toggle and confirm it reports status without error

---
_Generated by [Claude Code](https://claude.ai/code/session_014j7KcqkRtRV9D2DgzsJdiG)_