### PR TITLE
Migrate to Lore HEAD: relationship types and ruleset-declared reports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "expo-linear-gradient": "~15.0.8",
         "expo-sharing": "~14.0.8",
         "expo-status-bar": "~3.0.9",
-        "lore": "git+https://github.com/mccarjac/Lore.git#e8b15f9e4871ae3619f6dabba744149b4b162e83",
+        "lore": "git+https://github.com/mccarjac/Lore.git#6ce8a8f28dd5e3f5dcf6c11ead809a2d2105e211",
         "process": "^0.11.10",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -14069,8 +14069,8 @@
     },
     "node_modules/lore": {
       "version": "2.0.0",
-      "resolved": "git+ssh://git@github.com/mccarjac/Lore.git#e8b15f9e4871ae3619f6dabba744149b4b162e83",
-      "integrity": "sha512-ofWw0c3Yl1J2SydHDF2XWFJkjumjFp5ADkF+3X9NWiBJxv//WfYqtcqWUH28aJ2ajc6GHsmMFjBXo4h+kTpUrQ==",
+      "resolved": "git+ssh://git@github.com/mccarjac/Lore.git#6ce8a8f28dd5e3f5dcf6c11ead809a2d2105e211",
+      "integrity": "sha512-nzJH3vAajDnVqdQ7uX3OzpilaF6bd62qXOJa999kQnGEWmj7Ja9Hpzq3d0EPUw/YeHRtiAy8BZkJRHiszJzf2w==",
       "peerDependencies": {
         "@octokit/rest": "^22.0.1",
         "@react-native-async-storage/async-storage": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "expo-linear-gradient": "~15.0.8",
     "expo-sharing": "~14.0.8",
     "expo-status-bar": "~3.0.9",
-    "lore": "git+https://github.com/mccarjac/Lore.git#e8b15f9e4871ae3619f6dabba744149b4b162e83",
+    "lore": "git+https://github.com/mccarjac/Lore.git#6ce8a8f28dd5e3f5dcf6c11ead809a2d2105e211",
     "process": "^0.11.10",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/src/rulesets/afterworlds/index.ts
+++ b/src/rulesets/afterworlds/index.ts
@@ -22,6 +22,9 @@ import {
   type FacetEntry,
   type FacetBonusRule,
   type Modifier,
+  type RelationshipTypeCollection,
+  type RelationshipTypeEntry,
+  type ReportDefinition,
 } from 'lore/ruleset';
 import { afterworldsTerminology } from './terminology';
 import { afterworldsTraitCategories } from './categories';
@@ -261,6 +264,26 @@ const modifications: FacetCollection = {
   entries: [],
 };
 
+/**
+ * The old builtin `GameCharacter.present` boolean (#56), reproduced as a
+ * `single` collection so out-of-the-box behavior — a new character starting
+ * absent, presence editable per character — is unchanged from before
+ * attendance was ruleset-declared. No custom terminology: this app never
+ * overrode it.
+ */
+const attendance: FacetCollection = {
+  id: 'attendance',
+  singular: 'Attendance',
+  plural: 'Attendance',
+  selection: 'single',
+  defaultEntryId: 'absent',
+  legacyField: 'present',
+  entries: [
+    { id: 'present', label: 'Present', legacyValue: true },
+    { id: 'absent', label: 'Absent', legacyValue: false },
+  ],
+};
+
 /** The old `recipes` collection: a catalog, only ever reached via `links`. */
 const recipes: FacetCollection = {
   id: 'recipes',
@@ -275,22 +298,91 @@ const recipes: FacetCollection = {
   })),
 };
 
+/**
+ * The old `RelationshipStanding` enum (#50), reproduced as one entry list
+ * shared by all three legacy pairs so out-of-the-box behavior — values,
+ * polarity, and default color — is unchanged from before relationship types
+ * were ruleset-declared. No custom terminology: this app never overrode it.
+ */
+const STANDING_ENTRIES: RelationshipTypeEntry[] = [
+  { id: 'ally', label: 'Ally', role: 'positive', legacyValue: 'Ally' },
+  { id: 'friend', label: 'Friend', role: 'positive', legacyValue: 'Friend' },
+  {
+    id: 'neutral',
+    label: 'Neutral',
+    role: 'neutral',
+    legacyValue: 'Neutral',
+  },
+  {
+    id: 'hostile',
+    label: 'Hostile',
+    role: 'negative',
+    legacyValue: 'Hostile',
+  },
+  { id: 'enemy', label: 'Enemy', role: 'negative', legacyValue: 'Enemy' },
+];
+
+const characterStanding: RelationshipTypeCollection = {
+  id: 'characterStanding',
+  singular: 'Relationship',
+  plural: 'Relationships',
+  appliesTo: ['character', 'character'],
+  legacyField: 'characterStanding',
+  defaultEntryId: 'neutral',
+  entries: STANDING_ENTRIES,
+};
+
+const characterFactionStanding: RelationshipTypeCollection = {
+  id: 'characterFactionStanding',
+  singular: 'Standing',
+  plural: 'Standings',
+  appliesTo: ['character', 'faction'],
+  legacyField: 'characterFactionStanding',
+  defaultEntryId: 'neutral',
+  entries: STANDING_ENTRIES,
+};
+
+const factionStanding: RelationshipTypeCollection = {
+  id: 'factionStanding',
+  singular: 'Relationship',
+  plural: 'Relationships',
+  appliesTo: ['faction', 'faction'],
+  legacyField: 'factionStanding',
+  defaultEntryId: 'neutral',
+  entries: STANDING_ENTRIES,
+};
+
+/**
+ * The old fixed `FeatureFlags` booleans (`influenceReport`,
+ * `relationshipGraph`, `characterStats`, `factionStats`) generalized into a
+ * ruleset-ordered list (#56-#58). All four were on before; keeping all four,
+ * in the same order, preserves the drawer as players know it.
+ */
+const reports: ReportDefinition[] = [
+  { kind: 'influenceReport' },
+  { kind: 'relationshipGraph' },
+  { kind: 'characterStats' },
+  { kind: 'factionStats' },
+];
+
 export const afterworldsRuleset: RulesetDefinition = {
   id: 'afterworlds',
   name: 'Junktown Intelligence',
   version: '1.0.0',
   terminology: afterworldsTerminology,
   attributes,
-  facets: [archetypes, traits, qualities, modifications, recipes],
+  facets: [archetypes, traits, qualities, modifications, attendance, recipes],
+  relationshipTypes: [
+    characterStanding,
+    characterFactionStanding,
+    factionStanding,
+  ],
   features: {
     quests: true,
     discord: true,
     map: true,
-    influenceReport: true,
-    relationshipGraph: true,
-    characterStats: true,
-    factionStats: true,
   },
+  reports,
   map: { imageKey: 'map' },
   branding: { appName: APP_NAME },
 };

--- a/tst/rulesets/afterworlds.test.ts
+++ b/tst/rulesets/afterworlds.test.ts
@@ -86,10 +86,19 @@ describe('afterworldsRuleset', () => {
   });
 
   it('enables every feature — Junktown uses all of them', () => {
-    expect(Object.values(afterworldsRuleset.features)).toHaveLength(7);
+    expect(Object.values(afterworldsRuleset.features)).toHaveLength(3);
     Object.values(afterworldsRuleset.features).forEach(enabled => {
       expect(enabled).toBe(true);
     });
+  });
+
+  it('enables every report — Junktown uses all of them', () => {
+    expect(afterworldsRuleset.reports.map(r => r.kind)).toEqual([
+      'influenceReport',
+      'relationshipGraph',
+      'characterStats',
+      'factionStats',
+    ]);
   });
 
   it.each([


### PR DESCRIPTION
## Summary

- Bumps the `lore` dependency from the #51 (facet collections) pin to [mccarjac/Lore#59](https://github.com/mccarjac/Lore/pull/59), which picks up #50 (`RelationshipStanding` generalized into ruleset-declared `relationshipTypes`) and #56-#58 (`present` folded into a facet, the four stats/report `FeatureFlags` booleans replaced by an ordered `reports` list) — plus a small upstream fix exporting `ReportDefinition`/`ReportKind`/`useReports`, which the new `reports` field requires and which neither `lore` nor `lore/ruleset` exported until now.
- `afterworldsRuleset` (`src/rulesets/afterworlds/index.ts`) is updated to declare the new required fields, reproducing the engine's own previous defaults so existing behavior and stored data are unaffected:
  - `relationshipTypes`: three `RelationshipTypeCollection`s (`characterStanding`, `characterFactionStanding`, `factionStanding`) carrying the same Ally/Friend/Neutral/Hostile/Enemy vocabulary the engine used to hardcode, each wired to its `legacyField` so existing stored relationships migrate automatically.
  - `facets`: adds an `attendance` collection (`present`/`absent`, `legacyField: 'present'`) reproducing the old `GameCharacter.present` boolean.
  - `features`/`reports`: drops the four removed booleans (`influenceReport`, `relationshipGraph`, `characterStats`, `factionStats`) from `features` and moves them into `reports`, in the same order, so every report Junktown had on stays on.
- Updates `tst/rulesets/afterworlds.test.ts`'s feature-count assertion for the new 3-boolean `features` shape and adds a coverage assertion for the new `reports` list.

## Test plan

- [x] `npm run check-all` (type-check, lint, format, tests) is green
- [x] The 27-case derived-stat parity suite (`tst/utils/derivedStats.parity.test.ts`) passes unchanged — this diff touches ruleset schema declarations, not attribute/facet contribution logic
- [ ] Not verified in a running app/device — this is a native RN/Expo app with no device available in this environment; recommend a maintainer smoke-test the Data Management, character relationship, and Statistics screens before merging

## Notes for reviewers

No peer-dependency changes were needed — this checkout's peer versions already matched Lore's `docs/consuming-lore.md` table exactly at both the old and new pin. `configureLore`'s call site in `index.ts` is untouched; only the ruleset literal changed.

A runbook for migrating an existing GitHub-backed data source (e.g. `AWInvestigationsDataLibrary`) through this kind of breaking ruleset change was written up in the requesting conversation rather than committed here, per the requester's preference (one-time activity, not durable documentation).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtT1zVxGyHkFHkoMV5sbKn)_